### PR TITLE
Only try to edit files that contain the current version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
@@ -16,13 +16,15 @@
 
 package org.scalasteward.core.nurture
 
+import better.files.File
+import cats.Traverse
 import cats.effect.Sync
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.util._
+import org.scalasteward.core.vcs.data.Repo
 
 trait EditAlg[F[_]] {
   def applyUpdate(repo: Repo, update: Update): F[Unit]
@@ -38,22 +40,24 @@ object EditAlg {
   ): EditAlg[F] =
     new EditAlg[F] {
       override def applyUpdate(repo: Repo, update: Update): F[Unit] =
-        workspaceAlg.repoDir(repo).flatMap { repoDir =>
-          def log(strategy: String): F[Unit] =
-            logger.info(s"Trying update strategy '$strategy'")
+        for {
+          repoDir <- workspaceAlg.repoDir(repo)
+          files <- fileAlg.findSourceFilesContaining(repoDir, update.currentVersion)
+          noFilesFound = logger.warn("No source files found that contain the current version")
+          _ <- files.toNel.fold(noFilesFound)(applyUpdateTo(_, update))
+        } yield ()
 
-          val strategies = Nel.of(
-            log("replaceAllInStrict") >>
-              fileAlg.editSourceFiles(repoDir, update.replaceAllInStrict),
-            log("replaceAllIn") >>
-              fileAlg.editSourceFiles(repoDir, update.replaceAllIn),
-            log("replaceAllInRelaxed") >>
-              fileAlg.editSourceFiles(repoDir, update.replaceAllInRelaxed),
-            log("replaceAllInSliding") >>
-              fileAlg.editSourceFiles(repoDir, update.replaceAllInSliding)
-          )
+      def applyUpdateTo[G[_]: Traverse](files: G[File], update: Update): F[Unit] = {
+        def applyHeuristic(name: String, edit: String => Option[String]): F[Boolean] =
+          logger.info(s"Trying heuristic '$name'") >> fileAlg.editFiles(files, edit)
 
-          bindUntilTrue(strategies).void
-        }
+        val heuristics = Nel.of(
+          applyHeuristic("strict", update.replaceAllInStrict),
+          applyHeuristic("original", update.replaceAllIn),
+          applyHeuristic("relaxed", update.replaceAllInRelaxed),
+          applyHeuristic("sliding", update.replaceAllInSliding)
+        )
+        bindUntilTrue(heuristics).void
+      }
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/EditAlg.scala
@@ -43,7 +43,7 @@ object EditAlg {
         for {
           repoDir <- workspaceAlg.repoDir(repo)
           files <- fileAlg.findSourceFilesContaining(repoDir, update.currentVersion)
-          noFilesFound = logger.warn("No source files found that contain the current version")
+          noFilesFound = logger.warn("No files found that contain the current version")
           _ <- files.toNel.fold(noFilesFound)(applyUpdateTo(_, update))
         } yield ()
 

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -79,27 +79,4 @@ class FileAlgTest extends FunSuite with Matchers {
     )
     edited shouldBe true
   }
-
-  test("editSourceFiles") {
-    val file1 = File.root / "tmp" / "steward" / "test1.sbt"
-    val file2 = File.root / "tmp" / "steward" / "test2.scala"
-    val (state, edited) = (for {
-      _ <- fileAlg.writeFile(file1, "123")
-      _ <- fileAlg.writeFile(file2, "456")
-      edit = (s: String) => if (s.contains("2")) Some(s.replace("2", "8")) else None
-      edited <- fileAlg.editSourceFiles(file1.parent, edit)
-    } yield edited).run(MockState.empty).unsafeRunSync()
-
-    state shouldBe MockState.empty.copy(
-      commands = Vector(
-        List("write", file1.pathAsString),
-        List("write", file2.pathAsString),
-        List("read", file1.pathAsString),
-        List("write", file1.pathAsString),
-        List("read", file2.pathAsString)
-      ),
-      files = Map(file1 -> "183", file2 -> "456")
-    )
-    edited shouldBe true
-  }
 }


### PR DESCRIPTION
This is an optimization where the update heuristics are only tried
on files that contain the current version number. Since the heuristics
consists of non-trivial regular expressions, this has a significant effect
on large projects. In one instance applyUpdate now only takes ~1s
instead of ~30s.