### PR TITLE
Put all global sbt plugins in scala-steward.sbt

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -64,8 +64,7 @@ object SbtAlg {
       override def addGlobalPlugins: F[Unit] =
         for {
           _ <- logger.info("Add global sbt plugins")
-          _ <- addGlobalPlugin(sbtScalafixPlugin)
-          _ <- addGlobalPlugin(sbtUpdatesPlugin)
+          _ <- addGlobalPlugin(scalaStewardSbt)
           _ <- addGlobalPlugin(stewardPlugin)
         } yield ()
 

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -35,11 +35,13 @@ package object sbt {
       case _      => defaultSbtVersion
     }
 
-  val sbtScalafixPlugin: FileData =
-    FileData("sbt-scalafix.sbt", """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")""")
-
-  val sbtUpdatesPlugin: FileData =
-    FileData("sbt-updates.sbt", """addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")""")
+  val scalaStewardSbt: FileData =
+    FileData(
+      "scala-steward.sbt",
+      """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
+        |addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")
+      """.stripMargin
+    )
 
   val stewardPlugin: FileData = {
     val name = "StewardPlugin.scala"

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -12,19 +12,15 @@ class SbtAlgTest extends FunSuite with Matchers {
   test("addGlobalPlugins") {
     sbtAlg.addGlobalPlugins.runS(MockState.empty).unsafeRunSync() shouldBe MockState.empty.copy(
       commands = Vector(
-        List("write", "/tmp/steward/.sbt/0.13/plugins/sbt-scalafix.sbt"),
-        List("write", "/tmp/steward/.sbt/1.0/plugins/sbt-scalafix.sbt"),
-        List("write", "/tmp/steward/.sbt/0.13/plugins/sbt-updates.sbt"),
-        List("write", "/tmp/steward/.sbt/1.0/plugins/sbt-updates.sbt"),
+        List("write", "/tmp/steward/.sbt/0.13/plugins/scala-steward.sbt"),
+        List("write", "/tmp/steward/.sbt/1.0/plugins/scala-steward.sbt"),
         List("write", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala"),
         List("write", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala")
       ),
       logs = Vector((None, "Add global sbt plugins")),
       files = Map(
-        File("/tmp/steward/.sbt/0.13/plugins/sbt-scalafix.sbt") -> sbtScalafixPlugin.content,
-        File("/tmp/steward/.sbt/1.0/plugins/sbt-scalafix.sbt") -> sbtScalafixPlugin.content,
-        File("/tmp/steward/.sbt/0.13/plugins/sbt-updates.sbt") -> sbtUpdatesPlugin.content,
-        File("/tmp/steward/.sbt/1.0/plugins/sbt-updates.sbt") -> sbtUpdatesPlugin.content,
+        File("/tmp/steward/.sbt/0.13/plugins/scala-steward.sbt") -> scalaStewardSbt.content,
+        File("/tmp/steward/.sbt/1.0/plugins/scala-steward.sbt") -> scalaStewardSbt.content,
         File("/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala") -> stewardPlugin.content,
         File("/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala") -> stewardPlugin.content
       )


### PR DESCRIPTION
The reason for this is to better distinguish what scala-steward
installed and everything else.