### PR TITLE
Remove MockState.extraEnv

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.{FunSuite, Matchers}
 class GitAlgTest extends FunSuite with Matchers {
   val repo = Repo("fthomas", "datapackage")
   val repoDir: String = (config.workspace / "fthomas/datapackage").toString
+  val askPass = s"GIT_ASKPASS=${config.gitAskPass}"
 
   test("clone") {
     val url = uri"https://scala-steward@github.com/fthomas/datapackage"
@@ -17,6 +18,7 @@ class GitAlgTest extends FunSuite with Matchers {
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
+          askPass,
           config.workspace.toString,
           "git",
           "clone",
@@ -24,9 +26,6 @@ class GitAlgTest extends FunSuite with Matchers {
           "https://scala-steward@github.com/fthomas/datapackage",
           repoDir
         )
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
       )
     )
   }
@@ -39,10 +38,7 @@ class GitAlgTest extends FunSuite with Matchers {
 
     state shouldBe MockState.empty.copy(
       commands = Vector(
-        List(repoDir, "git", "log", "--pretty=format:'%an'", "master..update/cats-1.0.0")
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
+        List(askPass, repoDir, "git", "log", "--pretty=format:'%an'", "master..update/cats-1.0.0")
       )
     )
   }
@@ -55,10 +51,7 @@ class GitAlgTest extends FunSuite with Matchers {
 
     state shouldBe MockState.empty.copy(
       commands = Vector(
-        List(repoDir, "git", "commit", "--all", "-m", "Initial commit", "--gpg-sign")
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
+        List(askPass, repoDir, "git", "commit", "--all", "-m", "Initial commit", "--gpg-sign")
       )
     )
   }
@@ -74,18 +67,19 @@ class GitAlgTest extends FunSuite with Matchers {
 
     state shouldBe MockState.empty.copy(
       commands = Vector(
-        List(repoDir, "git", "remote", "add", "upstream", "http://github.com/fthomas/datapackage"),
-        List(repoDir, "git", "fetch", "upstream"),
-        List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
-        List(repoDir, "git", "merge", "upstream/master"),
-        List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
+        List(
+          askPass,
+          repoDir,
+          "git",
+          "remote",
+          "add",
+          "upstream",
+          "http://github.com/fthomas/datapackage"
+        ),
+        List(askPass, repoDir, "git", "fetch", "upstream"),
+        List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
+        List(askPass, repoDir, "git", "merge", "upstream/master"),
+        List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.{FunSuite, Matchers}
 class GitHubRepoAlgTest extends FunSuite with Matchers {
   val repo = Repo("fthomas", "datapackage")
   val repoDir: String = (config.workspace / "fthomas/datapackage").toString
+  val askPass = s"GIT_ASKPASS=${config.gitAskPass}"
 
   val parentRepoOut = RepoOut(
     "datapackage",
@@ -34,6 +35,7 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
+          askPass,
           config.workspace.toString,
           "git",
           "clone",
@@ -41,13 +43,8 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
           s"https://${config.gitHubLogin}@github.com/scala-steward/datapackage",
           repoDir.toString
         ),
-        List(repoDir, "git", "config", "user.email", "bot@example.org"),
-        List(repoDir, "git", "config", "user.name", "Bot Doe")
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
+        List(askPass, repoDir, "git", "config", "user.email", "bot@example.org"),
+        List(askPass, repoDir, "git", "config", "user.name", "Bot Doe")
       )
     )
   }
@@ -68,6 +65,7 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
+          askPass,
           repoDir,
           "git",
           "remote",
@@ -75,17 +73,10 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
           "upstream",
           s"https://${config.gitHubLogin}@github.com/fthomas/datapackage"
         ),
-        List(repoDir, "git", "fetch", "upstream"),
-        List(repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
-        List(repoDir, "git", "merge", "upstream/master"),
-        List(repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
-      ),
-      extraEnv = Vector(
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString)),
-        List(("GIT_ASKPASS", config.gitAskPass.toString))
+        List(askPass, repoDir, "git", "fetch", "upstream"),
+        List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
+        List(askPass, repoDir, "git", "merge", "upstream/master"),
+        List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
       )
     )
     result shouldBe parentRepoOut

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -34,8 +34,9 @@ class ProcessAlgTest extends FunSuite with Matchers {
       .unsafeRunSync()
 
     state shouldBe MockState.empty.copy(
-      commands = Vector(List(File.temp.toString, "echo", "hello")),
-      extraEnv = Vector(List(("TEST_VAR", "GREAT"), ("ANOTHER_TEST_VAR", "ALSO_GREAT")))
+      commands = Vector(
+        List("TEST_VAR=GREAT", "ANOTHER_TEST_VAR=ALSO_GREAT", File.temp.toString, "echo", "hello")
+      )
     )
   }
 
@@ -47,10 +48,15 @@ class ProcessAlgTest extends FunSuite with Matchers {
 
     state shouldBe MockState.empty.copy(
       commands = Vector(
-        List(File.temp.toString, "firejail", s"--whitelist=${File.temp}", "echo", "hello")
-      ),
-      extraEnv = Vector(
-        List(("TEST_VAR", "GREAT"), ("ANOTHER_TEST_VAR", "ALSO_GREAT"))
+        List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
+          File.temp.toString,
+          "firejail",
+          s"--whitelist=${File.temp}",
+          "echo",
+          "hello"
+        )
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockState.scala
@@ -4,7 +4,6 @@ import better.files.File
 
 final case class MockState(
     commands: Vector[List[String]],
-    extraEnv: Vector[List[(String, String)]],
     logs: Vector[(Option[Throwable], String)],
     files: Map[File, String]
 ) {
@@ -18,9 +17,7 @@ final case class MockState(
     copy(files = files - file)
 
   def exec(cmd: List[String], env: (String, String)*): MockState =
-    // Vector() != Vector(List())
-    if (env.isEmpty) copy(commands = commands :+ cmd)
-    else copy(commands = commands :+ cmd, extraEnv :+ env.toList)
+    copy(commands = commands :+ (env.map { case (k, v) => s"$k=$v" }.toList ++ cmd))
 
   def log(maybeThrowable: Option[Throwable], msg: String): MockState =
     copy(logs = logs :+ ((maybeThrowable, msg)))
@@ -28,5 +25,5 @@ final case class MockState(
 
 object MockState {
   def empty: MockState =
-    MockState(Vector.empty, Vector.empty, Vector.empty, Map.empty)
+    MockState(commands = Vector.empty, logs = Vector.empty, files = Map.empty)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -35,6 +35,8 @@ class SbtAlgTest extends FunSuite with Matchers {
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
@@ -43,9 +45,6 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
         )
-      ),
-      extraEnv = Vector(
-        List(("TEST_VAR", "GREAT"), ("ANOTHER_TEST_VAR", "ALSO_GREAT"))
       )
     )
   }
@@ -64,6 +63,8 @@ class SbtAlgTest extends FunSuite with Matchers {
         List("rm", (repoDir / ".sbtopts").toString),
         List("create", (repoDir / ".jvmopts").toString),
         List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
@@ -75,9 +76,6 @@ class SbtAlgTest extends FunSuite with Matchers {
         List("rm", (repoDir / ".jvmopts").toString),
         List("restore", (repoDir / ".sbtopts").toString),
         List("restore", (repoDir / ".jvmopts").toString)
-      ),
-      extraEnv = Vector(
-        List(("TEST_VAR", "GREAT"), ("ANOTHER_TEST_VAR", "ALSO_GREAT"))
       )
     )
   }
@@ -93,6 +91,8 @@ class SbtAlgTest extends FunSuite with Matchers {
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
           repoDir.toString,
           "firejail",
           s"--whitelist=$repoDir",
@@ -101,9 +101,6 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";dependencyUpdates;reload plugins;dependencyUpdates"
         )
-      ),
-      extraEnv = Vector(
-        List(("TEST_VAR", "GREAT"), ("ANOTHER_TEST_VAR", "ALSO_GREAT"))
       )
     )
   }


### PR DESCRIPTION
Environment variables are now prepended to MockState.commands entries.
This clarifies which environment variables are used for which command.