### PR TITLE
Do not leak file handles in deleteForce

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val core = myCrossProject("core")
       Dependencies.circeGeneric,
       Dependencies.circeParser,
       Dependencies.circeRefined,
+      Dependencies.commonsIo,
       Dependencies.fs2Core,
       Dependencies.http4sBlazeClient,
       Dependencies.http4sCirce,

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -20,6 +20,7 @@ import better.files.File
 import cats.effect.Sync
 import cats.implicits._
 import fs2.Stream
+import org.apache.commons.io.FileUtils
 
 trait FileAlg[F[_]] {
   def deleteForce(file: File): F[Unit]
@@ -44,7 +45,7 @@ object FileAlg {
   def create[F[_]](implicit F: Sync[F]): FileAlg[F] =
     new FileAlg[F] {
       override def deleteForce(file: File): F[Unit] =
-        F.delay(if (file.exists) file.delete())
+        F.delay(if (file.exists) FileUtils.forceDelete(file.toJava))
 
       def ensureExists(dir: File): F[File] =
         F.delay {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
   val circeGeneric = "io.circe" %% "circe-generic" % Versions.circe
   val circeParser = "io.circe" %% "circe-parser" % Versions.circe
   val circeRefined = "io.circe" %% "circe-refined" % Versions.circe
+  val commonsIo = "commons-io" % "commons-io" % "2.6"
   val fs2Core = "co.fs2" %% "fs2-core" % "1.0.2"
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
   val http4sCirce = "org.http4s" %% "http4s-circe" % Versions.http4s


### PR DESCRIPTION
better.files.File#delete() leaks file handles which can be observed
by watching `lsof | grep steward | wc -l` grow while steward runs.
With `FileUtils.forceDelete` the count of open files remains nearly
constant.