### PR TITLE
Refine replaceAllInGroupId

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/UpdateTest.scala
@@ -235,6 +235,18 @@ class UpdateTest extends FunSuite with Matchers {
       .replaceAllInGroupId(original) shouldBe Some(expected)
   }
 
+  test("replaceAllInGroupId: ignore TLD") {
+    val original = """ "com.propensive" %% "contextual" % "1.0.1" """
+    Single("com.slamdata", "fs2-gzip", "1.0.1", Nel.of("1.1.1"))
+      .replaceAllInGroupId(original) shouldBe None
+  }
+
+  test("replaceAllInGroupId: ignore short words") {
+    val original = "SBT_VERSION=1.2.7"
+    Single("org.scala-sbt", "scripted-plugin", "1.2.7", Nel.of("1.2.8"))
+      .replaceAllInGroupId(original) shouldBe None
+  }
+
   test("Group.artifactId") {
     Group(
       "org.http4s",


### PR DESCRIPTION
... to prevent PRs listed in https://github.com/fthomas/scala-steward/pull/545#issuecomment-499437250

This change drops the TLD from the groupId and only uses words that are
longer than three characters.