### PR TITLE
Remove cross-version suffix from artifactIds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ addCommandsAlias(
 addCommandAlias(
   "runSteward", {
     val home = System.getenv("HOME")
-    val projectDir = s"$home/code/sso/batch"
+    val projectDir = s"$home/code/scala-steward/core"
     Seq(
       Seq("core/run"),
       Seq("--workspace", s"$projectDir/workspace"),
@@ -207,8 +207,7 @@ addCommandAlias(
       Seq("--whitelist", s"$home/.cache/coursier"),
       Seq("--whitelist", s"$home/.coursier"),
       Seq("--whitelist", s"$home/.ivy2"),
-      Seq("--whitelist", s"$home/.sbt"),
-      Seq("--whitelist", s"$home/.scio-ideaPluginIC")
+      Seq("--whitelist", s"$home/.sbt")
     ).flatten.mkString(" ")
   }
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
@@ -113,7 +113,7 @@ object Update {
   }
 
   object Single {
-    val artifactId: Lens[Update.Single, String] =
+    val artifactIdLens: Lens[Update.Single, String] =
       Lens[Update.Single, String](_.artifactId)(artifactId => _.copy(artifactId = artifactId))
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Update.scala
@@ -19,6 +19,7 @@ package org.scalasteward.core.model
 import cats.implicits._
 import eu.timepit.refined.W
 import io.circe.{Decoder, Encoder}
+import monocle.Lens
 import org.scalasteward.core.model.Update.{Group, Single}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
@@ -109,6 +110,11 @@ object Update {
   ) extends Update {
     override def artifactIds: Nel[String] =
       Nel.one(artifactId)
+  }
+
+  object Single {
+    val artifactId: Lens[Update.Single, String] =
+      Lens[Update.Single, String](_.artifactId)(artifactId => _.copy(artifactId = artifactId))
   }
 
   final case class Group(

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -20,7 +20,6 @@ import better.files.File
 import cats.Monad
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import monocle.Lens
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.dependency.parser.parseDependencies

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -20,6 +20,7 @@ import better.files.File
 import cats.Monad
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
+import monocle.Lens
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.dependency.parser.parseDependencies
@@ -86,7 +87,7 @@ object SbtAlg {
           allDeps = project.libraries ++ project.plugins
           uncross = allDeps.map(dep => dep.artifactIdCross -> dep.artifactId).toMap
           updates = updatesWithCrossSuffix.flatMap { update =>
-            uncross.get(update.artifactId).map(id => update.copy(artifactId = id)).toList
+            Update.Single.artifactId.modifyF(uncross.get)(update).toList
           }
         } yield updates
 

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -86,7 +86,7 @@ object SbtAlg {
           allDeps = project.libraries ++ project.plugins
           uncross = allDeps.map(dep => dep.artifactIdCross -> dep.artifactId).toMap
           updates = updatesWithCrossSuffix.flatMap { update =>
-            Update.Single.artifactId.modifyF(uncross.get)(update).toList
+            Update.Single.artifactIdLens.modifyF(uncross.get)(update).toList
           }
         } yield updates
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -111,7 +111,7 @@ class UpdateService[F[_]](
             ignorableUpdates.exists(
               ignUpdate =>
                 update.groupId == ignUpdate.groupId && update.nextVersion == ignUpdate.nextVersion &&
-                  ignUpdate.artifactIds.exists(id => update.artifactId.startsWith(id))
+                  ignUpdate.artifactIds.exists(_ === update.artifactId)
             )
         )
         _ <- F.pure(println(repo + " " + updates1))
@@ -122,7 +122,7 @@ class UpdateService[F[_]](
 object UpdateService {
   def isUpdateFor(update: Update.Single, dependency: Dependency): Boolean =
     update.groupId === dependency.groupId &&
-      update.artifactId === dependency.artifactIdCross &&
+      update.artifactId === dependency.artifactId &&
       update.currentVersion === dependency.version
 
   def includeInUpdateCheck(dependency: Dependency): Boolean =


### PR DESCRIPTION
This makes it easier to compare them with updates of created
PRs which are already persisted without cross-version suffix.