### PR TITLE
attempt to include sbt-catalysts

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -311,7 +311,6 @@
 - travisbrown/iteratee-twitter
 - twilio/guardrail
 - typelevel/cats
-- typelevel/sbt-catalysts
 - typelevel/cats-collections
 - typelevel/cats-effect
 - typelevel/cats-mtl
@@ -321,6 +320,7 @@
 - typelevel/kittens
 - typelevel/machinist
 - typelevel/mouse
+- typelevel/sbt-catalysts
 - typelevel/spire
 - ua-parser/uap-scala
 - underscoreio/slickless

--- a/repos.md
+++ b/repos.md
@@ -311,6 +311,7 @@
 - travisbrown/iteratee-twitter
 - twilio/guardrail
 - typelevel/cats
+- typelevel/sbt-catalysts
 - typelevel/cats-collections
 - typelevel/cats-effect
 - typelevel/cats-mtl


### PR DESCRIPTION
I am not sure how scala-steward works and if it will work for sbt-catalyts. 
The versions I cared most are stored [here](https://github.com/typelevel/sbt-catalysts/blob/master/src/main/scala/org/typelevel/TypelevelDeps.scala), not even in the `build.sbt` file or in `project`
It's fine if steward doesn't know how to work with these versions at least I imagine it will update the plugin's own deps.