### PR TITLE
Set DEBIAN_FRONTEND to noninteractive in docker build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val metadataSettings = Def.settings(
 lazy val dockerSettings = Def.settings(
   dockerCommands := Seq(
     Cmd("FROM", "openjdk:8"),
+    Cmd("ARG", "DEBIAN_FRONTEND=noninteractive"),
     ExecCmd("RUN", "apt-get", "update"),
     ExecCmd("RUN", "apt-get", "install", "-y", "apt-transport-https", "firejail"),
     ExecCmd(


### PR DESCRIPTION
This fixes an issue I've run across when building the docker image on CircleCI. I've tried many different things and setting the `DEBIAN_FRONTEND` to `interactive` in the DOCKERFILE during the build seems to be the only way I could get it to work.

```
[info] Setting up keyboard-configuration (1.164) ...
[info] debconf: unable to initialize frontend: Dialog
[info] debconf: (TERM is not set, so the dialog frontend is not usable.)
[info] debconf: falling back to frontend: Readline
[info] cat: '/sys/bus/usb/devices/*:*/bInterfaceClass': No such file or directory
[info] cat: '/sys/bus/usb/devices/*:*/bInterfaceSubClass': No such file or directory
[info] cat: '/sys/bus/usb/devices/*:*/bInterfaceProtocol': No such file or directory
[info] Configuring keyboard-configuration
[info] ----------------------------------
[info] Please select the layout matching the keyboard for this machine.
[info]   1. English (US)
[info]   2. English (US) - Cherokee
[info]   3. English (US) - English (Colemak)
[info]   4. English (US) - English (Dvorak alternative international no dead keys)
[info]   5. English (US) - English (Dvorak)
[info]   6. English (US) - English (Dvorak, international with dead keys)
[info]   7. English (US) - English (Macintosh)
[info]   8. English (US) - English (Programmer Dvorak)
[info]   9. English (US) - English (US, alternative international)
[info]   10. English (US) - English (US, international with dead keys)
[info]   11. English (US) - English (US, with euro on 5)
[info]   12. English (US) - English (Workman)
[info]   13. English (US) - English (Workman, international with dead keys)
[info]   14. English (US) - English (classic Dvorak)
[info]   15. English (US) - English (international AltGr dead keys)
[info]   16. English (US) - English (left handed Dvorak)
[info]   17. English (US) - English (right handed Dvorak)
[info]   18. English (US) - English (the divide/multiply keys toggle the layout)
[info]   19. English (US) - Russian (US, phonetic)
[info]   20. English (US) - Serbo-Croatian (US)
[info]   21. Other
[info] Keyboard layout: 
```