### PR TITLE
Adds configuration settings to disable PR updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val core = myCrossProject("core")
       Dependencies.circeGeneric,
       Dependencies.circeParser,
       Dependencies.circeRefined,
+      Dependencies.circeExtras,
       Dependencies.commonsIo,
       Dependencies.fs2Core,
       Dependencies.http4sBlazeClient,

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -17,13 +17,18 @@
 package org.scalasteward.core.repoconfig
 
 import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.extras.semiauto.deriveDecoder
+import io.circe.generic.extras.Configuration
 
 final case class RepoConfig(
-    updates: Option[UpdatesConfig] = None
+    updates: Option[UpdatesConfig] = None,
+    updatePullRequests: Boolean = true
 )
 
 object RepoConfig {
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+
   implicit val repoConfigDecoder: Decoder[RepoConfig] =
     deriveDecoder
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -29,6 +29,21 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     )
   }
 
+  test("config with 'updateBranch disabled") {
+    val repo = Repo("fthomas", "scala-steward")
+    val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
+    val content =
+      """|updatePullRequests = false
+         |""".stripMargin
+    val initialState = MockState.empty.add(configFile, content)
+    val config = repoConfigAlg.getRepoConfig(repo).runA(initialState).unsafeRunSync()
+
+    config shouldBe RepoConfig(
+      updates = None,
+      updatePullRequests = false
+    )
+  }
+
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val circeLiteral = "io.circe" %% "circe-literal" % Versions.circe
   val circeParser = "io.circe" %% "circe-parser" % Versions.circe
   val circeRefined = "io.circe" %% "circe-refined" % Versions.circe
+  val circeExtras = "io.circe" %% "circe-generic-extras" % Versions.circe
   val commonsIo = "commons-io" % "commons-io" % "2.6"
   val fs2Core = "co.fs2" %% "fs2-core" % "1.0.4"
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s


### PR DESCRIPTION
This a fix for #384 and it builds on #387. 

I added tests for `RepoConfig`, but didn't find tests to simulate PR rebase and forced-pushes. 

This change preserves the previous behaviour, which is the PR is rebased when the bot detects that the current branch is behind upstream.