### PR TITLE
replaceAllInRelaxed: split camel case artifactIds

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
@@ -66,7 +66,13 @@ sealed trait Update extends Product with Serializable {
       )
 
     val artifactIdParts =
-      if (splitArtifactId) artifactId.split(Array('-', '_')).filter(_.length >= 3).toList else Nil
+      if (splitArtifactId) {
+        artifactId
+          .split(Array('-', '_'))
+          .toList
+          .flatMap(util.string.splitBetweenLowerAndUpperChars)
+          .filter(_.length >= 3)
+      } else Nil
     val quotedSearchTerms = searchTerms
       .concat(artifactIdParts)
       .map { term =>

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -70,4 +70,20 @@ object string {
     val line = "─" * 12
     s"$line $s $line"
   }
+
+  /**
+    * @example {{{
+    * scala> string.splitBetweenLowerAndUpperChars("javaLowerCase")
+    * res1: List[String] = List(java, Lower, Case)
+    *
+    * scala> string.splitBetweenLowerAndUpperChars("HikariCP")
+    * res2: List[String] = List(Hikari, CP)
+    * }}}
+    */
+  def splitBetweenLowerAndUpperChars(s: String): List[String] = {
+    val lowerAndThenUpper = "\\p{javaLowerCase}\\p{javaUpperCase}".r
+    val bounds = lowerAndThenUpper.findAllIn(s).matchData.map(_.start + 1).toList
+    val indices = (0 +: bounds :+ s.length).distinct
+    indices.sliding(2).collect { case i1 :: i2 :: Nil => s.substring(i1, i2) }.toList
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
@@ -204,6 +204,13 @@ class UpdateTest extends FunSuite with Matchers {
       .replaceAllInRelaxed(original) shouldBe Some(expected)
   }
 
+  test("replaceAllInRelaxed: camel case artifactId") {
+    val original = """val hikariVersion = "3.3.0" """
+    val expected = """val hikariVersion = "3.4.0" """
+    Single("com.zaxxer", "HikariCP", "3.3.0", Nel.of("3.4.0"))
+      .replaceAllInRelaxed(original) shouldBe Some(expected)
+  }
+
   test("Group.artifactId") {
     Group(
       "org.http4s",

--- a/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/stringTest.scala
@@ -1,0 +1,21 @@
+package org.scalasteward.core.util
+
+import org.scalacheck.Gen
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class stringTest extends FunSuite with Matchers with ScalaCheckPropertyChecks {
+  test("splitBetweenLowerAndUpperChars(s).mkString == s") {
+    forAll(Gen.asciiStr) { s: String =>
+      string.splitBetweenLowerAndUpperChars(s).mkString shouldBe s
+    }
+  }
+
+  test("splitBetweenLowerAndUpperChars: substrings end with lower case char or all are upper case") {
+    forAll(Gen.asciiStr) { s: String =>
+      string
+        .splitBetweenLowerAndUpperChars(s)
+        .forall(sub => sub.matches(".*\\p{javaLowerCase}") || sub.matches("\\p{javaUpperCase}*"))
+    }
+  }
+}


### PR DESCRIPTION
With this change `val hikariVersion = "3.3.0"` is found as version
definition for `"com.zaxxer" % "HikariCP"` because `HikariCP` is split
into `Hikari` and `CP` (which is discarded because it is shorter than
three characters).