### PR TITLE
Use configurations to filter updates

### DIFF
--- a/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/model/Update.scala
@@ -66,7 +66,7 @@ sealed trait Update extends Product with Serializable {
 
   def show: String = {
     val artifacts = this match {
-      case s: Single => s.artifactId
+      case s: Single => s.artifactId + s.configurations.fold("")(":" + _)
       case g: Group  => g.artifactIds.mkString_("{", ", ", "}")
     }
     val versions = (currentVersion :: newerVersions).mkString_("", " -> ", "")
@@ -79,7 +79,8 @@ object Update {
       groupId: String,
       artifactId: String,
       currentVersion: String,
-      newerVersions: Nel[String]
+      newerVersions: Nel[String],
+      configurations: Option[String] = None
   ) extends Update {
     override def artifactIds: Nel[String] =
       Nel.one(artifactId)

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/sbt/parser.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/sbt/parser.scala
@@ -25,9 +25,10 @@ object parser {
     Either.catchNonFatal {
       val regex = """([^\s:]+):([^\s:]+)(:([^\s]+))?\s+:\s+([^\s]+)\s+->(.+)""".r
       str match {
-        case regex(groupId, artifactId, _, _, current, newer) =>
+        case regex(groupId, artifactId, _, configurationsOrNull, current, newer) =>
+          val configurations = Option(configurationsOrNull)
           val newerVersions = Nel.fromListUnsafe(newer.split("->").map(_.trim).toList)
-          Update.Single(groupId, artifactId, current, newerVersions)
+          Update.Single(groupId, artifactId, current, newerVersions, configurations)
       }
     }
 

--- a/modules/core/src/main/scala/eu/timepit/scalasteward/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/eu/timepit/scalasteward/update/FilterAlg.scala
@@ -45,20 +45,13 @@ trait FilterAlg[F[_]] {
 object FilterAlg {
   def create[F[_]](implicit logger: Logger[F], F: Applicative[F]): FilterAlg[F] =
     new FilterAlg[F] {
-      override def globalKeep(update: Update.Single): Boolean =
+      override def globalKeep(update: Update.Single): Boolean = {
         (update.groupId, update.artifactId, update.nextVersion) match {
           case ("org.scala-lang", "scala-compiler", _) => false
           case ("org.scala-lang", "scala-library", _)  => false
           case ("org.scala-lang", "scala-reflect", _)  => false
 
           case ("org.typelevel", "scala-library", _) => false
-
-          case ("org.eclipse.jetty", "jetty-server", _)    => false
-          case ("org.eclipse.jetty", "jetty-websocket", _) => false
-
-          // transitive dependencies of e.g. com.lucidchart:sbt-scalafmt
-          case ("com.geirsson", "scalafmt-cli_2.11", _)  => false
-          case ("com.geirsson", "scalafmt-core_2.12", _) => false
 
           // https://github.com/fthomas/scala-steward/issues/105
           case ("io.monix", _, "3.0.0-fbcb270") => false
@@ -74,6 +67,14 @@ object FilterAlg {
 
           case _ => true
         }
+      } && {
+        update.configurations match {
+          case Some("phantom-js-jetty") => false
+          case Some("scalafmt")         => false
+          case Some("tut")              => false
+          case _                        => true
+        }
+      }
 
       override def localKeep(repo: Repo, update: Update.Single): Boolean =
         (repo.show, update.groupId, update.artifactId) match {

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/model/UpdateTest.scala
@@ -128,4 +128,15 @@ class UpdateTest extends FunSuite with Matchers {
         Group("org.specs2", Nel.of("specs2-core", "specs2-scalacheck"), "3.9.4", Nel.of("3.9.5"))
       )
   }
+
+  test("Single.show") {
+    val update = Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"), Some("test"))
+    update.show shouldBe "org.specs2:specs2-core:test : 3.9.4 -> 3.9.5"
+  }
+
+  test("Group.show") {
+    val update =
+      Group("org.scala-sbt", Nel.of("sbt-launch", "scripted-plugin"), "1.2.1", Nel.of("1.2.4"))
+    update.show shouldBe "org.scala-sbt:{sbt-launch, scripted-plugin} : 1.2.1 -> 1.2.4"
+  }
 }

--- a/modules/core/src/test/scala/eu/timepit/scalasteward/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/eu/timepit/scalasteward/sbt/parserTest.scala
@@ -31,7 +31,16 @@ class parserTest extends FunSuite with Matchers {
   test("parseSingleUpdate: test dependency") {
     val str = "org.scalacheck:scalacheck:test   : 1.12.5 -> 1.12.6  -> 1.14.0"
     parseSingleUpdate(str) shouldBe
-      Right(Update.Single("org.scalacheck", "scalacheck", "1.12.5", Nel.of("1.12.6", "1.14.0")))
+      Right(
+        Update
+          .Single(
+            "org.scalacheck",
+            "scalacheck",
+            "1.12.5",
+            Nel.of("1.12.6", "1.14.0"),
+            Some("test")
+          )
+      )
   }
 
   test("parseSingleUpdate: no groupId") {
@@ -58,9 +67,15 @@ class parserTest extends FunSuite with Matchers {
       """.stripMargin.trim
     parseSingleUpdates(str.lines.toList) shouldBe
       List(
-        Update.Single("ai.x", "diff", "1.2.0", Nel.of("1.2.1")),
+        Update.Single("ai.x", "diff", "1.2.0", Nel.of("1.2.1"), Some("test")),
         Update
-          .Single("com.geirsson", "scalafmt-cli_2.11", "0.3.0", Nel.of("0.3.1", "0.6.8", "1.5.1")),
+          .Single(
+            "com.geirsson",
+            "scalafmt-cli_2.11",
+            "0.3.0",
+            Nel.of("0.3.1", "0.6.8", "1.5.1"),
+            Some("scalafmt")
+          ),
         Update.Single("eu.timepit", "refined", "0.7.0", Nel.of("0.9.3"))
       )
   }


### PR DESCRIPTION
This parses [`configurations`](https://www.scala-sbt.org/1.x/api/sbt/librarymanagement/ModuleID.html#configurations:Option[String]) from `dependencyUpdates` to skip updates that seem to be in most cases transitive dependencies of plugins.