### PR TITLE
Ignore untracked files when checking if a repository has changes

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -101,7 +101,7 @@ object GitAlg {
 
       override def containsChanges(repo: Repo): F[Boolean] =
         workspaceAlg.repoDir(repo).flatMap { repoDir =>
-          exec(Nel.of("status", "--porcelain"), repoDir).map(_.nonEmpty)
+          exec(Nel.of("status", "--porcelain", "--untracked-files=no"), repoDir).map(_.nonEmpty)
         }
 
       override def createBranch(repo: Repo, branch: Branch): F[Unit] =


### PR DESCRIPTION
This prevents errors like this:
```
[info] 2019-06-14 23:19:20,117 WARN  No files found that contain the current version
[info] 2019-06-14 23:19:20,148 INFO  Create branch update/scripted-plugin-1.1.6
[info] java.io.IOException: On branch update/scripted-plugin-1.1.6
[info] Untracked files:
[info]  project/project/
[info]  project/target/
[info]  target/
[info] nothing added to commit but untracked files present
```