### PR TITLE
Read RepoConfig only once when updating a repo

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
@@ -19,9 +19,11 @@ package org.scalasteward.core.nurture
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.model.Update
+import org.scalasteward.core.repoconfig.RepoConfig
 
 final case class UpdateData(
     repo: Repo,
+    repoConfig: RepoConfig,
     update: Update,
     baseBranch: Branch,
     baseSha1: Sha1,

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -4,6 +4,7 @@ import io.circe.syntax._
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.nurture.UpdateData
+import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
@@ -11,6 +12,7 @@ class NewPullRequestDataTest extends FunSuite with Matchers {
   test("asJson") {
     val data = UpdateData(
       Repo("foo", "bar"),
+      RepoConfig(),
       Update.Single("ch.qos.logback", "logback-classic", "1.2.0", Nel.of("1.2.3")),
       Branch("master"),
       Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),


### PR DESCRIPTION
This is just an optimization to not repeatedly reading and parsing the
repository config when working on a repo.