### PR TITLE
support swagger-akka-http and swagger-scala-module

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -270,6 +270,8 @@
 - spotify/scio.g8
 - spotify/scio-contrib
 - spotify/scio-idea-plugin
+- swagger-akka-http/swagger-akka-http
+- swagger-akka-http/swagger-scala-module
 - sullis/jms-testkit
 - ThoughtWorksInc/Binding.scala
 - ThoughtWorksInc/Dsl.scala


### PR DESCRIPTION
I am the maintainer of these 2 projects and would like to have scala-steward keep me informed of updated dependencies.