### PR TITLE
remove scala-dist

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -220,7 +220,6 @@
 - scala/scala-collection-contrib
 - scala/scala-collections-laws
 - scala/scala-continuations
-- scala/scala-dist
 - scala/scala-dist-smoketest
 - scala/scala-java8-compat
 - scala/scala-module-dependency-sample


### PR DESCRIPTION
we're very conservative about upgrading anything in this repo, so I probably
just shouldn't have added it in the first place.