### PR TITLE
Include groupId only if an artifactId is a common suffix

### DIFF
--- a/modules/core/src/main/scala/eu/timepit/scalasteward/gitLegacy.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/gitLegacy.scala
@@ -37,7 +37,7 @@ object gitLegacy {
     exec(List("commit", "--all", "-m", message), dir)
 
   def commitMsg(update: Update): String =
-    s"Update ${update.name} to ${update.nextVersion}"
+    s"Update ${NameResolver.resolve(update)} to ${update.nextVersion}"
 
   def containsChanges(dir: File): IO[Boolean] =
     exec(List("status", "--porcelain"), dir).map(_.nonEmpty)

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
@@ -20,7 +20,7 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.scalasteward.model.Update.{Group, Single}
-import eu.timepit.scalasteward.{utilLegacy, NameResolver}
+import eu.timepit.scalasteward.utilLegacy
 import scala.util.matching.Regex
 
 sealed trait Update extends Product with Serializable {
@@ -31,7 +31,7 @@ sealed trait Update extends Product with Serializable {
   def newerVersions: NonEmptyList[String]
 
   def name: String =
-    NameResolver.resolve(this)
+    Update.nameOf(groupId, artifactId)
 
   def nextVersion: String =
     newerVersions.head

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/NameResolverTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/NameResolverTest.scala
@@ -11,9 +11,9 @@ class NameResolverTest extends FunSuite with Matchers {
     NameResolver.resolve(update) shouldBe "sttp:core"
   }
 
-  test("resolve single update name: typelevel:cats-core") {
+  test("resolve single update name: cats-core") {
     val update = Single("org.typelevel", "cats-core", "0.9.0", NonEmptyList.one("1.0.0"))
-    NameResolver.resolve(update) shouldBe "typelevel:cats-core"
+    NameResolver.resolve(update) shouldBe "cats-core"
   }
 
   test("resolve single update name: monix") {
@@ -33,7 +33,7 @@ class NameResolverTest extends FunSuite with Matchers {
       "0.9.0",
       NonEmptyList.one("1.0.0")
     )
-    val expected = "typelevel:cats-core, typelevel:cats-free"
+    val expected = "cats-core, cats-free"
     NameResolver.resolve(update) shouldBe expected
   }
 
@@ -44,7 +44,18 @@ class NameResolverTest extends FunSuite with Matchers {
       "0.9.0",
       NonEmptyList.one("1.0.0")
     )
-    val expected = "typelevel:cats-core, typelevel:cats-free, typelevel:cats-laws..."
+    val expected = "cats-core, cats-free, cats-laws..."
+    NameResolver.resolve(update) shouldBe expected
+  }
+
+  test("resolve group update name when one artifact is a common suffix") {
+    val update = Group(
+      "com.softwaremill.sttp",
+      NonEmptyList.of("circe", "core", "okhttp-backend-monix"),
+      "1.3.3",
+      NonEmptyList.one("1.3.5")
+    )
+    val expected = "sttp:circe, sttp:core, sttp:okhttp-backend-monix"
     NameResolver.resolve(update) shouldBe expected
   }
 }


### PR DESCRIPTION
This is a small follow-up to #68 that only includes the groupId
in the name if an artifactId is a common suffix. If no artifactId
is a common suffix, their names should be unambiguous enough.

I've also noted that `Update.name` is used for branch names, so we're
now using NameResolver only for commit messages and PR titles.