### PR TITLE
Ignore updates via a repo-specific .scala-steward.conf file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val core = myCrossProject("core")
       Dependencies.betterFiles,
       Dependencies.caseApp,
       Dependencies.catsEffect,
+      Dependencies.circeConfig,
       Dependencies.circeGeneric,
       Dependencies.circeParser,
       Dependencies.circeRefined,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -30,9 +30,11 @@ import org.scalasteward.core.github.http4s.Http4sGitHubApiAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.json.JsonPullRequestRepo
 import org.scalasteward.core.nurture.{EditAlg, NurtureAlg, PullRequestRepository}
+import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.json.JsonUpdateRepository
 import org.scalasteward.core.update.{FilterAlg, UpdateRepository, UpdateService}
+
 import scala.concurrent.ExecutionContext
 
 final case class Context[F[_]](
@@ -58,10 +60,11 @@ object Context {
       implicit val config: Config = config_
       implicit val logger: Logger[F] = logger_
       implicit val fileAlg: FileAlg[F] = FileAlg.create[F]
-      implicit val filterAlg: FilterAlg[F] = FilterAlg.create[F]
       implicit val processAlg: ProcessAlg[F] = ProcessAlg.create[F]
       implicit val user: AuthenticatedUser = user_
       implicit val workspaceAlg: WorkspaceAlg[F] = WorkspaceAlg.create[F]
+      implicit val repoConfigAlg: RepoConfigAlg[F] = new RepoConfigAlg[F]
+      implicit val filterAlg: FilterAlg[F] = new FilterAlg[F]
       implicit val dependencyRepository: DependencyRepository[F] = new JsonDependencyRepository[F]
       implicit val editAlg: EditAlg[F] = EditAlg.create[F]
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -34,7 +34,6 @@ import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.json.JsonUpdateRepository
 import org.scalasteward.core.update.{FilterAlg, UpdateRepository, UpdateService}
-
 import scala.concurrent.ExecutionContext
 
 final case class Context[F[_]](

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -16,32 +16,12 @@
 
 package org.scalasteward.core.repoconfig
 
-import cats.implicits._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import org.scalasteward.core.model.Update
-import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig}
 
 final case class RepoConfig(
-    allowedUpdates: Option[List[UpdatePattern]] = None,
-    ignoredUpdates: Option[List[UpdatePattern]] = None
-) {
-  def keep(update: Update.Single): FilterResult =
-    isAllowed(update) *> isIgnored(update)
-
-  private def isAllowed(update: Update.Single): FilterResult = {
-    val patterns = allowedUpdates.getOrElse(List.empty)
-    val m = UpdatePattern.findMatch(patterns, update)
-    if (m.byArtifactId.isEmpty || m.byVersion.nonEmpty) Right(update)
-    else Left(NotAllowedByConfig(update))
-  }
-
-  private def isIgnored(update: Update.Single): FilterResult = {
-    val patterns = ignoredUpdates.getOrElse(List.empty)
-    val m = UpdatePattern.findMatch(patterns, update)
-    if (m.byVersion.nonEmpty) Left(IgnoredByConfig(update)) else Right(update)
-  }
-}
+    updates: Option[UpdatesConfig] = None
+)
 
 object RepoConfig {
   implicit val repoConfigDecoder: Decoder[RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -16,12 +16,17 @@
 
 package org.scalasteward.core.repoconfig
 
+import cats.implicits._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import org.scalasteward.core.model.Update
 
 final case class RepoConfig(
     ignoreDependencies: List[String] = List.empty
-)
+) {
+  def isIgnored(update: Update.Single): Boolean =
+    ignoreDependencies.contains_(s"${update.groupId}:${update.artifactId}")
+}
 
 object RepoConfig {
   implicit val repoConfigDecoder: Decoder[RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-2019 scala-steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+final case class RepoConfig(
+    ignoreDependencies: List[String] = List.empty
+)
+
+object RepoConfig {
+  implicit val repoConfigDecoder: Decoder[RepoConfig] =
+    deriveDecoder
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2019 scala-steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.data.OptionT
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import io.circe.config.parser
+import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
+import org.scalasteward.core.util.MonadThrowable
+
+class RepoConfigAlg[F[_]](
+    implicit
+    fileAlg: FileAlg[F],
+    logger: Logger[F],
+    workspaceAlg: WorkspaceAlg[F],
+    F: MonadThrowable[F]
+) {
+  def getRepoConfig(repo: Repo): F[RepoConfig] =
+    workspaceAlg.repoDir(repo).flatMap { dir =>
+      val file = dir / ".scala-steward.conf"
+      OptionT(fileAlg.readFile(file))
+        .flatMapF { content =>
+          parser.decode[RepoConfig](content) match {
+            case Right(config) => F.pure(config.some)
+            case Left(error) =>
+              logger
+                .info(s"Failed to parse ${file.name}: ${error.getMessage}")
+                .as(Option.empty[RepoConfig])
+          }
+        }
+        .getOrElse(RepoConfig())
+    }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -21,25 +21,25 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import org.scalasteward.core.model.Update
 
-final case class DependencyPattern(
+final case class UpdatePattern(
     groupId: String,
     artifactId: Option[String],
     version: Option[String]
 )
 
-object DependencyPattern {
+object UpdatePattern {
   final case class MatchResult(
-      byArtifactId: List[DependencyPattern],
-      byVersion: List[DependencyPattern]
+      byArtifactId: List[UpdatePattern],
+      byVersion: List[UpdatePattern]
   )
 
-  def findMatch(patterns: List[DependencyPattern], update: Update.Single): MatchResult = {
+  def findMatch(patterns: List[UpdatePattern], update: Update.Single): MatchResult = {
     val byGroupId = patterns.filter(_.groupId === update.groupId)
     val byArtifactId = byGroupId.filter(_.artifactId.forall(_ === update.artifactId))
     val byVersion = byArtifactId.filter(_.version.forall(update.nextVersion.startsWith))
     MatchResult(byArtifactId, byVersion)
   }
 
-  implicit val dependencyPatternDecoder: Decoder[DependencyPattern] =
+  implicit val updatePatternDecoder: Decoder[UpdatePattern] =
     deriveDecoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -23,21 +23,21 @@ import org.scalasteward.core.model.Update
 import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig}
 
 final case class UpdatesConfig(
-    allowed: Option[List[UpdatePattern]] = None,
-    ignored: Option[List[UpdatePattern]] = None
+    allow: Option[List[UpdatePattern]] = None,
+    ignore: Option[List[UpdatePattern]] = None
 ) {
   def keep(update: Update.Single): FilterResult =
     isAllowed(update) *> isIgnored(update)
 
   private def isAllowed(update: Update.Single): FilterResult = {
-    val patterns = allowed.getOrElse(List.empty)
+    val patterns = allow.getOrElse(List.empty)
     val m = UpdatePattern.findMatch(patterns, update)
     if (m.byArtifactId.isEmpty || m.byVersion.nonEmpty) Right(update)
     else Left(NotAllowedByConfig(update))
   }
 
   private def isIgnored(update: Update.Single): FilterResult = {
-    val patterns = ignored.getOrElse(List.empty)
+    val patterns = ignore.getOrElse(List.empty)
     val m = UpdatePattern.findMatch(patterns, update)
     if (m.byVersion.nonEmpty) Left(IgnoredByConfig(update)) else Right(update)
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2019 scala-steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import cats.implicits._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import org.scalasteward.core.model.Update
+import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig}
+
+final case class UpdatesConfig(
+    allowed: Option[List[UpdatePattern]] = None,
+    ignored: Option[List[UpdatePattern]] = None
+) {
+  def keep(update: Update.Single): FilterResult =
+    isAllowed(update) *> isIgnored(update)
+
+  private def isAllowed(update: Update.Single): FilterResult = {
+    val patterns = allowed.getOrElse(List.empty)
+    val m = UpdatePattern.findMatch(patterns, update)
+    if (m.byArtifactId.isEmpty || m.byVersion.nonEmpty) Right(update)
+    else Left(NotAllowedByConfig(update))
+  }
+
+  private def isIgnored(update: Update.Single): FilterResult = {
+    val patterns = ignored.getOrElse(List.empty)
+    val m = UpdatePattern.findMatch(patterns, update)
+    if (m.byVersion.nonEmpty) Left(IgnoredByConfig(update)) else Right(update)
+  }
+}
+
+object UpdatesConfig {
+  implicit val updatesConfigDecoder: Decoder[UpdatesConfig] =
+    deriveDecoder
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -34,13 +34,17 @@ class FilterAlg[F[_]](
   def globalFilterMany[G[_]: TraverseFilter](updates: G[Update.Single]): F[G[Update.Single]] =
     updates.traverseFilter(update => logIfRejected(globalFilter(update)))
 
+  def localFilterManyWithConfig[G[_]: TraverseFilter](
+      config: RepoConfig,
+      updates: G[Update.Single]
+  ): F[G[Update.Single]] =
+    updates.traverseFilter(update => logIfRejected(localFilter(update, config)))
+
   def localFilterMany[G[_]: TraverseFilter](
       repo: Repo,
       updates: G[Update.Single]
   ): F[G[Update.Single]] =
-    repoConfigAlg.getRepoConfig(repo).flatMap { config =>
-      updates.traverseFilter(update => logIfRejected(localFilter(update, config)))
-    }
+    repoConfigAlg.getRepoConfig(repo).flatMap(localFilterManyWithConfig(_, updates))
 
   private def logIfRejected(result: FilterResult): F[Option[Update.Single]] =
     result match {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -43,7 +43,7 @@ class FilterAlg[F[_]](
   ): F[G[Update.Single]] =
     repoConfigAlg.getRepoConfig(repo).flatMap { config =>
       updates.traverseFilter { update =>
-        filterImpl(globalKeep(update) && !config.isIgnored(update), update)
+        filterImpl(globalKeep(update) && config.keep(update), update)
       }
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -66,7 +66,9 @@ object FilterAlg {
     removeBadVersions(update).flatMap(isIgnoredGlobally)
 
   def localFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
-    globalFilter(update).flatMap(repoConfig.keep)
+    globalFilter(update).flatMap { update1 =>
+      repoConfig.updates.map(_.keep(update1)).getOrElse(Right(update1))
+    }
 
   def isIgnoredGlobally(update: Update.Single): FilterResult = {
     val keep = ((update.groupId, update.artifactId) match {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -43,7 +43,7 @@ class UpdateService[F[_]](
     updateRepository.deleteAll >>
       dependencyRepository.getDependencies(repos).flatMap { dependencies =>
         val (libraries, plugins) = dependencies
-          .filter(d => filterAlg.globalKeep(d.toUpdate) && UpdateService.includeInUpdateCheck(d))
+          .filter(d => FilterAlg.globalKeep(d.toUpdate) && UpdateService.includeInUpdateCheck(d))
           .partition(_.sbtVersion.isEmpty)
         val libProjects = splitter
           .xxx(libraries)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -43,7 +43,11 @@ class UpdateService[F[_]](
     updateRepository.deleteAll >>
       dependencyRepository.getDependencies(repos).flatMap { dependencies =>
         val (libraries, plugins) = dependencies
-          .filter(d => FilterAlg.globalKeep(d.toUpdate) && UpdateService.includeInUpdateCheck(d))
+          .filter(
+            d =>
+              FilterAlg.isIgnoredGlobally(d.toUpdate).isRight && UpdateService
+                .includeInUpdateCheck(d)
+          )
           .partition(_.sbtVersion.isEmpty)
         val libProjects = splitter
           .xxx(libraries)

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -5,7 +5,9 @@ import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{Author, GitAlg}
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.scalasteward.core.nurture.EditAlg
+import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
+import org.scalasteward.core.update.FilterAlg
 
 object MockContext {
   implicit val config: Config = Config(
@@ -31,4 +33,6 @@ object MockContext {
   implicit val editAlg: EditAlg[MockEff] = EditAlg.create
   implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
   implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
+  implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
+  implicit val filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,0 +1,20 @@
+package org.scalasteward.core.repoconfig
+
+import better.files.File
+import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.mock.MockContext.repoConfigAlg
+import org.scalasteward.core.mock.MockState
+import org.scalatest.{FunSuite, Matchers}
+
+class RepoConfigAlgTest extends FunSuite with Matchers {
+  test("malformed config") {
+    val repo = Repo("fthomas", "scala-steward")
+    val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
+    val initialState = MockState.empty.add(configFile, """ignoreDependencies: ["foo """)
+    val (state, config) = repoConfigAlg.getRepoConfig(repo).run(initialState).unsafeRunSync()
+
+    config shouldBe RepoConfig()
+    state.logs.headOption.map { case (_, msg) => msg }.getOrElse("") should
+      startWith("Failed to parse .scala-steward.conf")
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -7,10 +7,30 @@ import org.scalasteward.core.mock.MockState
 import org.scalatest.{FunSuite, Matchers}
 
 class RepoConfigAlgTest extends FunSuite with Matchers {
+  test("config with all fields set") {
+    val repo = Repo("fthomas", "scala-steward")
+    val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
+    val content =
+      """|updates.allowed = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
+         |updates.ignored = [ { groupId = "org.acme", version = "1.0" } ]
+         |""".stripMargin
+    val initialState = MockState.empty.add(configFile, content)
+    val config = repoConfigAlg.getRepoConfig(repo).runA(initialState).unsafeRunSync()
+
+    config shouldBe RepoConfig(
+      updates = Some(
+        UpdatesConfig(
+          allowed = Some(List(UpdatePattern("eu.timepit", Some("refined"), Some("0.8.")))),
+          ignored = Some(List(UpdatePattern("org.acme", None, Some("1.0"))))
+        )
+      )
+    )
+  }
+
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
-    val initialState = MockState.empty.add(configFile, """ignoreDependencies: ["foo """)
+    val initialState = MockState.empty.add(configFile, """updates.ignored = [ "foo """)
     val (state, config) = repoConfigAlg.getRepoConfig(repo).run(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig()

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -11,8 +11,8 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
     val content =
-      """|updates.allowed = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
-         |updates.ignored = [ { groupId = "org.acme", version = "1.0" } ]
+      """|updates.allow  = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
+         |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
          |""".stripMargin
     val initialState = MockState.empty.add(configFile, content)
     val config = repoConfigAlg.getRepoConfig(repo).runA(initialState).unsafeRunSync()
@@ -20,8 +20,8 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     config shouldBe RepoConfig(
       updates = Some(
         UpdatesConfig(
-          allowed = Some(List(UpdatePattern("eu.timepit", Some("refined"), Some("0.8.")))),
-          ignored = Some(List(UpdatePattern("org.acme", None, Some("1.0"))))
+          allow = Some(List(UpdatePattern("eu.timepit", Some("refined"), Some("0.8.")))),
+          ignore = Some(List(UpdatePattern("org.acme", None, Some("1.0"))))
         )
       )
     )
@@ -30,7 +30,7 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
-    val initialState = MockState.empty.add(configFile, """updates.ignored = [ "foo """)
+    val initialState = MockState.empty.add(configFile, """updates.ignore = [ "foo """)
     val (state, config) = repoConfigAlg.getRepoConfig(repo).run(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig()

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -27,14 +27,14 @@ class FilterAlgTest extends FunSuite with Matchers {
     FilterAlg.removeBadVersions(update) shouldBe Left(BadVersions(update))
   }
 
-  test("ignore update via repo config") {
+  test("ignore update via config updates.ignore") {
     val repo = Repo("fthomas", "scala-steward")
     val update1 = Update.Single("org.http4s", "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
     val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
 
     val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
     val configContent =
-      """updates.ignored = [ { groupId = "eu.timepit", artifactId = "refined" } ]"""
+      """updates.ignore = [ { groupId = "eu.timepit", artifactId = "refined" } ]"""
 
     val initialState = MockState.empty.add(configFile, configContent)
     val (state, filtered) =
@@ -47,14 +47,14 @@ class FilterAlgTest extends FunSuite with Matchers {
     )
   }
 
-  test("ignore update via repo config using allowUpdates") {
+  test("ignore update via config updates.allow") {
     val update1 = Update.Single("org.http4s", "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
     val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
       updates = Some(
         UpdatesConfig(
-          allowed = Some(
+          allow = Some(
             List(
               UpdatePattern("org.http4s", None, Some("0.17")),
               UpdatePattern("eu.timepit", Some("refined"), Some("0.8"))

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -6,23 +6,24 @@ import org.scalasteward.core.github.data.Repo
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update
+import org.scalasteward.core.update.FilterAlg.BadVersions
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
 class FilterAlgTest extends FunSuite with Matchers {
   test("removeBadVersions: update without bad version") {
     val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
-    FilterAlg.removeBadVersions(update) shouldBe Some(update)
+    FilterAlg.removeBadVersions(update) shouldBe Right(update)
   }
 
   test("removeBadVersions: update with bad version") {
     val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.2-1", Nel.of("1.1.2", "2.0.0"))
-    FilterAlg.removeBadVersions(update) shouldBe Some(update.copy(newerVersions = Nel.of("2.0.0")))
+    FilterAlg.removeBadVersions(update) shouldBe Right(update.copy(newerVersions = Nel.of("2.0.0")))
   }
 
   test("removeBadVersions: update with only bad versions") {
     val update = Update.Single("org.http4s", "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
-    FilterAlg.removeBadVersions(update) shouldBe None
+    FilterAlg.removeBadVersions(update) shouldBe Left(BadVersions(update))
   }
 
   test("ignore update via repo config") {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -1,8 +1,13 @@
 package org.scalasteward.core.update
 
+import better.files.File
+import cats.implicits._
+import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.mock.MockContext.filterAlg
+import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update
-import org.scalatest.{FunSuite, Matchers}
 import org.scalasteward.core.util.Nel
+import org.scalatest.{FunSuite, Matchers}
 
 class FilterAlgTest extends FunSuite with Matchers {
   test("removeBadVersions: update without bad version") {
@@ -18,5 +23,24 @@ class FilterAlgTest extends FunSuite with Matchers {
   test("removeBadVersions: update with only bad versions") {
     val update = Update.Single("org.http4s", "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
     FilterAlg.removeBadVersions(update) shouldBe None
+  }
+
+  test("ignore update via repo config") {
+    val repo = Repo("fthomas", "scala-steward")
+    val update1 = Update.Single("org.http4s", "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
+    val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
+
+    val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
+    val initialState =
+      MockState.empty.add(configFile, """ignoreDependencies: ["eu.timepit:refined"]""")
+
+    val (state, filtered) =
+      filterAlg.localFilterMany(repo, List(update1, update2)).run(initialState).unsafeRunSync()
+
+    filtered shouldBe List(update1)
+    state shouldBe initialState.copy(
+      commands = Vector(List("read", configFile.pathAsString)),
+      logs = Vector((None, "Ignore eu.timepit:refined : 0.8.0 -> 0.8.1"))
+    )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -6,7 +6,7 @@ import org.scalasteward.core.github.data.Repo
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update
-import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern}
+import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
 import org.scalasteward.core.update.FilterAlg.BadVersions
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
@@ -33,7 +33,8 @@ class FilterAlgTest extends FunSuite with Matchers {
     val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
 
     val configFile = File("/tmp/ws/fthomas/scala-steward/.scala-steward.conf")
-    val configContent = """ignoredUpdates: [ { groupId: "eu.timepit", artifactId: "refined" } ]"""
+    val configContent =
+      """updates.ignored = [ { groupId = "eu.timepit", artifactId = "refined" } ]"""
 
     val initialState = MockState.empty.add(configFile, configContent)
     val (state, filtered) =
@@ -51,10 +52,14 @@ class FilterAlgTest extends FunSuite with Matchers {
     val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
-      allowedUpdates = Some(
-        List(
-          UpdatePattern("org.http4s", None, Some("0.17")),
-          UpdatePattern("eu.timepit", Some("refined"), Some("0.8"))
+      updates = Some(
+        UpdatesConfig(
+          allowed = Some(
+            List(
+              UpdatePattern("org.http4s", None, Some("0.17")),
+              UpdatePattern("eu.timepit", Some("refined"), Some("0.8"))
+            )
+          )
         )
       )
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   val betterFiles = "com.github.pathikrit" %% "better-files" % "3.7.0"
   val caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0-M5"
   val catsEffect = "org.typelevel" %% "cats-effect" % "1.2.0"
+  val circeConfig = "io.circe" %% "circe-config" % "0.6.1"
   val circeGeneric = "io.circe" %% "circe-generic" % Versions.circe
   val circeParser = "io.circe" %% "circe-parser" % Versions.circe
   val circeRefined = "io.circe" %% "circe-refined" % Versions.circe


### PR DESCRIPTION
This implements repository specific configuration via a `.scala-steward.conf` file to ignore or only allow specific updates. [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) is used as format for this file. If a repository has `.scala-steward.conf` file in its root directory, scala-steward will read it and ignore updates according to the content therein.

Here is an example of a `.scala-steward.conf` file:
```hocon
updates.ignore = [
  { groupId = "com.typesafe.akka", artifactId = "akka-actor" },
  { groupId = "org.scalaz", artifactId = "scalaz-zio", version = "0.5" }
]
updates.allow = [
  { groupId = "org.http4s", version = "0.18" }
]
```
The objects of the `ignore` and `allow` lists are patterns that are matched against each update. `groupId` and `artifactId` are matched exactly while the `version` pattern matches if it is a prefix of the version of the update. If a `groupId`, `artifactId`, or `version` pattern is not specified, it is treated like a wildcard.  So the example above instructs scala-steward to
 * ignore all updates of akka-actor
 * ignore all updates of scalaz-zio where the version begins with  `0.5`
 * ignore all updates of any http4s module except those where the version starts with `0.18`

Closes #91.