### PR TITLE
Add command-line options for firejail

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,12 @@ addCommandAlias(
       Seq("--github-api-host", "https://api.github.com"),
       Seq("--github-login", projectName),
       Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),
-      Seq("--sign-commits")
+      Seq("--sign-commits"),
+      Seq("--whitelist", s"$home/.cache/coursier"),
+      Seq("--whitelist", s"$home/.coursier"),
+      Seq("--whitelist", s"$home/.ivy2"),
+      Seq("--whitelist", s"$home/.sbt"),
+      Seq("--whitelist", s"$home/.scio-ideaPluginIC")
     ).flatten.mkString(" ")
   }
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -34,7 +34,9 @@ object Cli {
       githubApiHost: String,
       githubLogin: String,
       gitAskPass: String,
-      signCommits: Boolean = false
+      signCommits: Boolean = false,
+      whitelist: List[String] = Nil,
+      readOnly: List[String] = Nil
   )
 
   def create[F[_]](implicit F: ApplicativeThrowable[F]): Cli[F] = new Cli[F] {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -50,7 +50,9 @@ final case class Config(
     gitHubApiHost: String,
     gitHubLogin: String,
     gitAskPass: File,
-    signCommits: Boolean
+    signCommits: Boolean,
+    whitelistedDirectories: List[String],
+    readOnlyDirectories: List[String]
 ) {
   def gitHubUser[F[_]](implicit F: Sync[F]): F[AuthenticatedUser] =
     util.uri.fromString[F](gitHubApiHost).flatMap { url =>
@@ -73,7 +75,9 @@ object Config {
         gitHubApiHost = args.githubApiHost,
         gitHubLogin = args.githubLogin,
         gitAskPass = args.gitAskPass.toFile,
-        signCommits = args.signCommits
+        signCommits = args.signCommits,
+        whitelistedDirectories = args.whitelist,
+        readOnlyDirectories = args.readOnly
       )
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/ConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/ConfigTest.scala
@@ -1,0 +1,18 @@
+package org.scalasteward.core.application
+
+import better.files.File
+import org.scalasteward.core.git.Author
+
+object ConfigTest {
+  val dummyConfig: Config = Config(
+    workspace = File.temp,
+    reposFile = File.temp / "repos.md",
+    gitAuthor = Author("", ""),
+    gitHubApiHost = "",
+    gitHubLogin = "",
+    gitAskPass = File.temp / "askpass.sh",
+    signCommits = true,
+    whitelistedDirectories = Nil,
+    readOnlyDirectories = Nil
+  )
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -1,25 +1,16 @@
 package org.scalasteward.core.git
 
-import better.files.File
 import cats.effect.IO
 import org.http4s.Uri
 import org.scalasteward.core.MockState.MockEnv
-import org.scalasteward.core.application.Config
+import org.scalasteward.core.application.{Config, ConfigTest}
 import org.scalasteward.core.github.data.Repo
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.scalasteward.core.{util, MockState}
 import org.scalatest.{FunSuite, Matchers}
 
 class GitAlgTest extends FunSuite with Matchers {
-  implicit val config: Config = Config(
-    workspace = File.temp,
-    reposFile = File.temp / "repos.md",
-    gitAuthor = Author("", ""),
-    gitHubApiHost = "",
-    gitHubLogin = "",
-    gitAskPass = File.temp / "askpass.sh",
-    signCommits = true
-  )
+  implicit val config: Config = ConfigTest.dummyConfig
   implicit val fileAlg: MockFileAlg = new MockFileAlg
   implicit val processAlg: MockProcessAlg = new MockProcessAlg
   implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockProcessAlg.scala
@@ -3,16 +3,14 @@ package org.scalasteward.core.io
 import better.files.File
 import cats.data.State
 import org.scalasteward.core.MockState.MockEnv
+import org.scalasteward.core.application.ConfigTest
 import org.scalasteward.core.util.Nel
 
-class MockProcessAlg extends ProcessAlg[MockEnv] {
+class MockProcessAlg extends ProcessAlg.UsingFirejail[MockEnv](ConfigTest.dummyConfig) {
   override def exec(
       command: Nel[String],
       cwd: File,
       extraEnv: (String, String)*
   ): MockEnv[List[String]] =
     State(s => (s.exec(command.toList), List.empty))
-
-  override def execSandboxed(command: Nel[String], cwd: File): MockEnv[List[String]] =
-    exec("sandbox" :: command, cwd)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -2,12 +2,13 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.effect.IO
+import org.scalasteward.core.application.{Config, ConfigTest}
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
 class ProcessAlgTest extends FunSuite with Matchers {
-  val processAlg: ProcessAlg[IO] =
-    ProcessAlg.create[IO]
+  implicit val config: Config = ConfigTest.dummyConfig
+  val processAlg: ProcessAlg[IO] = ProcessAlg.create[IO]
 
   test("exec echo") {
     processAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -2,25 +2,40 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.effect.IO
+import org.scalasteward.core.MockState
 import org.scalasteward.core.application.{Config, ConfigTest}
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
 class ProcessAlgTest extends FunSuite with Matchers {
   implicit val config: Config = ConfigTest.dummyConfig
-  val processAlg: ProcessAlg[IO] = ProcessAlg.create[IO]
+  val ioProcessAlg: ProcessAlg[IO] = ProcessAlg.create[IO]
+  val mockProcessAlg: MockProcessAlg = new MockProcessAlg
 
   test("exec echo") {
-    processAlg
+    ioProcessAlg
       .exec(Nel.of("echo", "hello"), File.currentWorkingDirectory)
       .unsafeRunSync() shouldBe List("hello")
   }
 
   test("exec false") {
-    processAlg
+    ioProcessAlg
       .exec(Nel.of("ls", "--foo"), File.currentWorkingDirectory)
       .attempt
       .map(_.isLeft)
       .unsafeRunSync()
+  }
+
+  test("execSandboxed echo") {
+    val state = mockProcessAlg
+      .execSandboxed(Nel.of("echo", "hello"), File.root / "tmp")
+      .runS(MockState.empty)
+      .value
+
+    state shouldBe MockState.empty.copy(
+      commands = Vector(
+        List("firejail", "--whitelist=/tmp", "echo", "hello")
+      )
+    )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -35,7 +35,8 @@ class SbtAlgTest extends FunSuite with Matchers {
         List("rm", "/tmp/ws/fthomas/refined/.jvmopts"),
         List("rm", "/tmp/ws/fthomas/refined/.sbtopts"),
         List(
-          "sandbox",
+          "firejail",
+          "--whitelist=/tmp/ws/fthomas/refined",
           "sbt",
           "-batch",
           "-no-colors",

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,4 +21,11 @@ java -jar ${JAR} \
   --github-api-host "https://api.github.com" \
   --github-login ${LOGIN} \
   --git-ask-pass "$HOME/.github/askpass/$LOGIN.sh" \
-  --sign-commits
+  --sign-commits \
+  --whitelist $HOME/.cache/coursier \
+  --whitelist $HOME/.coursier \
+  --whitelist $HOME/.ivy2 \
+  --whitelist $HOME/.sbt \
+  --whitelist $HOME/.scio-ideaPluginIC \
+  --whitelist $JAVA_HOME \
+  --read-only $JAVA_HOME


### PR DESCRIPTION
This allows to set firejail's --whitelist and --read-only options
as command-line options of scala-steward.