### PR TITLE
Call .value outside of lambda

### DIFF
--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -32,10 +32,13 @@ object StewardPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     libraryDependenciesAsJson := {
       val sourcePositions = dependencyPositions.value
+      val scalaBinaryVersionValue = scalaBinaryVersion.value
+      val scalaVersionValue = scalaVersion.value
+
       val deps = libraryDependencies.value.filter(isDefinedInBuildFiles(_, sourcePositions)).map {
         moduleId =>
           val cross =
-            CrossVersion(moduleId.crossVersion, scalaVersion.value, scalaBinaryVersion.value)
+            CrossVersion(moduleId.crossVersion, scalaVersionValue, scalaBinaryVersionValue)
 
           val artifactIdCross =
             cross.fold(moduleId.name)(_(moduleId.name))


### PR DESCRIPTION
To prevent errors like this:
```
.sbt/1.0/plugins/StewardPlugin.scala:38:49: The evaluation of `scalaVersion` inside an anonymous function is prohibited.
[error]
[error] Problem: Task invocations inside anonymous functions are evaluated independently of whether the anonymous function is invoked or not.
[error]
[error] Solution:
[error]   1. Make `scalaVersion` evaluation explicit outside of the function body if you don't care about its evaluation.
[error]   2. Use a dynamic task to evaluate `scalaVersion` and pass that value as a parameter to an anonymous function.
[error]
[error]             CrossVersion(moduleId.crossVersion, scalaVersion.value, scalaBinaryVersion.value)
[error]                                                 ^
```