### PR TITLE
Fix docker volume mounting in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ Or,
 ```bash
 sbt docker:publishLocal
 
-docker run -v $STEWARD_DIR:/opt/docker -it scala-steward:0.1.0-SNAPSHOT \
-  --workspace  "/opt/docker/workspace" \
-  --repos-file "/opt/docker/repos.md" \
+docker run -v $STEWARD_DIR:/opt/scala-steward -it scala-steward:0.1.0-SNAPSHOT \
+  --workspace  "/opt/scala-steward/workspace" \
+  --repos-file "/opt/scala-steward/repos.md" \
   --git-author-name "Scala steward" \
   --git-author-email ${EMAIL} \
   --github-api-host "https://api.github.com" \
   --github-login ${LOGIN} \
-  --git-ask-pass "/opt/docker/.github/askpass/$LOGIN.sh" \
+  --git-ask-pass "/opt/scala-steward/.github/askpass/$LOGIN.sh" \
   --sign-commits
 ```
 


### PR DESCRIPTION
By mounting scala-steward directory into `/opt/docker` inside of the container, you overwrite all of the existing files including `/opt/docker/bin/scala-steward` and all the jars in `/opt/docker/lib/` which makes the container fail on startup (as the entry point script can no longer be executed).

I've updated the README to address this by mounting `$STEWARD_DIR` into `/opt/scala-steward` instead.