### PR TITLE
Always use Config.gitHubLogin in PR body

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
@@ -64,11 +64,11 @@ object NewPullRequestData {
         |""".stripMargin.trim
   }
 
-  def from(data: UpdateData, login: String): NewPullRequestData =
+  def from(data: UpdateData, headLogin: String, authorLogin: String): NewPullRequestData =
     NewPullRequestData(
       title = git.commitMsgFor(data.update),
-      body = bodyFor(data.update, login),
-      head = github.headFor(login, data.update),
+      body = bodyFor(data.update, authorLogin),
+      head = github.headFor(headLogin, data.update),
       base = data.baseBranch
     )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/github/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/package.scala
@@ -16,15 +16,14 @@
 
 package org.scalasteward.core
 
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.model.Update
 
 package object github {
 
   def getLogin(config: Config, repo: Repo): String =
-    if (config.doNotFork) repo.owner
-    else config.gitHubLogin
+    if (config.doNotFork) repo.owner else config.gitHubLogin
 
   def headFor(login: String, update: Update): String =
     s"$login:${git.branchFor(update).name}"

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -116,7 +116,8 @@ class NurtureAlg[F[_]](
   def createPullRequest(data: UpdateData): F[Unit] =
     for {
       _ <- logger.info(s"Create PR ${data.updateBranch.name}")
-      requestData = NewPullRequestData.from(data, github.getLogin(config, data.repo))
+      headLogin = github.getLogin(config, data.repo)
+      requestData = NewPullRequestData.from(data, headLogin, config.gitHubLogin)
       pr <- gitHubApiAlg.createPullRequest(data.repo, requestData)
       _ <- pullRequestRepo.createOrUpdate(data.repo, pr.html_url, data.baseSha1, data.update)
       _ <- logger.info(s"Created PR ${pr.html_url}")

--- a/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
@@ -16,11 +16,11 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
       Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
       Branch("update/logback-classic-1.2.3")
     )
-    NewPullRequestData.from(data, "scala-steward").asJson.spaces2 shouldBe
+    NewPullRequestData.from(data, "foo", "scala-steward").asJson.spaces2 shouldBe
       """|{
          |  "title" : "Update logback-classic to 1.2.3",
          |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>",
-         |  "head" : "scala-steward:update/logback-classic-1.2.3",
+         |  "head" : "foo:update/logback-classic-1.2.3",
          |  "base" : "master"
          |}
          |""".stripMargin.trim


### PR DESCRIPTION
This uses Config.gitHubLogin as contact in the PR body if
Config.doNotFork is true. Prior to this change, the login of the repo
in which the PR was created was used in the body of PRs. But the login
in the PR body should be the account responsible for running the
scala-steward instance.