### PR TITLE
remove scala-swing

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -301,7 +301,6 @@
 - scala/scala-parallel-collections
 - scala/scala-parser-combinators
 - scala/scala-seed.g8
-- scala/scala-swing
 - scala/scala-xml
 - scanamo/scanamo
 - schrepfler/artemis


### PR DESCRIPTION
- it is now community maintained with very low frequency commits
- it's better for us to simply check for updates whenever someone
  works on the code base