### PR TITLE
Split getRepoConfig into readRepoConfig{,OrDefault}

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -68,7 +68,7 @@ final class NurtureAlg[F[_]](
   def updateDependencies(repo: Repo, fork: Repo, baseBranch: Branch): F[Unit] =
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      repoConfig <- repoConfigAlg.getRepoConfig(repo)
+      repoConfig <- repoConfigAlg.readRepoConfigOrDefault(repo)
       updates <- sbtAlg.getUpdatesForRepo(repo)
       filtered <- filterAlg.localFilterMany(repoConfig, updates)
       grouped = Update.group(filtered)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -26,6 +26,8 @@ final case class RepoConfig(
 )
 
 object RepoConfig {
+  val default = RepoConfig()
+
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -17,7 +17,7 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
          |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
          |""".stripMargin
     val initialState = MockState.empty.add(configFile, content)
-    val config = repoConfigAlg.getRepoConfig(repo).runA(initialState).unsafeRunSync()
+    val config = repoConfigAlg.readRepoConfigOrDefault(repo).runA(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig(
       updates = UpdatesConfig(
@@ -32,7 +32,7 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
     val content = "updatePullRequests = false"
     val initialState = MockState.empty.add(configFile, content)
-    val config = repoConfigAlg.getRepoConfig(repo).runA(initialState).unsafeRunSync()
+    val config = repoConfigAlg.readRepoConfigOrDefault(repo).runA(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig(updatePullRequests = false)
   }
@@ -41,7 +41,8 @@ class RepoConfigAlgTest extends FunSuite with Matchers {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
     val initialState = MockState.empty.add(configFile, """updates.ignore = [ "foo """)
-    val (state, config) = repoConfigAlg.getRepoConfig(repo).run(initialState).unsafeRunSync()
+    val (state, config) =
+      repoConfigAlg.readRepoConfigOrDefault(repo).run(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig()
     state.logs.headOption.map { case (_, msg) => msg }.getOrElse("") should


### PR DESCRIPTION
This will be useful for https://github.com/fthomas/scala-steward/issues/592
where we only want to cache actual `RepoConfig`s and not also the default
values.