### PR TITLE
Ignore updates which have closed PR

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
@@ -65,8 +65,8 @@ class JsonPullRequestRepo[F[_]](
     readJson.map { store =>
       val pullRequests = store.store.get(repo).fold(List.empty[(String, PullRequestData)])(_.toList)
       pullRequests
-        .find(d => UpdateService.isUpdateFor(d._2.update, dependency))
-        .map(d => (Uri.unsafeFromString(d._1), d._2.baseSha1, d._2.state))
+        .find { case (_, data) => UpdateService.isUpdateFor(data.update, dependency) }
+        .map { case (url, data) => (Uri.unsafeFromString(url), data.baseSha1, data.state) }
     }
 
   def jsonFile: F[File] =

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
@@ -21,11 +21,13 @@ import cats.implicits._
 import io.circe.parser.decode
 import io.circe.syntax._
 import org.http4s.Uri
+import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.github.data.{PullRequestState, Repo}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.nurture.PullRequestRepository
+import org.scalasteward.core.update.UpdateService
 import org.scalasteward.core.util.MonadThrowable
 
 class JsonPullRequestRepo[F[_]](
@@ -54,6 +56,17 @@ class JsonPullRequestRepo[F[_]](
       store.store.get(repo).fold(List.empty[Update]) { data =>
         data.values.filter(_.baseSha1 == baseSha1).map(_.update).toList
       }
+    }
+
+  override def findPullRequest(
+      repo: Repo,
+      dependency: Dependency
+  ): F[Option[(Uri, Sha1, PullRequestState)]] =
+    readJson.map { store =>
+      val pullRequests = store.store.get(repo).fold(List.empty[(String, PullRequestData)])(_.toList)
+      pullRequests
+        .find(d => UpdateService.isUpdateFor(d._2.update, dependency))
+        .map(d => (Uri.unsafeFromString(d._1), d._2.baseSha1, d._2.state))
     }
 
   def jsonFile: F[File] =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.nurture
+package org.scalasteward.core.update.data
 
 import org.http4s.Uri
 import org.scalasteward.core.dependency.Dependency
-import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.github.data.{PullRequestState, Repo}
 import org.scalasteward.core.model.Update
 
-trait PullRequestRepository[F[_]] {
-  def createOrUpdate(
-      repo: Repo,
-      url: Uri,
-      baseSha1: Sha1,
-      update: Update,
-      state: PullRequestState
-  ): F[Unit]
+sealed trait UpdateState extends Product with Serializable {
+  def dependency: Dependency
+}
 
-  def findUpdates(repo: Repo, baseSha1: Sha1): F[List[Update]]
+object UpdateState {
+  final case class NoUpdateFound(dependency: Dependency) extends UpdateState
 
-  def findPullRequest(repo: Repo, dependency: Dependency): F[Option[(Uri, Sha1, PullRequestState)]]
+  final case class UpdateFound(dependency: Dependency, update: Update) extends UpdateState
+
+  final case class PullRequestUpToDate(dependency: Dependency, update: Update, pr: Uri)
+      extends UpdateState
+
+  final case class PullRequestOutdated(dependency: Dependency, update: Update, pr: Uri)
+      extends UpdateState
+
+  final case class PullRequestClosed(dependency: Dependency, update: Update, pr: Uri)
+      extends UpdateState
 }


### PR DESCRIPTION
This is another part of #123 where scala-steward ignores updates for which it already created PRs that where closed without merging. It also shows the `UpdateState` of each dependency in all repos.