### PR TITLE
Config for sandbox execution

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -36,7 +36,8 @@ object Cli {
       gitAskPass: String,
       signCommits: Boolean = false,
       whitelist: List[String] = Nil,
-      readOnly: List[String] = Nil
+      readOnly: List[String] = Nil,
+      execSandbox: Boolean = true
   )
 
   def create[F[_]](implicit F: ApplicativeThrowable[F]): Cli[F] = new Cli[F] {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -52,7 +52,8 @@ final case class Config(
     gitAskPass: File,
     signCommits: Boolean,
     whitelistedDirectories: List[String],
-    readOnlyDirectories: List[String]
+    readOnlyDirectories: List[String],
+    execSandbox: Boolean
 ) {
   def gitHubUser[F[_]](implicit F: Sync[F]): F[AuthenticatedUser] =
     util.uri.fromString[F](gitHubApiHost).flatMap { url =>
@@ -77,7 +78,8 @@ object Config {
         gitAskPass = args.gitAskPass.toFile,
         signCommits = args.signCommits,
         whitelistedDirectories = args.whitelist,
-        readOnlyDirectories = args.readOnly
+        readOnlyDirectories = args.readOnly,
+        execSandbox = args.execSandbox
       )
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/ConfigTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/ConfigTest.scala
@@ -13,6 +13,7 @@ object ConfigTest {
     gitAskPass = File.temp / "askpass.sh",
     signCommits = true,
     whitelistedDirectories = Nil,
-    readOnlyDirectories = Nil
+    readOnlyDirectories = Nil,
+    execSandbox = true
   )
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -12,6 +12,7 @@ class SbtAlgTest extends FunSuite with Matchers {
   implicit val loggerAlg: MockLogger = new MockLogger
   implicit val processAlg: MockProcessAlg = new MockProcessAlg
   implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg
+
   val sbtAlg: SbtAlg[MockEnv] = SbtAlg.create
 
   test("addGlobalPlugins") {


### PR DESCRIPTION
My attempt to work on https://github.com/fthomas/scala-steward/issues/180 

I can get the tests to compile in my machine but the tests fail when they try to read files with test data like "create-fork.json"

Submitting this for initial feedback.

## TODO:
1. I need to figure out how to get the tests to pass in my machine
2. Need to write unit test for this new config flag.
3. I am using scalafmt 1.5.1 . I ran it against both src and test. Still I can't get past the scalafmtCheck in travis CI.