### PR TITLE
Create temporary .jvmopts to set stack size

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -11,6 +11,19 @@ import org.scalatest.{FunSuite, Matchers}
 class FileAlgTest extends FunSuite with Matchers {
   val ioFileAlg: FileAlg[IO] = FileAlg.create[IO]
 
+  test("createTemporarily") {
+    val file = File.temp / "test-scala-steward3.tmp"
+    val content = Arbitrary.arbitrary[String].sample.getOrElse("")
+
+    val p = for {
+      before <- ioFileAlg.readFile(file)
+      during <- ioFileAlg.createTemporarily(file, content)(ioFileAlg.readFile(file))
+      after <- ioFileAlg.readFile(file)
+    } yield (before, during, after)
+
+    p.unsafeRunSync() shouldBe ((None, Some(content), None))
+  }
+
   test("writeFile *> readFile <* deleteForce") {
     val file = File.temp / "test-scala-steward1.tmp"
     val content = Arbitrary.arbitrary[String].sample.getOrElse("")

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockFileAlg.scala
@@ -7,6 +7,13 @@ import fs2.Stream
 import org.scalasteward.core.mock.{applyPure, MockEff, MockState}
 
 class MockFileAlg extends FileAlg[MockEff] {
+  override def createTemporarily[A](file: File, content: String)(fa: MockEff[A]): MockEff[A] =
+    for {
+      _ <- StateT.modify[IO, MockState](_.exec(List("create", file.pathAsString)))
+      a <- fa
+      _ <- StateT.modify[IO, MockState](_.exec(List("rm", file.pathAsString)))
+    } yield a
+
   override def deleteForce(file: File): MockEff[Unit] =
     StateT.modify(_.exec(List("rm", "-rf", file.pathAsString)).rm(file))
 

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -62,6 +62,7 @@ class SbtAlgTest extends FunSuite with Matchers {
       commands = Vector(
         List("rm", (repoDir / ".jvmopts").toString),
         List("rm", (repoDir / ".sbtopts").toString),
+        List("create", (repoDir / ".jvmopts").toString),
         List(
           repoDir.toString,
           "firejail",
@@ -71,6 +72,7 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
         ),
+        List("rm", (repoDir / ".jvmopts").toString),
         List("restore", (repoDir / ".sbtopts").toString),
         List("restore", (repoDir / ".jvmopts").toString)
       ),


### PR DESCRIPTION
This allows scala-steward to run the doobie build without running
into a SOE