### PR TITLE
Install sbt-scalafix plugin only during migrations

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -38,9 +38,13 @@ package object sbt {
   val scalaStewardSbt: FileData =
     FileData(
       "scala-steward.sbt",
-      """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
-        |addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.1")
-        |""".stripMargin.trim
+      """addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.1")"""
+    )
+
+  val scalaStewardScalafixSbt: FileData =
+    FileData(
+      "scala-steward-scalafix.sbt",
+      """addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")"""
     )
 
   val stewardPlugin: FileData = {


### PR DESCRIPTION
This fixes two issues. The first is a conflict between the globally
installed sbt-scalafix and sbt-scalafix comming from a repo that uses a
different version. Here is an example where scala-steward can't load a
build because of a conflict:
```
[info] Loading global plugins from /home/frank/.sbt/1.0/plugins
[info] Updating ProjectRef(uri("file:/home/frank/.sbt/1.0/plugins/"), "global-plugins")...
[info] Done updating.
[info] Compiling 1 Scala source to /home/frank/.sbt/1.0/plugins/target/scala-2.12/sbt-1.0/classes ...
[info] Done compiling.
[info] Loading settings for project recursionz-build-build from hack.sbt ...
[info] Loading project definition from /home/frank/scala-steward/workspace/repos/enzief/recursionz/project/project
[info] Updating ProjectRef(uri("file:/home/frank/scala-steward/workspace/repos/enzief/recursionz/project/project/"), "recursionz-build-build")...
[info] Done updating.
[info] Compiling 2 Scala sources to /home/frank/scala-steward/workspace/repos/enzief/recursionz/project/project/target/scala-2.12/sbt-1.0/classes ...
[info] Done compiling.
/home/frank/scala-steward/workspace/repos/enzief/recursionz/project/plugins.sbt:9: error: reference to scalafix is ambiguous;
it is imported twice in the same scope by
import enzief.Dependencies.SbtPlugin._
and import _root_.scalafix.sbt.ScalafixPlugin.autoImport._
addSbtPlugin(scalafix)
             ^
[error] Type error in expression
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```

The second issue is an OOME I've seen with http4s:
```
[info] Loading global plugins from /home/frank/.sbt/1.0/plugins
[info] Loading settings for project http4s-build from plugins.sbt,build.sbt ...
[info] Loading project definition from /home/frank/scala-steward/workspace/repos/http4s/http4s/project
[info] Updating ProjectRef(uri("file:/home/frank/scala-steward/workspace/repos/http4s/http4s/project/"), "http4s-build")...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 4 Scala sources to /home/frank/scala-steward/workspace/repos/http4s/http4s/project/target/scala-2.12/sbt-1.0/classes ...
[info] Done compiling.
[info] Loading settings for project root from build.sbt,version.sbt ...
java.lang.OutOfMemoryError: Java heap space
        at org.eclipse.jgit.internal.storage.file.PackIndexV2.<init>(PackIndexV2.java:128)
        at org.eclipse.jgit.internal.storage.file.PackIndex.read(PackIndex.java:140)
        at org.eclipse.jgit.internal.storage.file.PackIndex.open(PackIndex.java:99)
        at org.eclipse.jgit.internal.storage.file.PackFile.idx(PackFile.java:181)
        at org.eclipse.jgit.internal.storage.file.PackFile.get(PackFile.java:272)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedObject(ObjectDirectory.java:421)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedFromSelfOrAlternate(ObjectDirectory.java:390)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObject(ObjectDirectory.java:382)
        at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:154)
        at org.eclipse.jgit.revwalk.RevWalk.getCachedBytes(RevWalk.java:903)
        at org.eclipse.jgit.revwalk.RevCommit.parseHeaders(RevCommit.java:155)
        at org.eclipse.jgit.revwalk.RevWalk.markStart(RevWalk.java:293)
        at org.eclipse.jgit.api.LogCommand.add(LogCommand.java:338)
        at org.eclipse.jgit.api.LogCommand.add(LogCommand.java:197)
        at org.eclipse.jgit.api.LogCommand.call(LogCommand.java:153)
        at scalafix.internal.sbt.JGitCompletion.<init>(JGitCompletions.scala:26)
        at scalafix.internal.sbt.ScalafixCompletions.gitDiffParser$lzycompute(ScalafixCompletions.scala:94)
        at scalafix.internal.sbt.ScalafixCompletions.gitDiffParser(ScalafixCompletions.scala:93)
        at scalafix.internal.sbt.ScalafixCompletions.parser(ScalafixCompletions.scala:139)
        at scalafix.sbt.ScalafixPlugin$.scalafix$sbt$ScalafixPlugin$$scalafixInputTask(ScalafixPlugin.scala:142)
        at scalafix.sbt.ScalafixPlugin$autoImport$.scalafixConfigSettings(ScalafixPlugin.scala:52)
        at scalafix.sbt.ScalafixPlugin$.$anonfun$projectSettings$1(ScalafixPlugin.scala:76)
        at scalafix.sbt.ScalafixPlugin$$$Lambda$4951/2063469051.apply(Unknown Source)
        at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:240)
        at scala.collection.TraversableLike$$Lambda$60/825936265.apply(Unknown Source)
        at scala.collection.immutable.List.foreach(List.scala:388)
        at scala.collection.TraversableLike.flatMap(TraversableLike.scala:240)
        at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:237)
        at scala.collection.immutable.List.flatMap(List.scala:351)
        at scalafix.sbt.ScalafixPlugin$.projectSettings(ScalafixPlugin.scala:76)
        at sbt.internal.Load$.$anonfun$resolveProject$3(Load.scala:1062)
        at sbt.internal.Load$$$Lambda$998/2050715938.apply(Unknown Source)
Error during sbt execution: java.lang.OutOfMemoryError: Java heap space
```
This OOME happens with sbt-scalafix 0.9.5.

Both issues can be prevented (or at least mitigated) when we're installing
sbt-scalafix only if it is required.