### PR TITLE
Extend ignore comments tests and fix a tiny bug

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
@@ -53,13 +53,17 @@ sealed trait Update extends Product with Serializable {
       splitArtifactId: Boolean
   ): Option[String] = {
     def replaceVersion(regex: Regex): Option[String] =
-      util.string.replaceSomeInOpt(regex, target, m => {
-        val group1 = m.group(1)
-        if (group1.toLowerCase.contains("previous") || group1.startsWith("//"))
-          None
-        else
-          Some(group1 + m.group(2) + nextVersion)
-      })
+      util.string.replaceSomeInOpt(
+        regex,
+        target,
+        m => {
+          val group1 = m.group(1)
+          if (group1.toLowerCase.contains("previous") || group1.trim.startsWith("//"))
+            None
+          else
+            Some(group1 + m.group(2) + nextVersion)
+        }
+      )
 
     val artifactIdParts =
       if (splitArtifactId) artifactId.split(Array('-', '_')).filter(_.length >= 3).toList else Nil

--- a/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
@@ -42,10 +42,18 @@ class UpdateTest extends FunSuite with Matchers {
     val original =
       """// val scalajsJqueryVersion = "0.9.3
         |val scalajsJqueryVersion = "0.9.3 //bla
+        | "be.doeraene" %% "scalajs-jquery"  % "0.9.3"
+        | // "be.doeraene" %% "scalajs-jquery"  % "0.9.3"
+        |   addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
+        |   //addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
         |"""".stripMargin.trim
     val expected =
       """// val scalajsJqueryVersion = "0.9.3
         |val scalajsJqueryVersion = "0.9.4 //bla
+        | "be.doeraene" %% "scalajs-jquery"  % "0.9.4"
+        | // "be.doeraene" %% "scalajs-jquery"  % "0.9.3"
+        |   addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.4")
+        |   //addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
         |"""".stripMargin.trim
     Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceAllIn(original) shouldBe Some(expected)


### PR DESCRIPTION
Hey there,

after adding some different test lines for ignore-comments test, i noticed i should have trimmed before checking if it starts with `//`. But nonetheless, here is the PR for it. Sorry for the inconvenience :sweat_smile: 

Cheers