### PR TITLE
Include base branch when searching for existing PRs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/GitHubApiAlg.scala
@@ -38,7 +38,7 @@ trait GitHubApiAlg[F[_]] {
   def getRepo(repo: Repo): F[RepoOut]
 
   /** https://developer.github.com/v3/pulls/#list-pull-requests */
-  def listPullRequests(repo: Repo, head: String): F[List[PullRequestOut]]
+  def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]]
 
   def createForkOrGetRepo(config: Config, repo: Repo): F[RepoOut] =
     if (config.doNotFork) getRepo(repo)

--- a/modules/core/src/main/scala/org/scalasteward/core/github/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/Url.scala
@@ -27,8 +27,11 @@ class Url(apiHost: Uri) {
   def forks(repo: Repo): Uri =
     repos(repo) / "forks"
 
-  def listPullRequests(repo: Repo, head: String): Uri =
-    pulls(repo).withQueryParam("head", head).withQueryParam("state", "all")
+  def listPullRequests(repo: Repo, head: String, base: Branch): Uri =
+    pulls(repo)
+      .withQueryParam("head", head)
+      .withQueryParam("base", base.name)
+      .withQueryParam("state", "all")
 
   def pulls(repo: Repo): Uri =
     repos(repo) / "pulls"

--- a/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
@@ -44,6 +44,6 @@ final class Http4sGitHubApiAlg[F[_]: Sync](
   override def getRepo(repo: Repo): F[RepoOut] =
     client.get(url.repos(repo), modify(repo))
 
-  override def listPullRequests(repo: Repo, head: String): F[List[PullRequestOut]] =
-    client.get(url.listPullRequests(repo, head), modify(repo))
+  override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
+    client.get(url.listPullRequests(repo, head, base), modify(repo))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -82,7 +82,7 @@ class NurtureAlg[F[_]](
       _ <- logger.info(s"Process update ${data.update.show}")
       head = github.headFor(github.getLogin(config, data.repo), data.update)
       repoConfig <- repoConfigAlg.getRepoConfig(data.repo)
-      pullRequests <- gitHubApiAlg.listPullRequests(data.repo, head)
+      pullRequests <- gitHubApiAlg.listPullRequests(data.repo, head, data.baseBranch)
       _ <- pullRequests.headOption match {
         case Some(pr) if pr.isClosed =>
           logger.info(s"PR ${pr.html_url} is closed")

--- a/modules/core/src/test/scala/org/scalasteward/core/github/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/UrlTest.scala
@@ -23,8 +23,8 @@ class UrlTest extends FunSuite with Matchers {
   }
 
   test("listPullRequests") {
-    listPullRequests(repo, "scala-steward:update/fs2-core-1.0.0").toString shouldBe
-      "https://api.github.com/repos/fthomas/refined/pulls?head=scala-steward%3Aupdate/fs2-core-1.0.0&state=all"
+    listPullRequests(repo, "scala-steward:update/fs2-core-1.0.0", Branch("series/0.6.x")).toString shouldBe
+      "https://api.github.com/repos/fthomas/refined/pulls?head=scala-steward%3Aupdate/fs2-core-1.0.0&base=series/0.6.x&state=all"
   }
 
   test("pulls") {


### PR DESCRIPTION
If a repository changes its default branch, scala-steward wouldn't
create PRs of current updates for which PRs already exist against the
old base branch. Including the current base in the search for existing
PRs changes this behaviour.

This is in response to https://github.com/tpolecat/doobie/pull/863 where
scala-steward created PRs against on old default branch, all created PRs
were closed, and the default branch was updated. With this change
scala-steward recreated some of the closed PRs against the new
default branch.