### PR TITLE
Do not use URLs with username and password for Git

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ addCommandsAlias(
 )
 
 addCommandsAlias(
-  "formatAll",
+  "fmt",
   Seq(
     "headerCreate",
     "scalafmt",

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/application/Context.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/application/Context.scala
@@ -67,7 +67,7 @@ object Context {
       implicit val filterAlg: FilterAlg[F] = FilterAlg.create[F]
       implicit val processAlg: ProcessAlg[F] = ProcessAlg.create[F]
       implicit val user: AuthenticatedUser = user_
-      implicit val workspace: File = config_.workspace
+      implicit val workspace: File = config.workspace
       implicit val workspaceAlg: WorkspaceAlg[F] = WorkspaceAlg.create[F]
       implicit val dependencyRepository: DependencyRepository[F] = new JsonDependencyRepository[F]
       implicit val editAlg: EditAlg[F] = EditAlg.create[F]

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/git/GitAlg.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/git/GitAlg.scala
@@ -21,6 +21,7 @@ import cats.Monad
 import cats.data.{NonEmptyList => Nel}
 import cats.effect.Bracket
 import cats.implicits._
+import eu.timepit.scalasteward.application.Config
 import eu.timepit.scalasteward.github.data.Repo
 import eu.timepit.scalasteward.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import eu.timepit.scalasteward.util.MonadThrowable
@@ -68,6 +69,7 @@ object GitAlg {
 
   def create[F[_]](
       implicit
+      config: Config,
       fileAlg: FileAlg[F],
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
@@ -174,6 +176,6 @@ object GitAlg {
         } yield ()
 
       def exec(command: Nel[String], cwd: File): F[List[String]] =
-        processAlg.exec(gitCmd :: command, cwd)
+        processAlg.exec(gitCmd :: command, cwd, "GIT_ASKPASS" -> config.gitAskPass.pathAsString)
     }
 }

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/util/uri.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/util/uri.scala
@@ -17,7 +17,6 @@
 package eu.timepit.scalasteward.util
 
 import cats.implicits._
-import eu.timepit.scalasteward.github.data.AuthenticatedUser
 import io.circe.Decoder
 import org.http4s.Uri
 
@@ -32,7 +31,4 @@ object uri {
     uri.authority.fold(uri) { auth =>
       uri.copy(authority = Some(auth.copy(userInfo = Some(userInfo))))
     }
-
-  def withCredentials(uri: Uri, user: AuthenticatedUser): Uri =
-    withUserInfo(uri, user.login + ":" + user.accessToken)
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/git/GitAlgTest.scala
@@ -1,13 +1,22 @@
 package eu.timepit.scalasteward.git
 
+import better.files.File
 import eu.timepit.scalasteward.MockState
 import eu.timepit.scalasteward.MockState.MockEnv
+import eu.timepit.scalasteward.application.Config
 import eu.timepit.scalasteward.github.data.Repo
 import eu.timepit.scalasteward.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.http4s.Uri
 import org.scalatest.{FunSuite, Matchers}
 
 class GitAlgTest extends FunSuite with Matchers {
+  implicit val config: Config = Config(
+    workspace = File.temp,
+    gitAuthor = Author("", ""),
+    gitHubApiHost = "",
+    gitHubLogin = "",
+    gitAskPass = File.temp / "askpass.sh"
+  )
   implicit val fileAlg: MockFileAlg = new MockFileAlg
   implicit val processAlg: MockProcessAlg = new MockProcessAlg
   implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/git/GitAlgTest.scala
@@ -1,6 +1,7 @@
 package eu.timepit.scalasteward.git
 
 import better.files.File
+import cats.effect.IO
 import eu.timepit.scalasteward.MockState
 import eu.timepit.scalasteward.MockState.MockEnv
 import eu.timepit.scalasteward.application.Config
@@ -8,6 +9,7 @@ import eu.timepit.scalasteward.github.data.Repo
 import eu.timepit.scalasteward.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.http4s.Uri
 import org.scalatest.{FunSuite, Matchers}
+import eu.timepit.scalasteward.util
 
 class GitAlgTest extends FunSuite with Matchers {
   implicit val config: Config = Config(
@@ -22,6 +24,25 @@ class GitAlgTest extends FunSuite with Matchers {
   implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg
   val gitAlg: GitAlg[MockEnv] = GitAlg.create
   val repo = Repo("fthomas", "datapackage")
+
+  test("clone") {
+    val url = util.uri
+      .fromString[IO]("https://scala-steward@github.com/fthomas/datapackage")
+      .unsafeRunSync()
+    val state = gitAlg.clone(repo, url).runS(MockState.empty).value
+
+    state shouldBe MockState.empty.copy(
+      commands = Vector(
+        List(
+          "git",
+          "clone",
+          "--recursive",
+          "https://scala-steward@github.com/fthomas/datapackage",
+          "/tmp/ws/fthomas/datapackage"
+        )
+      )
+    )
+  }
 
   test("branchAuthors") {
     val state = gitAlg

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/io/MockProcessAlg.scala
@@ -5,7 +5,11 @@ import cats.data.{State, NonEmptyList => Nel}
 import eu.timepit.scalasteward.MockState.MockEnv
 
 class MockProcessAlg extends ProcessAlg[MockEnv] {
-  override def exec(command: Nel[String], cwd: File): MockEnv[List[String]] =
+  override def exec(
+      command: Nel[String],
+      cwd: File,
+      extraEnv: (String, String)*
+  ): MockEnv[List[String]] =
     State(s => (s.exec(command.toList), List.empty))
 
   override def execSandboxed(command: Nel[String], cwd: File): MockEnv[List[String]] =

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/util/uriTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/util/uriTest.scala
@@ -1,7 +1,6 @@
 package eu.timepit.scalasteward.util
 
 import cats.implicits._
-import eu.timepit.scalasteward.github.data.AuthenticatedUser
 import org.http4s.Uri
 import org.scalatest.{FunSuite, Matchers}
 
@@ -14,10 +13,9 @@ class uriTest extends FunSuite with Matchers {
       Right("https://api.github.com/repos/")
   }
 
-  test("withCredentials") {
+  test("withUserInfo") {
     val url = Uri.uri("https://api.github.com/repos/")
-    val user = AuthenticatedUser("user", "pass")
-    uri.withCredentials(url, user).toString shouldBe
+    uri.withUserInfo(url, "user:pass").toString shouldBe
       "https://user:pass@api.github.com/repos/"
   }
 }


### PR DESCRIPTION
This changes how Git receives the password (or access token) of `gitHubLogin` for cloning, syncing, and pushing. Currently the password is part of the clone URL that is passed to Git. This means that the password is stored on disk in `.git/config` of each repository. This PR lets Git request the password via a [program in the `GIT_ASKPASS` environment variable](https://git-scm.com/docs/gitcredentials). The program used for this variable needs to be set in the `Config.gitAskPass` parameter.