### PR TITLE
Add Zalando to the list of companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following companies are using _scala-steward_ to manage their scala dependen
 * [Chartboost](https://www.chartboost.com/)
 * [HolidayCheck](https://github.com/holidaycheck)
 * [iAdvize](https://www.iadvize.com/en/)
+* [Zalando](https://en.zalando.de/)
 
 ## Participation
 


### PR DESCRIPTION
We have dozens of teams & hundreds of people using Scala in their daily work at Zalando, so it was inevitable to set up scala-steward for internal purposes.

As a side note, it was incredibly easy to configure it, so huge thanks!