### PR TITLE
Ignore dependencies introduced by plugins

### DIFF
--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -16,9 +16,8 @@
 
 package org.scalasteward.core
 
-import sbt._
 import sbt.Keys._
-import scala.collection.mutable.ListBuffer
+import sbt._
 
 object StewardPlugin extends AutoPlugin {
 

--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -14,29 +14,32 @@
  * limitations under the License.
  */
 
-package sbt.scalasteward
+package org.scalasteward.core
 
-import sbt.Keys._
 import sbt._
+import sbt.Keys._
+import scala.collection.mutable.ListBuffer
 
 object StewardPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
   object autoImport {
-    val libraryDependenciesAsJson = settingKey[String]("")
+    val libraryDependenciesAsJson = taskKey[String]("")
   }
 
   import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependenciesAsJson := {
-      val deps = libraryDependencies.value.map {
+      val sourcePositions = dependencyPositions.value
+      val deps = libraryDependencies.value.filter(isDefinedInBuildFiles(_, sourcePositions)).map {
         moduleId =>
           val cross =
             CrossVersion(moduleId.crossVersion, scalaVersion.value, scalaBinaryVersion.value)
+
           val artifactIdCross =
-            CrossVersion.applyCross(moduleId.name, cross)
+            cross.fold(moduleId.name)(_(moduleId.name))
 
           val entries: List[(String, String)] = List(
             "groupId" -> moduleId.organization,
@@ -52,4 +55,16 @@ object StewardPlugin extends AutoPlugin {
       deps.mkString("[ ", ", ", " ]")
     }
   )
+
+  // Inspired by https://github.com/rtimush/sbt-updates/issues/42
+  private def isDefinedInBuildFiles(
+      moduleId: ModuleID,
+      sourcePositions: Map[ModuleID, SourcePosition]
+  ): Boolean =
+    sourcePositions.get(moduleId) match {
+      case Some(fp: FilePosition) if fp.path.startsWith("(sbt.Classpaths") => true
+      case Some(fp: FilePosition) if fp.path.startsWith("(")               => false
+      case Some(fp: FilePosition) if fp.path.startsWith("Defaults.scala")  => false
+      case _                                                               => true
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.sbt
 
 object command {
   val dependencyUpdates = "dependencyUpdates"
-  val libraryDependenciesAsJson = "libraryDependenciesAsJson"
+  val libraryDependenciesAsJson = "show libraryDependenciesAsJson"
   val reloadPlugins = "reload plugins"
   val scalafix = "scalafix"
   val scalafixEnable = "scalafixEnable"

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -40,7 +40,7 @@ package object sbt {
       "scala-steward.sbt",
       """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
         |addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")
-      """.stripMargin
+        |""".stripMargin.trim
     )
 
   val stewardPlugin: FileData = {


### PR DESCRIPTION
This ignores dependencies of a repo which are not defined in the build
files but are introduced by plugins. This allows scala-steward to prune
more repositories it doesn't need to look at. Without this scala-steward
tried to update dependencies which were never defined in the build files
and therefore couldn't be updated.