### PR TITLE
escape multi line bash documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sbt stage
   --github-api-host "https://api.github.com" \
   --github-login ${LOGIN} \
   --git-ask-pass "$STEWARD_DIR/.github/askpass/$LOGIN.sh" \
-  --sign-commits
+  --sign-commits \
   --env-var FOO=BAR
 ```
 
@@ -103,15 +103,17 @@ docker run -v $STEWARD_DIR:/opt/scala-steward -it scala-steward:0.1.0-SNAPSHOT \
   --github-api-host "https://api.github.com" \
   --github-login ${LOGIN} \
   --git-ask-pass "/opt/scala-steward/.github/askpass/$LOGIN.sh" \
-  --sign-commits
+  --sign-commits \
   --env-var FOO=BAR
 ```
 
 If you run scala-steward for your own private projects, you can pass additional environment variables from the command line using the `--env-var` flag as shown in the examples above. You can use this to pass any credentials required by your projects to resolve any private dependencies, e.g.: 
-```
---env-var BINTRAY_USER=username
+
+```bash
+--env-var BINTRAY_USER=username \
 --env-var BINTRAY_PASS=password
 ```
+
 These variables will be accessible (in sbt) to all of the projects that scala-steward checks dependencies for.
 
 ## License


### PR DESCRIPTION
Makes copy pasting the examples less error-prone.