### PR TITLE
Add a semver "label" to PRs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val core = myCrossProject("core")
       Dependencies.log4catsSlf4j,
       Dependencies.monocleCore,
       Dependencies.refined,
+      Dependencies.refinedCats,
       Dependencies.logbackClassic % Runtime,
       Dependencies.circeLiteral % Test,
       Dependencies.http4sDsl % Test,

--- a/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
@@ -62,7 +62,7 @@ object NewPullRequestData {
         |```
         |</details>
         |
-        |${semVerLabel(update).getOrElse("")}
+        |${semVerLabel(update).fold("")("labels: " + _)}
         |""".stripMargin.trim
   }
 
@@ -71,7 +71,7 @@ object NewPullRequestData {
       curr <- SemVer.parse(update.currentVersion)
       next <- SemVer.parse(update.nextVersion)
       change <- SemVer.getChange(curr, next)
-    } yield s"semver: ${change.render}"
+    } yield s"semver-${change.render}"
 
   def from(data: UpdateData, headLogin: String, authorLogin: String): NewPullRequestData =
     NewPullRequestData(

--- a/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/data/NewPullRequestData.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import io.circe.Encoder
 import io.circe.generic.semiauto._
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{SemVer, Update}
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.{git, github}
@@ -61,8 +61,17 @@ object NewPullRequestData {
         |${RepoConfigAlg.configToIgnoreFurtherUpdates(update)}
         |```
         |</details>
+        |
+        |${semVerLabel(update).getOrElse("")}
         |""".stripMargin.trim
   }
+
+  def semVerLabel(update: Update): Option[String] =
+    for {
+      curr <- SemVer.parse(update.currentVersion)
+      next <- SemVer.parse(update.nextVersion)
+      change <- SemVer.getChange(curr, next)
+    } yield s"semver: ${change.render}"
 
   def from(data: UpdateData, headLogin: String, authorLogin: String): NewPullRequestData =
     NewPullRequestData(

--- a/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018-2019 scala-steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.model
+
+import cats.implicits._
+import eu.timepit.refined.cats.refTypeEq
+import eu.timepit.refined.types.numeric.NonNegInt
+import org.scalasteward.core.model.SemVer.Change._
+import scala.util.Try
+
+final case class SemVer(
+    major: NonNegInt,
+    minor: NonNegInt,
+    patch: NonNegInt,
+    preRelease: Option[String],
+    buildMetadata: Option[String]
+) {
+  def render: String =
+    s"${major.value}.${minor.value}.${patch.value}" +
+      preRelease.fold("")("-" + _) + buildMetadata.fold("")("+" + _)
+}
+
+object SemVer {
+  def parse(s: String): Option[SemVer] = {
+    val pattern = raw"""(\d+)\.(\d+)\.(\d+)(\-[^\+]+)?(\+.+)?""".r
+    val maybeSemVer = s match {
+      case pattern(majorStr, minorStr, patchStr, preReleaseStr, buildMetadataStr) =>
+        for {
+          major <- parseNonNegInt(majorStr)
+          minor <- parseNonNegInt(minorStr)
+          patch <- parseNonNegInt(patchStr)
+          preRelease = Option(preReleaseStr).map(_.drop(1))
+          buildMetadata = Option(buildMetadataStr).map(_.drop(1))
+        } yield SemVer(major, minor, patch, preRelease, buildMetadata)
+      case _ => None
+    }
+    maybeSemVer.filter(_.render === s)
+  }
+
+  def parseNonNegInt(s: String): Option[NonNegInt] =
+    Try(s.toInt).toOption.flatMap(NonNegInt.unapply)
+
+  sealed abstract class Change(val render: String)
+  object Change {
+    case object Major extends Change("major-bump")
+    case object Minor extends Change("minor-bump")
+    case object Patch extends Change("patch-bump")
+    case object PreRelease extends Change("pre-release-change")
+    case object BuildMetadata extends Change("build-metadata-change")
+  }
+
+  def getChange(from: SemVer, to: SemVer): Option[Change] =
+    if (from.major =!= to.major) Some(Major)
+    else if (from.minor =!= to.minor) Some(Minor)
+    else if (from.patch =!= to.patch) Some(Patch)
+    else if (from.preRelease =!= to.preRelease) Some(PreRelease)
+    else if (from.buildMetadata =!= to.buildMetadata) Some(BuildMetadata)
+    else None
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
@@ -56,11 +56,11 @@ object SemVer {
 
   sealed abstract class Change(val render: String)
   object Change {
-    case object Major extends Change("major-bump")
-    case object Minor extends Change("minor-bump")
-    case object Patch extends Change("patch-bump")
-    case object PreRelease extends Change("pre-release-change")
-    case object BuildMetadata extends Change("build-metadata-change")
+    case object Major extends Change("major")
+    case object Minor extends Change("minor")
+    case object Patch extends Change("patch")
+    case object PreRelease extends Change("pre-release")
+    case object BuildMetadata extends Change("build-metadata")
   }
 
   def getChange(from: SemVer, to: SemVer): Option[Change] =

--- a/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
@@ -18,14 +18,14 @@ package org.scalasteward.core.model
 
 import cats.implicits._
 import eu.timepit.refined.cats.refTypeEq
-import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.NonNegBigInt
 import org.scalasteward.core.model.SemVer.Change._
 import scala.util.Try
 
 final case class SemVer(
-    major: NonNegInt,
-    minor: NonNegInt,
-    patch: NonNegInt,
+    major: NonNegBigInt,
+    minor: NonNegBigInt,
+    patch: NonNegBigInt,
     preRelease: Option[String],
     buildMetadata: Option[String]
 ) {
@@ -40,9 +40,9 @@ object SemVer {
     val maybeSemVer = s match {
       case pattern(majorStr, minorStr, patchStr, preReleaseStr, buildMetadataStr) =>
         for {
-          major <- parseNonNegInt(majorStr)
-          minor <- parseNonNegInt(minorStr)
-          patch <- parseNonNegInt(patchStr)
+          major <- parseNonNegBigInt(majorStr)
+          minor <- parseNonNegBigInt(minorStr)
+          patch <- parseNonNegBigInt(patchStr)
           preRelease = Option(preReleaseStr).map(_.drop(1))
           buildMetadata = Option(buildMetadataStr).map(_.drop(1))
         } yield SemVer(major, minor, patch, preRelease, buildMetadata)
@@ -51,8 +51,8 @@ object SemVer {
     maybeSemVer.filter(_.render === s)
   }
 
-  def parseNonNegInt(s: String): Option[NonNegInt] =
-    Try(s.toInt).toOption.flatMap(NonNegInt.unapply)
+  def parseNonNegBigInt(s: String): Option[NonNegBigInt] =
+    Try(BigInt(s)).toOption.flatMap(NonNegBigInt.unapply)
 
   sealed abstract class Change(val render: String)
   object Change {

--- a/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
@@ -19,7 +19,7 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
     NewPullRequestData.from(data, "foo", "scala-steward").asJson.spaces2 shouldBe
       """|{
          |  "title" : "Update logback-classic to 1.2.3",
-         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>",
+         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>\n\nsemver: patch-bump",
          |  "head" : "foo:update/logback-classic-1.2.3",
          |  "base" : "master"
          |}

--- a/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/data/NewPullRequestDataTest.scala
@@ -19,7 +19,7 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
     NewPullRequestData.from(data, "foo", "scala-steward").asJson.spaces2 shouldBe
       """|{
          |  "title" : "Update logback-classic to 1.2.3",
-         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>\n\nsemver: patch-bump",
+         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention @scala-steward in the comments below.\n\nHave a nice day!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [{ groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" }]\n```\n</details>\n\nlabels: semver-patch",
          |  "head" : "foo:update/logback-classic-1.2.3",
          |  "base" : "master"
          |}

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -1,11 +1,12 @@
 package org.scalasteward.core.model
 
-import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.NonNegBigInt
 import org.scalasteward.core.model.SemVer.Change
 import org.scalatest.{FunSuite, Matchers}
 
 class SemVerTest extends FunSuite with Matchers {
-  implicit val toNonNegInt: Int => NonNegInt = NonNegInt.unsafeFrom
+  implicit val toNonNegBigInt: Int => NonNegBigInt =
+    i => NonNegBigInt.unsafeFrom(BigInt(i))
 
   test("parse: simple examples") {
     SemVer.parse("1.2.3") shouldBe Some(SemVer(1, 2, 3, None, None))

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.model
 
 import eu.timepit.refined.types.numeric.NonNegInt
+import org.scalasteward.core.model.SemVer.Change
 import org.scalatest.{FunSuite, Matchers}
 
 class SemVerTest extends FunSuite with Matchers {
@@ -43,5 +44,17 @@ class SemVerTest extends FunSuite with Matchers {
     SemVer.parse("01.0.0") shouldBe None
     SemVer.parse("0.01.0") shouldBe None
     SemVer.parse("0.0.01") shouldBe None
+  }
+
+  test("getChange") {
+    SemVer.getChange(SemVer(1, 3, 4, None, None), SemVer(2, 1, 2, None, None)) shouldBe
+      Some(Change.Major)
+    SemVer.getChange(SemVer(2, 3, 4, None, None), SemVer(2, 5, 2, None, None)) shouldBe
+      Some(Change.Minor)
+    SemVer.getChange(SemVer(2, 3, 4, Some("SNAP1"), None), SemVer(2, 3, 4, Some("SNAP2"), None)) shouldBe
+      Some(Change.PreRelease)
+    SemVer.getChange(SemVer(2, 3, 4, Some("M1"), Some("1")), SemVer(2, 3, 4, Some("M1"), Some("2"))) shouldBe
+      Some(Change.BuildMetadata)
+    SemVer.getChange(SemVer(2, 3, 4, Some("M1"), None), SemVer(2, 3, 4, Some("M1"), None)) shouldBe None
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -1,12 +1,16 @@
 package org.scalasteward.core.model
 
 import eu.timepit.refined.types.numeric.NonNegBigInt
+import eu.timepit.refined.types.string.NonEmptyString
 import org.scalasteward.core.model.SemVer.Change
 import org.scalatest.{FunSuite, Matchers}
 
 class SemVerTest extends FunSuite with Matchers {
   implicit val toNonNegBigInt: Int => NonNegBigInt =
     i => NonNegBigInt.unsafeFrom(BigInt(i))
+
+  implicit val toNonEmptyString: String => NonEmptyString =
+    NonEmptyString.unsafeFrom
 
   test("parse: simple examples") {
     SemVer.parse("1.2.3") shouldBe Some(SemVer(1, 2, 3, None, None))

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -1,0 +1,47 @@
+package org.scalasteward.core.model
+
+import eu.timepit.refined.types.numeric.NonNegInt
+import org.scalatest.{FunSuite, Matchers}
+
+class SemVerTest extends FunSuite with Matchers {
+  implicit val toNonNegInt: Int => NonNegInt = NonNegInt.unsafeFrom
+
+  test("parse: simple examples") {
+    SemVer.parse("1.2.3") shouldBe Some(SemVer(1, 2, 3, None, None))
+    SemVer.parse("0.0.0") shouldBe Some(SemVer(0, 0, 0, None, None))
+    SemVer.parse("123.456.789") shouldBe Some(SemVer(123, 456, 789, None, None))
+  }
+
+  test("parse: with pre-release identifier") {
+    SemVer.parse("1.0.0-SNAP5") shouldBe Some(SemVer(1, 0, 0, Some("SNAP5"), None))
+    SemVer.parse("9.10.100-0.3.7") shouldBe Some(SemVer(9, 10, 100, Some("0.3.7"), None))
+  }
+
+  test("parse: empty pre-release identifier") {
+    SemVer.parse("5.6.7-") shouldBe None
+  }
+
+  test("parse: with build metadata") {
+    SemVer.parse("1.0.0+20130313144700") shouldBe
+      Some(SemVer(1, 0, 0, None, Some("20130313144700")))
+    SemVer.parse("1.0.0-beta+exp.sha.5114f85") shouldBe
+      Some(SemVer(1, 0, 0, Some("beta"), Some("exp.sha.5114f85")))
+  }
+
+  test("parse: empty build metadata") {
+    SemVer.parse("6.7.8+") shouldBe None
+    SemVer.parse("9.10.11-M1+") shouldBe None
+  }
+
+  test("parse: negative numbers") {
+    SemVer.parse("-1.0.0") shouldBe None
+    SemVer.parse("0.-1.0") shouldBe None
+    SemVer.parse("0.0.-1") shouldBe None
+  }
+
+  test("parse: leading zeros") {
+    SemVer.parse("01.0.0") shouldBe None
+    SemVer.parse("0.01.0") shouldBe None
+    SemVer.parse("0.0.01") shouldBe None
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.2.3"
   val monocleCore = "com.github.julien-truffaut" %% "monocle-core" % "1.5.1-cats"
   val refined = "eu.timepit" %% "refined" % Versions.refined
+  val refinedCats = "eu.timepit" %% "refined-cats" % Versions.refined
   val refinedScalacheck = "eu.timepit" %% "refined-scalacheck" % Versions.refined
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.7"


### PR DESCRIPTION
This adds a simple `semver` label to PR bodies indicating the type of version bump according to [semantic versioning](https://semver.org/) if the current and next version adhere to the semver format.

For example if an update goes from 1.a.b to 2.x.y, scala-steward will add `labels: semver-major` to the PR body. It will add `labels: semver-minor` for bumps of the minor version and `labels: semver-patch` for bumps of the patch version.

This is the first step of a larger feature request @djspiewak mentioned on Gitter.