### PR TITLE
Removes lagom-akka-discovery-service-locator

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -182,7 +182,6 @@
 - kwark/play-refined
 - kwark/slick-refined
 - lagom/lagom
-- lagom/lagom-akka-discovery-service-locator
 - lancewalton/treelog
 - larsrh/sbt-libisabelle
 - laserdisc-io/laserdisc


### PR DESCRIPTION
We will be archiving this repo soon. It can be removed from scala-steward already.