### PR TITLE
Ignore certain dependencies in the updates cache

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -43,7 +43,7 @@ class UpdateService[F[_]](
     updateRepository.deleteAll >>
       dependencyRepository.getDependencies(repos).flatMap { dependencies =>
         val (libraries, plugins) = dependencies
-          .filter(d => filterAlg.globalKeep(d.toUpdate))
+          .filter(d => filterAlg.globalKeep(d.toUpdate) && UpdateService.includeInUpdateCheck(d))
           .partition(_.sbtVersion.isEmpty)
         val libProjects = splitter
           .xxx(libraries)
@@ -120,4 +120,15 @@ object UpdateService {
     update.groupId === dependency.groupId &&
       update.artifactId === dependency.artifactIdCross &&
       update.currentVersion === dependency.version
+
+  def includeInUpdateCheck(dependency: Dependency): Boolean =
+    (dependency.groupId, dependency.artifactId) match {
+      case ("com.ccadllc.cedi", "build")                     => false
+      case ("com.nrinaudo", "kantan.sbt-kantan")             => false
+      case ("org.foundweekends.giter8", "sbt-giter8")        => false
+      case ("org.scala-lang.modules", "sbt-scala-module")    => false
+      case ("org.scala-lang.modules", "scala-module-plugin") => false
+      case ("org.scodec", "scodec-build")                    => false
+      case _                                                 => true
+    }
 }


### PR DESCRIPTION
Certain dependencies can't be checked for updates in a
`ArtificialProject` because they require settings in the build.

For example, com.ccadllc.cedi:build in `ArtificialProject` leads to the
following error:

```
References to undefined settings:

  *:githubProject from *:pomExtra
((com.ccadllc.cedi.build.BuildSettings) BuildSettings.scala:147)

  *:githubProject from *:githubHttpUrl
((com.ccadllc.cedi.build.BuildSettings) BuildSettings.scala:70)
```

So this ignores certain dependencies that cannot be checked for
an update when building up the updates cache.