### PR TITLE
s/liquidity/liquidity-service/

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -116,7 +116,7 @@
 - daniel-shuy/liquibase-slick-codegen-sbt-plugin
 - daniel-shuy/sbt-release-mdoc
 - daniel-shuy/scripted-scalatest-sbt-plugin
-- dhpiggott/liquidity
+- dhpiggott/liquidity-service
 - dispalt/tagless-redux
 - djspiewak/gll-combinators
 - djspiewak/shims


### PR DESCRIPTION
dhpiggott/liquidity has been renamed to dhpiggott/liquidity-service.

Although GitHub redirects mean that dhpiggott/liquidity still works, it's
better to update references.