### PR TITLE
Add Scalafix migrations for Scio 0.7.0

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -118,7 +118,7 @@ object SbtAlg {
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {
           for {
             repoDir <- workspaceAlg.repoDir(repo)
-            scalafixCmds = migrations.map(m => s"$scalafix ${m.rewriteRule}").toList
+            scalafixCmds = migrations.flatMap(_.rewriteRules).map(rule => s"$scalafix $rule").toList
             _ <- exec(sbtCmd(scalafixEnable :: scalafixCmds), repoDir)
           } yield ()
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -24,5 +24,5 @@ final case class Migration(
     groupId: String,
     artifactIds: Nel[Regex],
     newVersion: Version,
-    rewriteRule: String
+    rewriteRules: Nel[String]
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -30,6 +30,15 @@ package object scalafix {
         "github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
       ),
       Migration(
+        "com.spotify",
+        Nel.of("scio-core".r),
+        Version("0.7.0"),
+        "github:spotify/scio/FixAvroIO?sha=v0.7.4"
+        // github:spotify/scio/AddMissingImports?sha=v0.7.4
+        // github:spotify/scio/RewriteSysProp?sha=v0.7.4
+        // github:spotify/scio/BQClientRefactoring?sha=v0.7.4
+      ),
+      Migration(
         "org.http4s",
         Nel.of("http4s-.*".r),
         Version("0.20.0"),

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -27,28 +27,30 @@ package object scalafix {
         "co.fs2",
         Nel.of("fs2-.*".r),
         Version("1.0.0"),
-        "github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
+        Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
       ),
       Migration(
         "com.spotify",
-        Nel.of("scio-core".r),
+        Nel.of("scio-.*".r),
         Version("0.7.0"),
-        "github:spotify/scio/FixAvroIO?sha=v0.7.4"
-        // github:spotify/scio/AddMissingImports?sha=v0.7.4
-        // github:spotify/scio/RewriteSysProp?sha=v0.7.4
-        // github:spotify/scio/BQClientRefactoring?sha=v0.7.4
+        Nel.of(
+          "github:spotify/scio/FixAvroIO?sha=v0.7.4",
+          "github:spotify/scio/AddMissingImports?sha=v0.7.4",
+          "github:spotify/scio/RewriteSysProp?sha=v0.7.4",
+          "github:spotify/scio/BQClientRefactoring?sha=v0.7.4"
+        )
       ),
       Migration(
         "org.http4s",
         Nel.of("http4s-.*".r),
         Version("0.20.0"),
-        "github:http4s/http4s/v0_20?sha=v0.20.3"
+        Nel.of("github:http4s/http4s/v0_20?sha=v0.20.3")
       ),
       Migration(
         "org.typelevel",
         Nel.of("cats-core".r),
         Version("1.0.0"),
-        "github:fthomas/cats/Cats_v1_0_0?sha=update/scalafix"
+        Nel.of("github:fthomas/cats/Cats_v1_0_0?sha=update/scalafix")
       )
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -116,7 +116,7 @@ class SbtAlgTest extends FunSuite with Matchers {
         "co.fs2",
         Nel.of("fs2-core".r),
         Version("1.0.0"),
-        "github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
+        Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
       )
     )
     val state = sbtAlg.runMigrations(repo, migrations).runS(MockState.empty).unsafeRunSync()


### PR DESCRIPTION
This is interesting because there is not one but four rules for migrating to 0.7.0. `Migration` currently supports only one rule and needs to be updated for multiple rules.

Example PR: https://github.com/fthomas/scalafix-test/pull/11

closes #612, /cc @regadas 
