### PR TITLE
Ignore updates which have existing up-to-date PRs

### DIFF
--- a/modules/core/src/main/scala/eu/timepit/scalasteward/application/Context.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/application/Context.scala
@@ -26,7 +26,8 @@ import eu.timepit.scalasteward.github.GitHubApiAlg
 import eu.timepit.scalasteward.github.data.AuthenticatedUser
 import eu.timepit.scalasteward.github.http4s.Http4sGitHubApiAlg
 import eu.timepit.scalasteward.io.{FileAlg, ProcessAlg, WorkspaceAlg}
-import eu.timepit.scalasteward.nurture.{EditAlg, NurtureAlg}
+import eu.timepit.scalasteward.nurture.json.JsonPullRequestRepo
+import eu.timepit.scalasteward.nurture.{EditAlg, NurtureAlg, PullRequestRepository}
 import eu.timepit.scalasteward.sbt.SbtAlg
 import eu.timepit.scalasteward.update.json.JsonUpdateRepository
 import eu.timepit.scalasteward.update.{FilterAlg, UpdateRepository, UpdateService}
@@ -72,6 +73,7 @@ object Context {
       implicit val editAlg: EditAlg[F] = EditAlg.create[F]
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val gitHubApiAlg: GitHubApiAlg[F] = new Http4sGitHubApiAlg[F]
+      implicit val pullRequestRepo: PullRequestRepository[F] = new JsonPullRequestRepo[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
       implicit val updateRepository: UpdateRepository[F] = new JsonUpdateRepository[F]
       implicit val dependencyService: DependencyService[F] = new DependencyService[F]

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/PullRequestRepository.scala
@@ -16,14 +16,13 @@
 
 package eu.timepit.scalasteward.nurture
 
-import eu.timepit.scalasteward.git.{Branch, Sha1}
+import eu.timepit.scalasteward.git.Sha1
 import eu.timepit.scalasteward.github.data.Repo
 import eu.timepit.scalasteward.model.Update
+import org.http4s.Uri
 
-final case class UpdateData(
-    repo: Repo,
-    update: Update,
-    baseBranch: Branch,
-    baseSha1: Sha1,
-    updateBranch: Branch
-)
+trait PullRequestRepository[F[_]] {
+  def createOrUpdate(repo: Repo, url: Uri, baseSha1: Sha1, update: Update): F[Unit]
+
+  def findUpdates(repo: Repo, baseSha1: Sha1): F[List[Update]]
+}

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/JsonPullRequestRepo.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 scala-steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.timepit.scalasteward.nurture.json
+
+import better.files.File
+import cats.implicits._
+import eu.timepit.scalasteward.git.Sha1
+import eu.timepit.scalasteward.github.data.Repo
+import eu.timepit.scalasteward.io.{FileAlg, WorkspaceAlg}
+import eu.timepit.scalasteward.model.Update
+import eu.timepit.scalasteward.nurture.PullRequestRepository
+import eu.timepit.scalasteward.util.MonadThrowable
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.http4s.Uri
+
+class JsonPullRequestRepo[F[_]](
+    implicit
+    fileAlg: FileAlg[F],
+    workspaceAlg: WorkspaceAlg[F],
+    F: MonadThrowable[F]
+) extends PullRequestRepository[F] {
+  override def createOrUpdate(repo: Repo, url: Uri, baseSha1: Sha1, update: Update): F[Unit] =
+    readJson.flatMap { store =>
+      val updated = store.store.get(repo) match {
+        case Some(prs) => prs.updated(url.toString(), PullRequestData(baseSha1, update))
+        case None      => Map(url.toString() -> PullRequestData(baseSha1, update))
+      }
+      writeJson(PullRequestStore(store.store.updated(repo, updated)))
+    }
+
+  override def findUpdates(repo: Repo, baseSha1: Sha1): F[List[Update]] =
+    readJson.map { store =>
+      store.store.get(repo).fold(List.empty[Update]) { data =>
+        data.values.filter(_.baseSha1 == baseSha1).map(_.update).toList
+      }
+    }
+
+  def jsonFile: F[File] =
+    workspaceAlg.rootDir.map(_ / "prs_v01.json")
+
+  def readJson: F[PullRequestStore] =
+    jsonFile.flatMap { file =>
+      fileAlg.readFile(file).flatMap {
+        case Some(content) => F.fromEither(decode[PullRequestStore](content))
+        case None          => F.pure(PullRequestStore(Map.empty))
+      }
+    }
+
+  def writeJson(store: PullRequestStore): F[Unit] =
+    jsonFile.flatMap { file =>
+      fileAlg.writeFile(file, store.asJson.toString)
+    }
+}

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/PullRequestData.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/PullRequestData.scala
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
-package eu.timepit.scalasteward.nurture
+package eu.timepit.scalasteward.nurture.json
 
-import eu.timepit.scalasteward.git.{Branch, Sha1}
-import eu.timepit.scalasteward.github.data.Repo
+import eu.timepit.scalasteward.git.Sha1
 import eu.timepit.scalasteward.model.Update
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
 
-final case class UpdateData(
-    repo: Repo,
-    update: Update,
-    baseBranch: Branch,
+final case class PullRequestData(
     baseSha1: Sha1,
-    updateBranch: Branch
+    update: Update
 )
+
+object PullRequestData {
+  implicit val pullRequestDataDecoder: Decoder[PullRequestData] =
+    deriveDecoder
+
+  implicit val pullRequestDataEncoder: Encoder[PullRequestData] =
+    deriveEncoder
+}

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/PullRequestStore.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/nurture/json/PullRequestStore.scala
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package eu.timepit.scalasteward.nurture
+package eu.timepit.scalasteward.nurture.json
 
-import eu.timepit.scalasteward.git.{Branch, Sha1}
 import eu.timepit.scalasteward.github.data.Repo
-import eu.timepit.scalasteward.model.Update
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
 
-final case class UpdateData(
-    repo: Repo,
-    update: Update,
-    baseBranch: Branch,
-    baseSha1: Sha1,
-    updateBranch: Branch
-)
+final case class PullRequestStore(store: Map[Repo, Map[String, PullRequestData]])
+
+object PullRequestStore {
+  implicit val pullRequestStoreDecoder: Decoder[PullRequestStore] =
+    deriveDecoder
+
+  implicit val pullRequestStoreEncoder: Encoder[PullRequestStore] =
+    deriveEncoder
+}

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/update/FilterAlg.scala
@@ -49,6 +49,8 @@ object FilterAlg {
           case ("org.eclipse.jetty", "jetty-server", _)    => false
           case ("org.eclipse.jetty", "jetty-websocket", _) => false
 
+          case ("com.geirsson", "scalafmt-core_2.12", _) => false
+
           // https://github.com/fthomas/scala-steward/issues/105
           case ("io.monix", _, "3.0.0-fbcb270") => false
 

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/update/UpdateService.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/update/UpdateService.scala
@@ -123,7 +123,7 @@ class UpdateService[F[_]](
               ignUpdate =>
                 update.groupId == ignUpdate.groupId && update.nextVersion == ignUpdate.nextVersion &&
                   ignUpdate.artifactIds.exists(id => update.artifactId.startsWith(id))
-          )
+            )
         )
         // 18
         // 17

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/update/UpdateService.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/update/UpdateService.scala
@@ -21,6 +21,7 @@ import cats.implicits._
 import eu.timepit.scalasteward.dependency.{Dependency, DependencyRepository}
 import eu.timepit.scalasteward.github.data.Repo
 import eu.timepit.scalasteward.model.Update
+import eu.timepit.scalasteward.nurture.PullRequestRepository
 import eu.timepit.scalasteward.sbt._
 import eu.timepit.scalasteward.util
 import eu.timepit.scalasteward.util.MonadThrowable
@@ -31,6 +32,7 @@ class UpdateService[F[_]](
     dependencyRepository: DependencyRepository[F],
     filterAlg: FilterAlg[F],
     logger: Logger[F],
+    pullRequestRepo: PullRequestRepository[F],
     sbtAlg: SbtAlg[F],
     updateRepository: UpdateRepository[F],
     F: Monad[F]
@@ -110,7 +112,24 @@ class UpdateService[F[_]](
         matchingUpdates = updates.filter { update =>
           dependencies.exists(dependency => UpdateService.isUpdateFor(update, dependency))
         }
-      } yield matchingUpdates.headOption.as(repo)
+        maybeBaseSha1 <- dependencyRepository.findSha1(repo)
+        ignorableUpdates <- maybeBaseSha1 match {
+          case Some(baseSha1) => pullRequestRepo.findUpdates(repo, baseSha1)
+          case None           => F.pure(List.empty[Update])
+        }
+        updates1 = matchingUpdates.filterNot(
+          update =>
+            ignorableUpdates.exists(
+              ignUpdate =>
+                update.groupId == ignUpdate.groupId && update.nextVersion == ignUpdate.nextVersion &&
+                  ignUpdate.artifactIds.exists(id => update.artifactId.startsWith(id))
+          )
+        )
+        // 18
+        // 17
+        // 10
+        _ <- F.pure(println(repo + " " + updates1))
+      } yield updates1.headOption.as(repo)
     }
 }
 

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/github/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/github/data/NewPullRequestDataTest.scala
@@ -1,7 +1,7 @@
 package eu.timepit.scalasteward.github.data
 
 import cats.data.NonEmptyList
-import eu.timepit.scalasteward.git.Branch
+import eu.timepit.scalasteward.git.{Branch, Sha1}
 import eu.timepit.scalasteward.model.Update
 import eu.timepit.scalasteward.nurture.UpdateData
 import io.circe.syntax._
@@ -13,6 +13,7 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
       Repo("foo", "bar"),
       Update.Single("ch.qos.logback", "logback-classic", "1.2.0", NonEmptyList.of("1.2.3")),
       Branch("master"),
+      Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
       Branch("update/logback-classic-1.2.3")
     )
     NewPullRequestData.from(data, "scala-steward").asJson.spaces2 shouldBe


### PR DESCRIPTION
This is another part of #123 where we ignore updates if there is already an existing and up-to-date PR for an update. This should drastically reduce the number of repositories that need to be processed on each run.