### PR TITLE
#365 Add --ignore-opts-files option

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -42,6 +42,7 @@ object Cli {
       readOnly: List[String] = Nil,
       disableSandbox: Boolean = false,
       doNotFork: Boolean = false,
+      ignoreOptsFiles: Boolean = false,
       keepCredentials: Boolean = false,
       envVar: List[EnvVar] = Nil
   )

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -56,6 +56,7 @@ final case class Config(
     readOnlyDirectories: List[String],
     disableSandbox: Boolean,
     doNotFork: Boolean,
+    ignoreOptsFiles: Boolean,
     keepCredentials: Boolean,
     envVars: List[EnvVar]
 ) {
@@ -84,6 +85,7 @@ object Config {
         readOnlyDirectories = args.readOnly,
         disableSandbox = args.disableSandbox,
         doNotFork = args.doNotFork,
+        ignoreOptsFiles = args.ignoreOptsFiles,
         keepCredentials = args.keepCredentials,
         envVars = args.envVar
       )

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -97,7 +97,9 @@ object SbtAlg {
         fileAlg.home.map(_ / ".sbt")
 
       def exec(command: Nel[String], repoDir: File): F[List[String]] =
-        ignoreOptsFiles(repoDir)(processAlg.execSandboxed(command, repoDir))
+        if (config.ignoreOptsFiles) {
+          ignoreOptsFiles(repoDir)(processAlg.execSandboxed(command, repoDir))
+        } else processAlg.execSandboxed(command, repoDir)
 
       def sbtCmd(commands: List[String]): Nel[String] =
         Nel.of("sbt", "-batch", "-no-colors", commands.mkString(";", ";", ""))

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -19,6 +19,7 @@ class CliTest extends FunSuite with Matchers {
         List("--github-api-host", "http://example.com"),
         List("--github-login", "e"),
         List("--git-ask-pass", "f"),
+        List("--ignore-opts-files"),
         List("--env-var", "g=h"),
         List("--env-var", "i=j")
       ).flatten
@@ -31,6 +32,7 @@ class CliTest extends FunSuite with Matchers {
         githubApiHost = Uri.uri("http://example.com"),
         githubLogin = "e",
         gitAskPass = "f",
+        ignoreOptsFiles = true,
         envVar = List(EnvVar("g", "h"), EnvVar("i", "j"))
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -26,6 +26,7 @@ object MockContext {
     readOnlyDirectories = Nil,
     disableSandbox = false,
     doNotFork = false,
+    ignoreOptsFiles = false,
     keepCredentials = false,
     envVars = List(
       EnvVar("TEST_VAR", "GREAT"),


### PR DESCRIPTION
Add a flag `--ignore-opts-files`. This flag will enable the temporary deletion of .sbtopts and .jvmopts files (previously this PR was to have a flag `--disable-ignore-opts-files` to do the opposite).

See: #365 

Please let me know if there's anything amiss or any tests that I should probably add. Thanks!