### PR TITLE
Elevate pre release semver

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/SemVer.scala
@@ -67,8 +67,8 @@ object SemVer {
   def getChange(from: SemVer, to: SemVer): Option[Change] =
     if (from.major =!= to.major) Some(Major)
     else if (from.minor =!= to.minor) Some(Minor)
-    else if (from.patch =!= to.patch) Some(Patch)
     else if (from.preRelease =!= to.preRelease) Some(PreRelease)
+    else if (from.patch =!= to.patch) Some(Patch)
     else if (from.buildMetadata =!= to.buildMetadata) Some(BuildMetadata)
     else None
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -61,5 +61,7 @@ class SemVerTest extends FunSuite with Matchers {
     SemVer.getChange(SemVer(2, 3, 4, Some("M1"), Some("1")), SemVer(2, 3, 4, Some("M1"), Some("2"))) shouldBe
       Some(Change.BuildMetadata)
     SemVer.getChange(SemVer(2, 3, 4, Some("M1"), None), SemVer(2, 3, 4, Some("M1"), None)) shouldBe None
+    SemVer.getChange(SemVer(0,20,0, Some("M4"), None), SemVer(0, 20, 3, None, None)) shouldBe
+      Some(Change.PreRelease)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/model/SemVerTest.scala
@@ -61,7 +61,7 @@ class SemVerTest extends FunSuite with Matchers {
     SemVer.getChange(SemVer(2, 3, 4, Some("M1"), Some("1")), SemVer(2, 3, 4, Some("M1"), Some("2"))) shouldBe
       Some(Change.BuildMetadata)
     SemVer.getChange(SemVer(2, 3, 4, Some("M1"), None), SemVer(2, 3, 4, Some("M1"), None)) shouldBe None
-    SemVer.getChange(SemVer(0,20,0, Some("M4"), None), SemVer(0, 20, 3, None, None)) shouldBe
+    SemVer.getChange(SemVer(0, 20, 0, Some("M4"), None), SemVer(0, 20, 3, None, None)) shouldBe
       Some(Change.PreRelease)
   }
 }


### PR DESCRIPTION
Found an error in SemVer when going from `0.20.0-M3` to `0.20.3` was labelled `semver-patch` which does not seem consistent with https://semver.org/

Hopefully this doesn't affect the system in another way I don't expect