### PR TITLE
Apply updates that differ only in their artifactId at the same time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val core = myCrossProject("core")
       Dependencies.catsEffect,
       Dependencies.circeParser,
       Dependencies.fs2Core,
+      Dependencies.refined,
       Dependencies.scalaTest % Test
     ),
     assembly / test := {}

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
@@ -105,13 +105,21 @@ object Update {
 
   ///
 
+  def apply(
+      groupId: String,
+      artifactId: String,
+      currentVersion: String,
+      newerVersions: NonEmptyList[String]
+  ): Single =
+    Single(groupId, artifactId, currentVersion, newerVersions)
+
   def fromString(str: String): Either[Throwable, Single] =
     Either.catchNonFatal {
       val regex = """([^\s:]+):([^\s:]+)[^\s]*\s+:\s+([^\s]+)\s+->(.+)""".r
       str match {
         case regex(groupId, artifactId, version, updates) =>
           val newerVersions = NonEmptyList.fromListUnsafe(updates.split("->").map(_.trim).toList)
-          Single(groupId, artifactId, version, newerVersions)
+          Update(groupId, artifactId, version, newerVersions)
       }
     }
 

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
@@ -27,10 +27,13 @@ import scala.util.matching.Regex
 sealed trait Update {
   def artifactId: String
   def currentVersion: String
+  def newerVersions: NonEmptyList[String]
   def groupId: String
   def name: String
-  def nextVersion: String
   def show: String
+
+  def nextVersion: String =
+    newerVersions.head
 
   def replaceAllIn(target: String): Option[String] = {
     val quoted = searchTerms.map { term =>
@@ -68,9 +71,6 @@ object Update {
       else
         artifactId
 
-    override def nextVersion: String =
-      newerVersions.head
-
     override def show: String =
       s"$groupId:$artifactId : ${(currentVersion :: newerVersions).mkString_("", " -> ", "")}"
   }
@@ -93,8 +93,8 @@ object Update {
     override def name: String =
       updates.head.name
 
-    override def nextVersion: String =
-      updates.head.nextVersion
+    override def newerVersions: NonEmptyList[String] =
+      updates.head.newerVersions
 
     override def show: String =
       updates.map(_.show).mkString_("", ", ", "")

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
@@ -18,7 +18,7 @@ package eu.timepit.scalasteward.model
 
 import cats.data.NonEmptyList
 import cats.implicits._
-
+import eu.timepit.scalasteward.util
 import scala.util.matching.Regex
 
 sealed trait Update {
@@ -90,13 +90,8 @@ object Update {
     override def show: String =
       updates.map(_.show).mkString_("", ", ", "")
 
-    def commonArtifactPrefix: Option[String] = {
-      val list = updates.map(_.artifactId).toList
-      val prefix = list.foldLeft("") { (_, _) =>
-        (list.min.view, list.max.view).zipped.takeWhile(v => v._1 == v._2).unzip._1.mkString
-      }
-      if (prefix.isEmpty) None else Some(prefix)
-    }
+    def commonArtifactPrefix: Option[String] =
+      util.longestCommonNonEmptyPrefix(updates.map(_.artifactId)).map(_.value)
 
     def replaceAllIn2(str: String): Option[String] = {
       def normalize(searchTerm: String): String =
@@ -132,8 +127,5 @@ object Update {
     List("core", "server")
 
   def removeMeaninglessSuffixes(str: String): String =
-    meaninglessSuffixes
-      .map("-" + _)
-      .find(suffix => str.endsWith(suffix))
-      .fold(str)(suffix => str.substring(0, str.length - suffix.length))
+    util.removeSuffix(str, meaninglessSuffixes)
 }

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/sbt.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/sbt.scala
@@ -42,9 +42,13 @@ object sbt {
   def sanitizeUpdates(updates: List[Update.Single]): List[Update] = {
     val distinctUpdates = updates.distinct
     distinctUpdates
-      .groupByNel(single => (single.groupId, single.currentVersion, single.newerVersions))
-      .mapValues(nel => if (nel.length > 1) Update.Group(nel) else nel.head)
+      .groupByNel(update => (update.groupId, update.currentVersion, update.newerVersions))
       .values
+      .map { nel =>
+        val head = nel.head
+        if (nel.length > 1) Update.Group(head.groupId, head.currentVersion, head.newerVersions, nel)
+        else head
+      }
       .toList
       .sortBy(update => (update.groupId, update.artifactId))
   }

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/util.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/util.scala
@@ -17,9 +17,29 @@
 package eu.timepit.scalasteward
 
 import cats.Monad
+import cats.data.NonEmptyList
 import cats.implicits._
+import eu.timepit.refined.types.string.NonEmptyString
 
 object util {
   def ifTrue[F[_]: Monad](fb: F[Boolean])(f: F[Unit]): F[Unit] =
     fb.ifM(f, Monad[F].unit)
+
+  def longestCommonPrefix(s1: String, s2: String): String = {
+    var i = 0
+    val min = math.min(s1.length, s2.length)
+    while (i < min && s1(i) == s2(i)) i = i + 1
+    s1.substring(0, i)
+  }
+
+  def longestCommonPrefix(xs: NonEmptyList[String]): String =
+    xs.reduceLeft(longestCommonPrefix)
+
+  def longestCommonNonEmptyPrefix(xs: NonEmptyList[String]): Option[NonEmptyString] =
+    NonEmptyString.unapply(longestCommonPrefix(xs))
+
+  def removeSuffix(target: String, suffixes: List[String]): String =
+    suffixes
+      .find(suffix => target.endsWith(suffix))
+      .fold(target)(suffix => target.substring(0, target.length - suffix.length))
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -8,21 +8,21 @@ class UpdateTest extends FunSuite with Matchers {
   test("fromString: 1 update") {
     val str = "org.scala-js:sbt-scalajs : 0.6.24 -> 0.6.25"
     Update.fromString(str) shouldBe Right(
-      Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+      Update.Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
     )
   }
 
   test("fromString: 2 updates") {
     val str = "org.scala-lang:scala-library   : 2.9.1 -> 2.9.3 -> 2.10.3"
     Update.fromString(str) shouldBe Right(
-      Update("org.scala-lang", "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3"))
+      Update.Single("org.scala-lang", "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3"))
     )
   }
 
   test("fromString: 3 updates") {
     val str = "ch.qos.logback:logback-classic : 0.8   -> 0.8.1 -> 0.9.30 -> 1.0.13"
     Update.fromString(str) shouldBe Right(
-      Update(
+      Update.Single(
         "ch.qos.logback",
         "logback-classic",
         "0.8",
@@ -34,7 +34,7 @@ class UpdateTest extends FunSuite with Matchers {
   test("fromString: test dependency") {
     val str = "org.scalacheck:scalacheck:test   : 1.12.5 -> 1.12.6  -> 1.14.0"
     Update.fromString(str) shouldBe Right(
-      Update("org.scalacheck", "scalacheck", "1.12.5", Nel.of("1.12.6", "1.14.0"))
+      Update.Single("org.scalacheck", "scalacheck", "1.12.5", Nel.of("1.12.6", "1.14.0"))
     )
   }
 
@@ -64,7 +64,8 @@ class UpdateTest extends FunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Update
+      .Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
@@ -74,44 +75,53 @@ class UpdateTest extends FunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Update
+      .Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceAllIn(orig) shouldBe None
   }
 
   test("replaceAllIn: ignore hyphen") {
     val original = """val scalajsJqueryVersion = "0.9.3""""
     val expected = """val scalajsJqueryVersion = "0.9.4""""
-    Update("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Update
+      .Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: ignore '-core' suffix") {
     val original = """val specs2Version = "4.2.0""""
     val expected = """val specs2Version = "4.3.4""""
-    Update("org.specs2", "specs2-core", "4.2.0", Nel.of("4.3.4"))
+    Update
+      .Single("org.specs2", "specs2-core", "4.2.0", Nel.of("4.3.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: use groupId if artifactId is 'core'") {
     val original = """lazy val sttpVersion = "1.3.2""""
     val expected = """lazy val sttpVersion = "1.3.3""""
-    Update("com.softwaremill.sttp", "core", "1.3.2", Nel.of("1.3.3"))
+    Update
+      .Single("com.softwaremill.sttp", "core", "1.3.2", Nel.of("1.3.3"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""
-    Update("org.specs2", "specs2-core", "3.+", Nel.of("4.3.4"))
+    Update
+      .Single("org.specs2", "specs2-core", "3.+", Nel.of("4.3.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
-  test("isImpliedBy") {
-    val update0 = Update("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
-    val update1 = update0.copy(artifactId = "specs2-scalacheck")
-    update0.isImpliedBy(update0) shouldBe false
-    update0.isImpliedBy(update1) shouldBe false
-    update1.isImpliedBy(update0) shouldBe true
-    update1.isImpliedBy(update1) shouldBe false
+  test("lockstep") {
+    val original = """ val circe = "0.10.0-M1" """
+    val expected = """ val circe = "0.10.0-M2" """
+    Update
+      .Group(Nel.of(
+        Update.Single("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
+        Update.Single("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
+        Update.Single("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
+        Update.Single(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
+      ))
+      .replaceAllIn(original) shouldBe Some(expected)
   }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -111,11 +111,38 @@ class UpdateTest extends FunSuite with Matchers {
     val expected = """ val circe = "0.10.0-M2" """
     Update
       .Group(
+        "io.circe",
+        "0.10.0-M1",
+        Nel.of("0.10.0-M2"),
         Nel.of(
           Update("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
           Update("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
           Update("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
           Update(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
+        )
+      )
+      .replaceAllIn(original) shouldBe Some(expected)
+  }
+
+  test("lockstep 2") {
+    val original =
+      """
+        |"com.pepegar" %% "hammock-core" % "0.8.1",
+        |"com.pepegar" %% "hammock-circe" % "0.8.1"
+      """.stripMargin.trim
+    val expected =
+      """
+        |"com.pepegar" %% "hammock-core" % "0.8.5",
+        |"com.pepegar" %% "hammock-circe" % "0.8.5"
+      """.stripMargin.trim
+    Update
+      .Group(
+        "com.pepegar",
+        "0.8.1",
+        Nel.of("0.8.5"),
+        Nel.of(
+          Update("com.pepegar", "hammock-core", "0.8.1", Nel.of("0.8.5")),
+          Update("com.pepegar", "hammock-circe", "0.8.1", Nel.of("0.8.5"))
         )
       )
       .replaceAllIn(original) shouldBe Some(expected)

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -116,12 +116,14 @@ class UpdateTest extends FunSuite with Matchers {
     val original = """ val circe = "0.10.0-M1" """
     val expected = """ val circe = "0.10.0-M2" """
     Update
-      .Group(Nel.of(
-        Update.Single("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
-        Update.Single("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
-        Update.Single("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
-        Update.Single(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
-      ))
+      .Group(
+        Nel.of(
+          Update.Single("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update.Single("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update.Single("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update.Single(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
+        )
+      )
       .replaceAllIn(original) shouldBe Some(expected)
   }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -8,21 +8,21 @@ class UpdateTest extends FunSuite with Matchers {
   test("fromString: 1 update") {
     val str = "org.scala-js:sbt-scalajs : 0.6.24 -> 0.6.25"
     Update.fromString(str) shouldBe Right(
-      Update.Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+      Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
     )
   }
 
   test("fromString: 2 updates") {
     val str = "org.scala-lang:scala-library   : 2.9.1 -> 2.9.3 -> 2.10.3"
     Update.fromString(str) shouldBe Right(
-      Update.Single("org.scala-lang", "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3"))
+      Update("org.scala-lang", "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3"))
     )
   }
 
   test("fromString: 3 updates") {
     val str = "ch.qos.logback:logback-classic : 0.8   -> 0.8.1 -> 0.9.30 -> 1.0.13"
     Update.fromString(str) shouldBe Right(
-      Update.Single(
+      Update(
         "ch.qos.logback",
         "logback-classic",
         "0.8",
@@ -34,7 +34,7 @@ class UpdateTest extends FunSuite with Matchers {
   test("fromString: test dependency") {
     val str = "org.scalacheck:scalacheck:test   : 1.12.5 -> 1.12.6  -> 1.14.0"
     Update.fromString(str) shouldBe Right(
-      Update.Single("org.scalacheck", "scalacheck", "1.12.5", Nel.of("1.12.6", "1.14.0"))
+      Update("org.scalacheck", "scalacheck", "1.12.5", Nel.of("1.12.6", "1.14.0"))
     )
   }
 
@@ -64,8 +64,7 @@ class UpdateTest extends FunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Update
-      .Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
@@ -75,40 +74,35 @@ class UpdateTest extends FunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Update
-      .Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Update("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceAllIn(orig) shouldBe None
   }
 
   test("replaceAllIn: ignore hyphen") {
     val original = """val scalajsJqueryVersion = "0.9.3""""
     val expected = """val scalajsJqueryVersion = "0.9.4""""
-    Update
-      .Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Update("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: ignore '-core' suffix") {
     val original = """val specs2Version = "4.2.0""""
     val expected = """val specs2Version = "4.3.4""""
-    Update
-      .Single("org.specs2", "specs2-core", "4.2.0", Nel.of("4.3.4"))
+    Update("org.specs2", "specs2-core", "4.2.0", Nel.of("4.3.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: use groupId if artifactId is 'core'") {
     val original = """lazy val sttpVersion = "1.3.2""""
     val expected = """lazy val sttpVersion = "1.3.3""""
-    Update
-      .Single("com.softwaremill.sttp", "core", "1.3.2", Nel.of("1.3.3"))
+    Update("com.softwaremill.sttp", "core", "1.3.2", Nel.of("1.3.3"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""
-    Update
-      .Single("org.specs2", "specs2-core", "3.+", Nel.of("4.3.4"))
+    Update("org.specs2", "specs2-core", "3.+", Nel.of("4.3.4"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
@@ -118,10 +112,10 @@ class UpdateTest extends FunSuite with Matchers {
     Update
       .Group(
         Nel.of(
-          Update.Single("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update.Single("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update.Single("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update.Single(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
+          Update("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
+          Update(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
         )
       )
       .replaceAllIn(original) shouldBe Some(expected)

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -106,25 +106,19 @@ class UpdateTest extends FunSuite with Matchers {
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
-  test("lockstep") {
+  test("replaceAllIn: group with prefix val") {
     val original = """ val circe = "0.10.0-M1" """
     val expected = """ val circe = "0.10.0-M2" """
     Update
       .Group(
         "io.circe",
+        Nel.of("circe-generic", "circe-literal", "circe-parser", "circe-testing"),
         "0.10.0-M1",
-        Nel.of("0.10.0-M2"),
-        Nel.of(
-          Update("io.circe", "circe-generic", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update("io.circe", "circe-literal", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update("io.circe", "circe-parser", "0.10.0-M1", Nel.of("0.10.0-M2")),
-          Update(" io.circe", "circe-testing", "0.10.0-M1", Nel.of("0.10.0-M2"))
-        )
-      )
+        Nel.of("0.10.0-M2"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
-  test("lockstep 2") {
+  test("replaceAllIn: group with repeated version") {
     val original =
       """
         |"com.pepegar" %% "hammock-core" % "0.8.1",
@@ -136,15 +130,7 @@ class UpdateTest extends FunSuite with Matchers {
         |"com.pepegar" %% "hammock-circe" % "0.8.5"
       """.stripMargin.trim
     Update
-      .Group(
-        "com.pepegar",
-        "0.8.1",
-        Nel.of("0.8.5"),
-        Nel.of(
-          Update("com.pepegar", "hammock-core", "0.8.1", Nel.of("0.8.5")),
-          Update("com.pepegar", "hammock-circe", "0.8.1", Nel.of("0.8.5"))
-        )
-      )
+      .Group("com.pepegar", Nel.of("hammock-core", "hammock-circe"), "0.8.1", Nel.of("0.8.5"))
       .replaceAllIn(original) shouldBe Some(expected)
   }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -114,20 +114,19 @@ class UpdateTest extends FunSuite with Matchers {
         "io.circe",
         Nel.of("circe-generic", "circe-literal", "circe-parser", "circe-testing"),
         "0.10.0-M1",
-        Nel.of("0.10.0-M2"))
+        Nel.of("0.10.0-M2")
+      )
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: group with repeated version") {
     val original =
-      """
-        |"com.pepegar" %% "hammock-core" % "0.8.1",
-        |"com.pepegar" %% "hammock-circe" % "0.8.1"
+      """ "com.pepegar" %% "hammock-core"  % "0.8.1",
+        | "com.pepegar" %% "hammock-circe" % "0.8.1"
       """.stripMargin.trim
     val expected =
-      """
-        |"com.pepegar" %% "hammock-core" % "0.8.5",
-        |"com.pepegar" %% "hammock-circe" % "0.8.5"
+      """ "com.pepegar" %% "hammock-core"  % "0.8.5",
+        | "com.pepegar" %% "hammock-circe" % "0.8.5"
       """.stripMargin.trim
     Update
       .Group("com.pepegar", Nel.of("hammock-core", "hammock-circe"), "0.8.1", Nel.of("0.8.5"))

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 class sbtTest extends FunSuite with Matchers {
   test("sanitizeUpdates") {
-    val update0 = Update.Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Update("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
     sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(
       Update.Group(Nel.of(update0, update1))
@@ -25,11 +25,11 @@ class sbtTest extends FunSuite with Matchers {
       "[info]   org.scala-lang:scala-library     : 2.12.3 -> 2.12.6"
     )
     sbt.toSingleUpdates(input) shouldBe List(
-      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
-      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
-      Update.Single("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0")),
-      Update.Single("com.github.pureconfig", "pureconfig", "0.8.0", Nel.of("0.9.2")),
-      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6"))
+      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
+      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
+      Update("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0")),
+      Update("com.github.pureconfig", "pureconfig", "0.8.0", Nel.of("0.9.2")),
+      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6"))
     )
   }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
@@ -9,7 +9,12 @@ class sbtTest extends FunSuite with Matchers {
     val update0 = Update("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
     sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(
-      Update.Group("org.specs2", "3.9.4", Nel.of("3.9.5"), Nel.of(update0, update1))
+      Update.Group(
+        "org.specs2",
+        Nel.of("specs2-core", "specs2-scalacheck"),
+        "3.9.4",
+        Nel.of("3.9.5")
+      )
     )
   }
 
@@ -24,7 +29,7 @@ class sbtTest extends FunSuite with Matchers {
       "[info]   com.github.pureconfig:pureconfig : 0.8.0            -> 0.9.2",
       "[info]   org.scala-lang:scala-library     : 2.12.3 -> 2.12.6"
     )
-    sbt.toSingleUpdates(input) shouldBe List(
+    sbt.toUpdates(input) shouldBe List(
       Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
       Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
       Update("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0")),

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
@@ -6,9 +6,10 @@ import org.scalatest.{FunSuite, Matchers}
 
 class sbtTest extends FunSuite with Matchers {
   test("sanitizeUpdates") {
-    val update0 = Update("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Update.Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
-    sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(update0)
+    sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(
+      Update.Group(Nel.of(update0, update1)))
   }
 
   test("toUpdates") {
@@ -22,12 +23,12 @@ class sbtTest extends FunSuite with Matchers {
       "[info]   com.github.pureconfig:pureconfig : 0.8.0            -> 0.9.2",
       "[info]   org.scala-lang:scala-library     : 2.12.3 -> 2.12.6"
     )
-    sbt.toUpdates(input) shouldBe List(
-      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
-      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
-      Update("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0")),
-      Update("com.github.pureconfig", "pureconfig", "0.8.0", Nel.of("0.9.2")),
-      Update("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6"))
+    sbt.toSingleUpdates(input) shouldBe List(
+      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
+      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
+      Update.Single("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0")),
+      Update.Single("com.github.pureconfig", "pureconfig", "0.8.0", Nel.of("0.9.2")),
+      Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6"))
     )
   }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
@@ -9,7 +9,8 @@ class sbtTest extends FunSuite with Matchers {
     val update0 = Update.Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
     sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(
-      Update.Group(Nel.of(update0, update1)))
+      Update.Group(Nel.of(update0, update1))
+    )
   }
 
   test("toUpdates") {

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbtTest.scala
@@ -9,7 +9,7 @@ class sbtTest extends FunSuite with Matchers {
     val update0 = Update("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
     sbt.sanitizeUpdates(List(update0, update1)) shouldBe List(
-      Update.Group(Nel.of(update0, update1))
+      Update.Group("org.specs2", "3.9.4", Nel.of("3.9.5"), Nel.of(update0, update1))
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,5 +5,6 @@ object Dependencies {
   val catsEffect = "org.typelevel" %% "cats-effect" % "1.0.0"
   val circeParser = "io.circe" %% "circe-parser" % "0.10.0-M2"
   val fs2Core = "co.fs2" %% "fs2-core" % "1.0.0-M5"
+  val refined = "eu.timepit" %% "refined" % "0.9.2"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
 }


### PR DESCRIPTION
This splits `Update` into two cases, `Single` and `Group`, so that we can group updates that differ only in their `artifactId` can be applied at the same time.

closes: #25 