### PR TITLE
Refactor to move github/data to vcs/data

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -21,7 +21,7 @@ import cats.effect.Sync
 import org.http4s.Uri
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
-import org.scalasteward.core.github.data.AuthenticatedUser
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.util
 import scala.sys.process.Process
 

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -25,7 +25,7 @@ import org.scalasteward.core.dependency.json.JsonDependencyRepository
 import org.scalasteward.core.dependency.{DependencyRepository, DependencyService}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
-import org.scalasteward.core.github.data.AuthenticatedUser
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.github.http4s.Http4sGitHubApiAlg
 import org.scalasteward.core.github.http4s.authentication.addCredentials
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -24,7 +24,7 @@ import org.http4s.client.blaze.BlazeClientBuilder
 import org.scalasteward.core.dependency.json.JsonDependencyRepository
 import org.scalasteward.core.dependency.{DependencyRepository, DependencyService}
 import org.scalasteward.core.git.GitAlg
-import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
+import org.scalasteward.core.github.GitHubApiAlg
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.github.http4s.Http4sGitHubApiAlg
 import org.scalasteward.core.github.http4s.authentication.addCredentials
@@ -36,6 +36,8 @@ import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.json.JsonUpdateRepository
 import org.scalasteward.core.update.{FilterAlg, UpdateRepository, UpdateService}
 import org.scalasteward.core.util.{DateTimeAlg, HttpJsonClient, LogAlg}
+import org.scalasteward.core.vcs.VCSRepoAlg
+
 import scala.concurrent.ExecutionContext
 
 final case class Context[F[_]](
@@ -74,7 +76,7 @@ object Context {
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val gitHubApiAlg: GitHubApiAlg[F] =
         new Http4sGitHubApiAlg[F](config.gitHubApiHost, _ => addCredentials(user))
-      implicit val gitHubRepoAlg: GitHubRepoAlg[F] = GitHubRepoAlg.create[F](config, gitAlg)
+      implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
       implicit val pullRequestRepo: PullRequestRepository[F] = new JsonPullRequestRepo[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
       implicit val updateRepository: UpdateRepository[F] = new JsonUpdateRepository[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyRepository.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.dependency
 
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 trait DependencyRepository[F[_]] {
   def findSha1(repo: Repo): F[Option[Sha1]]

--- a/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyService.scala
@@ -21,9 +21,10 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{GitAlg, Sha1}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
-import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
+import org.scalasteward.core.github.GitHubApiAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.util.{LogAlg, MonadThrowable}
+import org.scalasteward.core.vcs.VCSRepoAlg
 
 class DependencyService[F[_]](
     implicit
@@ -31,7 +32,7 @@ class DependencyService[F[_]](
     dependencyRepository: DependencyRepository[F],
     gitAlg: GitAlg[F],
     gitHubApiAlg: GitHubApiAlg[F],
-    gitHubRepoAlg: GitHubRepoAlg[F],
+    vcsRepoAlg: VCSRepoAlg[F],
     logAlg: LogAlg[F],
     logger: Logger[F],
     sbtAlg: SbtAlg[F],
@@ -56,8 +57,8 @@ class DependencyService[F[_]](
   def refreshDependencies(repo: Repo, repoOut: RepoOut, latestSha1: Sha1): F[Unit] =
     for {
       _ <- logger.info(s"Refresh dependencies of ${repo.show}")
-      _ <- gitHubRepoAlg.clone(repo, repoOut)
-      _ <- gitHubRepoAlg.syncFork(repo, repoOut)
+      _ <- vcsRepoAlg.clone(repo, repoOut)
+      _ <- vcsRepoAlg.syncFork(repo, repoOut)
       dependencies <- sbtAlg.getDependencies(repo)
       _ <- dependencyRepository.setDependencies(repo, latestSha1, dependencies)
       _ <- gitAlg.removeClone(repo)

--- a/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/dependency/DependencyService.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{GitAlg, Sha1}
-import org.scalasteward.core.github.data.{Repo, RepoOut}
+import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.util.{LogAlg, MonadThrowable}

--- a/modules/core/src/main/scala/org/scalasteward/core/dependency/json/JsonDependencyRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/dependency/json/JsonDependencyRepository.scala
@@ -22,7 +22,7 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import org.scalasteward.core.dependency.{Dependency, DependencyRepository}
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.util.MonadThrowable
 

--- a/modules/core/src/main/scala/org/scalasteward/core/dependency/json/RepoStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/dependency/json/RepoStore.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.dependency.json
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 final case class RepoStore(store: Map[Repo, RepoData])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -21,7 +21,7 @@ import cats.effect.Bracket
 import cats.implicits._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.{MonadThrowable, Nel}
 

--- a/modules/core/src/main/scala/org/scalasteward/core/github/GitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/GitHubApiAlg.scala
@@ -20,7 +20,7 @@ import cats.Monad
 import cats.implicits._
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.github.data._
+import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.util.MonadThrowable
 
 trait GitHubApiAlg[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/github/GitHubRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/GitHubRepoAlg.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.GitAlg
-import org.scalasteward.core.github.data.{Repo, RepoOut}
+import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.MonadThrowable
 

--- a/modules/core/src/main/scala/org/scalasteward/core/github/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/Url.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.github
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 class Url(apiHost: Uri) {
   def branches(repo: Repo, branch: Branch): Uri =

--- a/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
@@ -20,7 +20,7 @@ import cats.effect.Sync
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.github._
-import org.scalasteward.core.github.data._
+import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.util.HttpJsonClient
 
 final class Http4sGitHubApiAlg[F[_]: Sync](

--- a/modules/core/src/main/scala/org/scalasteward/core/github/http4s/authentication.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/http4s/authentication.scala
@@ -20,7 +20,7 @@ import cats.Applicative
 import cats.implicits._
 import org.http4s.headers.Authorization
 import org.http4s.{BasicCredentials, Request}
-import org.scalasteward.core.github.data.AuthenticatedUser
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 
 object authentication {
   def addCredentials[F[_]: Applicative](user: AuthenticatedUser): Request[F] => F[Request[F]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/github/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/package.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core
 
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
 
 package object github {

--- a/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/WorkspaceAlg.scala
@@ -21,7 +21,7 @@ import cats.FlatMap
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 trait WorkspaceAlg[F[_]] {
   def cleanWorkspace: F[Unit]

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.nurture
 import cats.effect.Sync
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.util._

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -21,12 +21,13 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{Branch, GitAlg}
 import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
-import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
+import org.scalasteward.core.github.GitHubApiAlg
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.FilterAlg
 import org.scalasteward.core.util.{BracketThrowable, LogAlg}
+import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalasteward.core.{git, github, util}
 
 class NurtureAlg[F[_]](
@@ -37,7 +38,7 @@ class NurtureAlg[F[_]](
     filterAlg: FilterAlg[F],
     gitAlg: GitAlg[F],
     gitHubApiAlg: GitHubApiAlg[F],
-    gitHubRepoAlg: GitHubRepoAlg[F],
+    vcsRepoAlg: VCSRepoAlg[F],
     logAlg: LogAlg[F],
     logger: Logger[F],
     pullRequestRepo: PullRequestRepository[F],
@@ -59,8 +60,8 @@ class NurtureAlg[F[_]](
     for {
       _ <- logger.info(s"Clone and synchronize ${repo.show}")
       repoOut <- gitHubApiAlg.createForkOrGetRepo(config, repo)
-      _ <- gitHubRepoAlg.clone(repo, repoOut)
-      parent <- gitHubRepoAlg.syncFork(repo, repoOut)
+      _ <- vcsRepoAlg.clone(repo, repoOut)
+      parent <- vcsRepoAlg.syncFork(repo, repoOut)
     } yield parent.default_branch
 
   def updateDependencies(repo: Repo, baseBranch: Branch): F[Unit] =

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{Branch, GitAlg}
-import org.scalasteward.core.github.data.{NewPullRequestData, Repo}
+import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
 import org.scalasteward.core.github.{GitHubApiAlg, GitHubRepoAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -28,7 +28,7 @@ import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.FilterAlg
 import org.scalasteward.core.util.{BracketThrowable, LogAlg}
 import org.scalasteward.core.vcs.VCSRepoAlg
-import org.scalasteward.core.{git, github, util}
+import org.scalasteward.core.{git, util, vcs}
 
 class NurtureAlg[F[_]](
     implicit
@@ -81,7 +81,7 @@ class NurtureAlg[F[_]](
   def processUpdate(data: UpdateData): F[Unit] =
     for {
       _ <- logger.info(s"Process update ${data.update.show}")
-      head = github.headFor(github.getLogin(config, data.repo), data.update)
+      head = vcs.headFor(vcs.getLogin(config, data.repo), data.update)
       repoConfig <- repoConfigAlg.getRepoConfig(data.repo)
       pullRequests <- gitHubApiAlg.listPullRequests(data.repo, head, data.baseBranch)
       _ <- pullRequests.headOption match {
@@ -121,7 +121,7 @@ class NurtureAlg[F[_]](
   def createPullRequest(data: UpdateData): F[Unit] =
     for {
       _ <- logger.info(s"Create PR ${data.updateBranch.name}")
-      headLogin = github.getLogin(config, data.repo)
+      headLogin = vcs.getLogin(config, data.repo)
       requestData = NewPullRequestData.from(data, headLogin, config.gitHubLogin)
       pr <- gitHubApiAlg.createPullRequest(data.repo, requestData)
       _ <- pullRequestRepo.createOrUpdate(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.nurture
 import org.http4s.Uri
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.{PullRequestState, Repo}
+import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 import org.scalasteward.core.model.Update
 
 trait PullRequestRepository[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.nurture
 
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
 
 final case class UpdateData(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
@@ -23,7 +23,7 @@ import io.circe.syntax._
 import org.http4s.Uri
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.{PullRequestState, Repo}
+import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.nurture.PullRequestRepository

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestData.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.nurture.json
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.PullRequestState
+import org.scalasteward.core.vcs.data.PullRequestState
 import org.scalasteward.core.model.Update
 
 final case class PullRequestData(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestStore.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.nurture.json
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 final case class PullRequestStore(store: Map[Repo, Map[String, PullRequestData]])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -20,7 +20,7 @@ import cats.data.OptionT
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import io.circe.config.parser
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg._

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -23,7 +23,7 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.dependency.parser.parseDependencies
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.sbt.command._

--- a/modules/core/src/main/scala/org/scalasteward/core/steward.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/steward.scala
@@ -21,7 +21,7 @@ import cats.FlatMap
 import cats.effect.{ExitCode, IO, IOApp, Sync}
 import cats.implicits._
 import org.scalasteward.core.application.Context
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 
 object steward extends IOApp {
   override def run(args: List[String]): IO[ExitCode] =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.update
 import cats.implicits._
 import cats.{Monad, TraverseFilter}
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.{RepoConfig, RepoConfigAlg}
 import org.scalasteward.core.update.FilterAlg._

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -20,8 +20,8 @@ import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.dependency.{Dependency, DependencyRepository}
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.PullRequestState.Closed
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.PullRequestState.Closed
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.sbt._

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSRepoAlg.scala
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github
+package org.scalasteward.core.vcs
 
 import cats.implicits._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.GitAlg
-import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 
-trait GitHubRepoAlg[F[_]] {
+trait VCSRepoAlg[F[_]] {
   def clone(repo: Repo, repoOut: RepoOut): F[Unit]
 
   def syncFork(repo: Repo, repoOut: RepoOut): F[RepoOut]
 }
 
-object GitHubRepoAlg {
-  def create[F[_]: MonadThrowable](config: Config, gitAlg: GitAlg[F]): GitHubRepoAlg[F] =
-    new GitHubRepoAlg[F] {
+object VCSRepoAlg {
+  def create[F[_]: MonadThrowable](config: Config, gitAlg: GitAlg[F]): VCSRepoAlg[F] =
+    new VCSRepoAlg[F] {
       override def clone(repo: Repo, repoOut: RepoOut): F[Unit] =
         for {
           _ <- gitAlg.clone(repo, withLogin(repoOut.clone_url))

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/AuthenticatedUser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/AuthenticatedUser.scala
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
-import io.circe.Decoder
-import io.circe.generic.semiauto._
-import org.scalasteward.core.git.Branch
-
-final case class BranchOut(
-    name: Branch,
-    commit: CommitOut
+final case class AuthenticatedUser(
+    login: String,
+    accessToken: String
 )
-
-object BranchOut {
-  implicit val branchOutDecoder: Decoder[BranchOut] =
-    deriveDecoder
-}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/BranchOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/BranchOut.scala
@@ -14,28 +14,18 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
-import cats.implicits._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
-import org.http4s.Uri
-import org.scalasteward.core.github.data.PullRequestState.Closed
-import org.scalasteward.core.util.uri.uriDecoder
+import org.scalasteward.core.git.Branch
 
-final case class PullRequestOut(
-    html_url: Uri,
-    state: PullRequestState,
-    title: String
-) {
-  def isClosed: Boolean =
-    state === Closed
-}
+final case class BranchOut(
+    name: Branch,
+    commit: CommitOut
+)
 
-object PullRequestOut {
-  implicit val pullRequestOutDecoder: Decoder[PullRequestOut] =
+object BranchOut {
+  implicit val branchOutDecoder: Decoder[BranchOut] =
     deriveDecoder
-
-  // prevent IntelliJ from removing the import of uriDecoder
-  locally(uriDecoder)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/CommitOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/CommitOut.scala
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.Decoder
 import io.circe.generic.semiauto._
+import org.scalasteward.core.git.Sha1
 
-final case class UserOut(
-    login: String
+final case class CommitOut(
+    sha: Sha1
 )
 
-object UserOut {
-  implicit val userOutDecoder: Decoder[UserOut] =
+object CommitOut {
+  implicit val commitOutDecoder: Decoder[CommitOut] =
     deriveDecoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.git.Branch
 import org.scalasteward.core.model.{SemVer, Update}
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfigAlg
-import org.scalasteward.core.{git, github}
+import org.scalasteward.core.{git, vcs}
 
 final case class NewPullRequestData(
     title: String,
@@ -77,7 +77,7 @@ object NewPullRequestData {
     NewPullRequestData(
       title = git.commitMsgFor(data.update),
       body = bodyFor(data.update, authorLogin),
-      head = github.headFor(headLogin, data.update),
+      head = vcs.headFor(headLogin, data.update),
       base = data.baseBranch
     )
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import cats.implicits._
 import io.circe.Encoder

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
+import cats.implicits._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
-import org.scalasteward.core.git.Sha1
+import org.http4s.Uri
+import org.scalasteward.core.vcs.data.PullRequestState.Closed
+import org.scalasteward.core.util.uri.uriDecoder
 
-final case class CommitOut(
-    sha: Sha1
-)
+final case class PullRequestOut(
+    html_url: Uri,
+    state: PullRequestState,
+    title: String
+) {
+  def isClosed: Boolean =
+    state === Closed
+}
 
-object CommitOut {
-  implicit val commitOutDecoder: Decoder[CommitOut] =
+object PullRequestOut {
+  implicit val pullRequestOutDecoder: Decoder[PullRequestOut] =
     deriveDecoder
+
+  // prevent IntelliJ from removing the import of uriDecoder
+  locally(uriDecoder)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import cats.Eq
 import io.circe.{Decoder, Encoder}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -14,9 +14,27 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
-final case class AuthenticatedUser(
-    login: String,
-    accessToken: String
-)
+import io.circe.{KeyDecoder, KeyEncoder}
+
+final case class Repo(
+    owner: String,
+    repo: String
+) {
+  def show: String = s"$owner/$repo"
+}
+
+object Repo {
+  implicit val repoKeyDecoder: KeyDecoder[Repo] = {
+    val string = "([^/]+)"
+    val / = s"$string/$string".r
+    KeyDecoder.instance {
+      case owner / repo => Some(Repo(owner, repo))
+      case _            => None
+    }
+  }
+
+  implicit val repoKeyEncoder: KeyEncoder[Repo] =
+    KeyEncoder.instance(repo => repo.owner + "/" + repo.repo)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/RepoOut.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.Decoder
 import io.circe.generic.semiauto._

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/UserOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/UserOut.scala
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
-import io.circe.{KeyDecoder, KeyEncoder}
+import io.circe.Decoder
+import io.circe.generic.semiauto._
 
-final case class Repo(
-    owner: String,
-    repo: String
-) {
-  def show: String = s"$owner/$repo"
-}
+final case class UserOut(
+    login: String
+)
 
-object Repo {
-  implicit val repoKeyDecoder: KeyDecoder[Repo] = {
-    val string = "([^/]+)"
-    val / = s"$string/$string".r
-    KeyDecoder.instance {
-      case owner / repo => Some(Repo(owner, repo))
-      case _            => None
-    }
-  }
-
-  implicit val repoKeyEncoder: KeyEncoder[Repo] =
-    KeyEncoder.instance(repo => repo.owner + "/" + repo.repo)
+object UserOut {
+  implicit val userOutDecoder: Decoder[UserOut] =
+    deriveDecoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -17,10 +17,10 @@
 package org.scalasteward.core
 
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
+import org.scalasteward.core.vcs.data.Repo
 
-package object github {
+package object vcs {
 
   def getLogin(config: Config, repo: Repo): String =
     if (config.doNotFork) repo.owner else config.gitHubLogin

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.git
 
 import org.http4s.Uri
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalatest.{FunSuite, Matchers}

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.github
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.github.data.{Repo, RepoOut, UserOut}
+import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 import org.scalasteward.core.mock.MockContext.{config, gitAlg, gitHubRepoAlg}
 import org.scalasteward.core.mock.{MockContext, MockState}
 import org.scalatest.{FunSuite, Matchers}

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
@@ -5,6 +5,7 @@ import org.scalasteward.core.git.Branch
 import org.scalasteward.core.vcs.data.{Repo, RepoOut, UserOut}
 import org.scalasteward.core.mock.MockContext.{config, gitAlg, gitHubRepoAlg}
 import org.scalasteward.core.mock.{MockContext, MockState}
+import org.scalasteward.core.vcs.VCSRepoAlg
 import org.scalatest.{FunSuite, Matchers}
 
 class GitHubRepoAlgTest extends FunSuite with Matchers {
@@ -92,7 +93,7 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
 
   test("syncFork should do nothing when doNotFork = true") {
     val (state, repoOut) =
-      GitHubRepoAlg
+      VCSRepoAlg
         .create(MockContext.config.copy(doNotFork = true), gitAlg)
         .syncFork(repo, parentRepoOut)
         .run(MockState.empty)

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GithubPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GithubPackageTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.github
 
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.config
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/github/UrlTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/UrlTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.github
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.{FunSuite, Matchers}
 
 class UrlTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlgTest.scala
@@ -9,7 +9,7 @@ import org.http4s.implicits._
 import org.http4s.{HttpRoutes, Uri}
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.github.data._
+import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.mock.MockContext.config
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalatest.{FunSuite, Matchers}

--- a/modules/core/src/test/scala/org/scalasteward/core/github/http4s/authenticationTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/http4s/authenticationTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.github.http4s
 import cats.Id
 import org.http4s.headers.{Accept, Authorization}
 import org.http4s.{BasicCredentials, Headers, MediaType, Request}
-import org.scalasteward.core.github.data.AuthenticatedUser
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalatest.{FunSuite, Matchers}
 
 class authenticationTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/MockWorkspaceAlg.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.io
 
 import better.files.File
 import cats.data.StateT
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.{MockContext, MockEff}
 
 class MockWorkspaceAlg extends WorkspaceAlg[MockEff] {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -5,13 +5,13 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.{Author, GitAlg}
-import org.scalasteward.core.github.GitHubRepoAlg
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.scalasteward.core.nurture.EditAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.FilterAlg
 import org.scalasteward.core.util.{DateTimeAlg, LogAlg}
+import org.scalasteward.core.vcs.VCSRepoAlg
 
 object MockContext {
   implicit val config: Config = Config(
@@ -42,7 +42,7 @@ object MockContext {
   implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
   implicit val editAlg: EditAlg[MockEff] = EditAlg.create
   implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
-  implicit val gitHubRepoAlg: GitHubRepoAlg[MockEff] = GitHubRepoAlg.create(config, gitAlg)
+  implicit val gitHubRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config, gitAlg)
   implicit val logAlg: LogAlg[MockEff] = new LogAlg[MockEff]
   implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
   implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/EditAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.nurture
 
 import better.files.File
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.editAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.repoConfigAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.sbt
 
 import better.files.File
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.{MockContext, MockState}
 import org.scalatest.{FunSuite, Matchers}

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.update
 
 import better.files.File
 import cats.implicits._
-import org.scalasteward.core.github.data.Repo
+import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.model.Update

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -1,10 +1,10 @@
-package org.scalasteward.core.github
+package org.scalasteward.core.vcs
 
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.config
+import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.{FunSuite, Matchers}
 
-class GithubPackageTest extends FunSuite with Matchers {
+class VCSPackageTest extends FunSuite with Matchers {
   val repo = Repo("fthomas", "datapackage")
 
   test("github login for fork enabled configuration") {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/BranchOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/BranchOutTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.parser
 import org.scalasteward.core.git.Sha1.HexString

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
 import org.scalasteward.core.git.{Branch, Sha1}

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestOutTest.scala
@@ -1,8 +1,8 @@
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.parser
 import org.http4s.Uri
-import org.scalasteward.core.github.data.PullRequestState.Open
+import org.scalasteward.core.vcs.data.PullRequestState.Open
 import org.scalatest.{FunSuite, Matchers}
 import scala.io.Source
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestStateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/PullRequestStateTest.scala
@@ -1,8 +1,8 @@
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import io.circe.Decoder
 import io.circe.syntax._
-import org.scalasteward.core.github.data.PullRequestState.{Closed, Open}
+import org.scalasteward.core.vcs.data.PullRequestState.{Closed, Open}
 import org.scalatest.{Assertion, FunSuite, Matchers}
 
 class PullRequestStateTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoOutTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/RepoOutTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.github.data
+package org.scalasteward.core.vcs.data
 
 import cats.effect.IO
 import io.circe.parser


### PR DESCRIPTION
This is mostly changes to prevent the PR with the actual logic to be obfuscated. I move the data structures from github/data to vcs/data. I also rename the `GitHubRepoAlg` to `VCSRepoAlg`.

With this PR, we are assuming the data structures (used to talk to GitHub) will work for any VCS be it BitBucket and GitLab. In reality, it's a bit of a stretch. I've made it work with a bunch of shortcut (as a prototype it ran on one of our internal repository and it opened a bunch of PR 👍 ). But we'll need to discuss what needs to change in those structures in order to accommodate other VCS when I open the PR with the actual logic.

The actual changes would look like:

* a new package called org.scalasteward.core.gitlab (with a different `Url` class 
* custom encoder/decoders to go from Gitlab's JSON to the vcs data structures (if they're left as-is)
* a VCSApiAlg that covers Github and Gitlab
* a VCS Selector (if you will) to read the config and build the appropriate implementation of `VCSApiAlg`



