### PR TITLE
Fix checkForUpdates

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
@@ -60,13 +60,24 @@ final case class ArtificialProject(
     )
 
   def halve: List[ArtificialProject] =
-    if (libraries.size <= 1 || plugins.size <= 1) Nil
-    else {
+    if (libraries.size > 1 && plugins.size > 1) {
       val halvedLibraries = util.halve(libraries)
       val halvedPlugins = util.halve(plugins)
       val zipped = halvedLibraries.zipAll(halvedPlugins, Nil, Nil)
       zipped.map {
         case (libraries1, plugins1) => copy(libraries = libraries1, plugins = plugins1)
       }
-    }
+    } else if (libraries.size > 1) {
+      val halvedLibraries = util.halve(libraries)
+      val zipped = halvedLibraries.zipAll(List(plugins), Nil, Nil)
+      zipped.map {
+        case (libraries1, plugins1) => copy(libraries = libraries1, plugins = plugins1)
+      }
+    } else if (plugins.size > 1) {
+      val halvedPlugins = util.halve(plugins)
+      val zipped = List(libraries).zipAll(halvedPlugins, Nil, Nil)
+      zipped.map {
+        case (libraries1, plugins1) => copy(libraries = libraries1, plugins = plugins1)
+      }
+    } else Nil
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
@@ -12,8 +12,12 @@ class utilTest extends FunSuite with Matchers {
     => (((2, 1), (1, 0)), ((1, 0), 1))
     => ((((1, 0), 1), (1, 0)), ((1, 0), 1))
      */
-    divideOnError((i: Int) => if (i > 1) List(i - 1, i - 2) else Nil)(
-      i => if (i <= 1) i.asRight[Unit] else ().asLeft[Int]
-    )(5) shouldBe Right(5)
+    val res = divideOnError(5) { i =>
+      if (i <= 1) i.asRight[Unit] else ().asLeft[Int]
+    } { i =>
+      if (i > 1) List(i - 1, i - 2) else List.empty[Int]
+    }((_, e: Unit) => Left(e))
+
+    res shouldBe Right(5)
   }
 }


### PR DESCRIPTION
This does two things:
- it changes `ArtificialProject.halve` to also halve the project if it only contains libraries or plugins
- uses the former `divideOnError2` in `UpdateService.checkForUpdates` which now collect all updates even if one invocation of `sbtAlg.getUpdatesForProject` fails

The result is that `checkForUpdates` now caches more updates and does not discard updates if one of the updates check fails.

I'm sorry for the code quality of `ArtificialProject` and `UpdateService`. This will be improved later.