### PR TITLE
Add details section to PR about ignoring updates

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
@@ -22,6 +22,7 @@ import io.circe.generic.semiauto._
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.nurture.UpdateData
+import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.{git, github}
 
 final case class NewPullRequestData(
@@ -51,6 +52,15 @@ object NewPullRequestData {
         |If you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @$login in the comments below.
         |
         |Have a nice day!
+        |
+        |<details>
+        |<summary>Ignore future updates</summary>
+        |
+        |Add this to your `${RepoConfigAlg.repoConfigBasename}` file to ignore future updates of this dependency:
+        |```
+        |${RepoConfigAlg.configToIgnoreFurtherUpdates(update)}
+        |```
+        |</details>
         |""".stripMargin.trim
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -22,6 +22,7 @@ import io.chrisdavenport.log4cats.Logger
 import io.circe.config.parser
 import org.scalasteward.core.github.data.Repo
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
+import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg._
 import org.scalasteward.core.util.MonadThrowable
 
@@ -51,5 +52,13 @@ object RepoConfigAlg {
   def parseRepoConfig(input: String): Either[String, RepoConfig] =
     parser.decode[RepoConfig](input).leftMap { error =>
       s"Failed to parse $repoConfigBasename: ${error.getMessage}"
+    }
+
+  def configToIgnoreFurtherUpdates(update: Update): String =
+    update match {
+      case s: Update.Single =>
+        s"""updates.ignore = [{ groupId = "${s.groupId}", artifactId = "${s.artifactId}" }]"""
+      case g: Update.Group =>
+        s"""updates.ignore = [{ groupId = "${g.groupId}" }]"""
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
@@ -19,7 +19,7 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
     NewPullRequestData.from(data, "scala-steward").asJson.spaces2 shouldBe
       """|{
          |  "title" : "Update logback-classic to 1.2.3",
-         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!",
+         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>",
          |  "head" : "scala-steward:update/logback-classic-1.2.3",
          |  "base" : "master"
          |}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -4,6 +4,8 @@ import better.files.File
 import org.scalasteward.core.github.data.Repo
 import org.scalasteward.core.mock.MockContext.repoConfigAlg
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.model.Update
+import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
 class RepoConfigAlgTest extends FunSuite with Matchers {
@@ -36,5 +38,35 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     config shouldBe RepoConfig()
     state.logs.headOption.map { case (_, msg) => msg }.getOrElse("") should
       startWith("Failed to parse .scala-steward.conf")
+  }
+
+  test("configToIgnoreFurtherUpdates with single update") {
+    val update = Update.Single("a", "b", "c", Nel.of("d"))
+    val repoConfig = RepoConfigAlg
+      .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
+      .getOrElse(RepoConfig())
+
+    repoConfig shouldBe RepoConfig(
+      updates = Some(
+        UpdatesConfig(
+          ignore = Some(List(UpdatePattern("a", Some("b"), None)))
+        )
+      )
+    )
+  }
+
+  test("configToIgnoreFurtherUpdates with group update") {
+    val update = Update.Group("a", Nel.of("b", "e"), "c", Nel.of("d"))
+    val repoConfig = RepoConfigAlg
+      .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
+      .getOrElse(RepoConfig())
+
+    repoConfig shouldBe RepoConfig(
+      updates = Some(
+        UpdatesConfig(
+          ignore = Some(List(UpdatePattern("a", None, None)))
+        )
+      )
+    )
   }
 }


### PR DESCRIPTION
This adds a `details` section to the PR body with a description of how to ignore updates using `.scala-steward.conf`.

A preview of this change can be seen here: https://github.com/fthomas/scala-steward/pull/302