### PR TITLE
Extend multi-step update strategy to all source files

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
@@ -62,7 +62,7 @@ sealed trait Update extends Product with Serializable {
       })
 
     val artifactIdParts =
-      if (splitArtifactId) artifactId.split('-').filter(_.length >= 3).toList else Nil
+      if (splitArtifactId) artifactId.split(Array('-', '_')).filter(_.length >= 3).toList else Nil
     val quotedSearchTerms = searchTerms
       .concat(artifactIdParts)
       .map { term =>

--- a/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
@@ -83,7 +83,7 @@ class UpdateTest extends FunSuite with Matchers {
       .replaceAllIn(original) shouldBe Some(expected)
   }
 
-  test("replaceAllIn: use multi-step strategy") {
+  test("replaceAllInStrict") {
     val original =
       """ "org.http4s" %% "jawn-fs2" % "0.14.0"
         | "org.typelevel" %% "jawn-json4s"  % "0.14.0",
@@ -95,7 +95,7 @@ class UpdateTest extends FunSuite with Matchers {
         | "org.typelevel" %% "jawn-play" % "0.14.1"
       """.stripMargin.trim
     Group("org.typelevel", Nel.of("jawn-json4s", "jawn-play"), "0.14.0", Nel.of("0.14.1"))
-      .replaceAllIn(original) shouldBe Some(expected)
+      .replaceAllInStrict(original) shouldBe Some(expected)
   }
 
   test("replaceAllIn: artifactIds are common suffixes") {
@@ -136,6 +136,13 @@ class UpdateTest extends FunSuite with Matchers {
       "0.10.0",
       Nel.of("0.10.1")
     ).replaceAllIn(original) shouldBe Some(expected)
+  }
+
+  test("replaceAllInRelaxed") {
+    val original = """lazy val circeVersion = "0.9.3""""
+    val expected = """lazy val circeVersion = "0.11.1""""
+    Single("io.circe", "circe-generic", "0.9.3", Nel.of("0.11.1"))
+      .replaceAllInRelaxed(original) shouldBe Some(expected)
   }
 
   test("Group.artifactId") {

--- a/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
@@ -145,6 +145,13 @@ class UpdateTest extends FunSuite with Matchers {
       .replaceAllInRelaxed(original) shouldBe Some(expected)
   }
 
+  test("replaceAllInRelaxed: artifactId with underscore") {
+    val original = """val scShapelessV = "1.1.6""""
+    val expected = """val scShapelessV = "1.1.8""""
+    Single("com.github.alexarchambault", "scalacheck-shapeless_1.13", "1.1.6", Nel.of("1.1.8"))
+      .replaceAllInRelaxed(original) shouldBe Some(expected)
+  }
+
   test("Group.artifactId") {
     Group(
       "org.http4s",


### PR DESCRIPTION
This extends the multi-step update strategy outlined in #236 to all
source files. That means we first try an update strategy on all source
files and stop if it changed any file. Only if it didn't change any file,
we'll try the next strategy and so on.

Also included is a relaxed update strategy that splits artifactIds by
hyphens and uses each part as a search term for updating the version
number. This helps in cases where there is an update for a single update
(e.g. for circe-parser) but the version is defined more generically
(e.g. `val circeVersion = "0.11.1"`).

The code is not pretty but will be improved once this idea proves to be
useful.