### PR TITLE
Use BigInt instead of Long for the numeric parts of Version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/model/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Version.scala
@@ -22,15 +22,15 @@ import org.scalasteward.core.util
 import scala.util.Try
 
 final case class Version(value: String) {
-  def numericComponents: List[Long] =
+  def numericComponents: List[BigInt] =
     value
-      .split(Array('.', '-'))
+      .split(Array('.', '-', '+'))
       .flatMap(util.string.splitNumericAndNonNumeric)
       .map {
-        case "SNAP" | "SNAPSHOT" => -3L
-        case "M"                 => -2L
-        case "RC"                => -1L
-        case s                   => Try(s.toLong).getOrElse(0L)
+        case "SNAP" | "SNAPSHOT" => BigInt(-3)
+        case "M"                 => BigInt(-2)
+        case "RC"                => BigInt(-1)
+        case s                   => Try(BigInt(s)).getOrElse(BigInt(0))
       }
       .toList
 }
@@ -41,8 +41,8 @@ object Version {
       val c1 = v1.numericComponents
       val c2 = v2.numericComponents
       val maxLength = math.max(c1.length, c2.length)
-      val padded1 = c1.padTo(maxLength, 0L)
-      val padded2 = c2.padTo(maxLength, 0L)
+      val padded1 = c1.padTo(maxLength, BigInt(0))
+      val padded2 = c2.padTo(maxLength, BigInt(0))
       padded1.compare(padded2)
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/model/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/VersionTest.scala
@@ -23,7 +23,8 @@ class VersionTest extends FunSuite with Discipline with Matchers {
       ("2.13.0-M2", "2.13.0", LessThan),
       ("2.13.0-M2", "2.13.0-RC1", LessThan),
       ("5.3.2.201906051522-r", "5.4.0.201906121030-r", LessThan),
-      ("105", "104", GreaterThan)
+      ("105", "104", GreaterThan),
+      ("1.0.0+20130313", "1.0.0+20130320", LessThan)
     )
 
     forAll(versions) { (x, y, result) =>


### PR DESCRIPTION
So we don't have to care about really really long version numbers.