### PR TITLE
Add ability to propose sbt version update

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -79,34 +79,27 @@ object UpdateHeuristic {
     getPrefixRegex = update => Some(s"${update.groupId}.*?")
   )
 
-  val sbt = UpdateHeuristic(
-    name = "sbt",
-    order = 2,
-    getSearchTerms = _ => List("sbt\\.version="),
-    getPrefixRegex = _ => None
-  )
-
   val original = UpdateHeuristic(
     name = "original",
-    order = 3,
+    order = 2,
     getSearchTerms = update => update.searchTerms.toList
   )
 
   val relaxed = UpdateHeuristic(
     name = "relaxed",
-    order = 4,
+    order = 3,
     getSearchTerms = update => util.string.extractWords(update.artifactId)
   )
 
   val sliding = UpdateHeuristic(
     name = "sliding",
-    order = 5,
+    order = 4,
     getSearchTerms = update => update.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList
   )
 
   val groupId = UpdateHeuristic(
     name = "groupId",
-    order = 6,
+    order = 5,
     getSearchTerms = update =>
       update.groupId
         .split('.')
@@ -117,5 +110,5 @@ object UpdateHeuristic {
   )
 
   val all: Nel[UpdateHeuristic] =
-    Nel.of(strict, original, relaxed, sliding, groupId, sbt).sortBy(_.order)
+    Nel.of(strict, original, relaxed, sliding, groupId).sortBy(_.order)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -79,27 +79,34 @@ object UpdateHeuristic {
     getPrefixRegex = update => Some(s"${update.groupId}.*?")
   )
 
+  val sbt = UpdateHeuristic(
+    name = "sbt",
+    order = 2,
+    getSearchTerms = _ => List("sbt\\.version="),
+    getPrefixRegex = _ => None
+  )
+
   val original = UpdateHeuristic(
     name = "original",
-    order = 2,
+    order = 3,
     getSearchTerms = update => update.searchTerms.toList
   )
 
   val relaxed = UpdateHeuristic(
     name = "relaxed",
-    order = 3,
+    order = 4,
     getSearchTerms = update => util.string.extractWords(update.artifactId)
   )
 
   val sliding = UpdateHeuristic(
     name = "sliding",
-    order = 4,
+    order = 5,
     getSearchTerms = update => update.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList
   )
 
   val groupId = UpdateHeuristic(
     name = "groupId",
-    order = 5,
+    order = 6,
     getSearchTerms = update =>
       update.groupId
         .split('.')
@@ -110,5 +117,5 @@ object UpdateHeuristic {
   )
 
   val all: Nel[UpdateHeuristic] =
-    Nel.of(strict, original, relaxed, sliding, groupId).sortBy(_.order)
+    Nel.of(strict, original, relaxed, sliding, groupId, sbt).sortBy(_.order)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/FileAlg.scala
@@ -61,11 +61,11 @@ trait FileAlg[F[_]] {
   ): F[Boolean] =
     files.traverse(editFile(_, edit)).map(_.foldLeft(false)(_ || _))
 
-  final def findSourceFilesContaining(dir: File, string: String)(
+  final def findSourceFilesContaining(dir: File, string: String, fileFilter: File => Boolean)(
       implicit F: Sync[F]
   ): F[List[File]] =
     walk(dir)
-      .filter(isSourceFile)
+      .filter(fileFilter)
       .through(util.evalFilter(isNoSymlink))
       .through(util.evalFilter(containsString(_, string)))
       .compile

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -23,7 +23,8 @@ package object io {
   def isSourceFile(file: File): Boolean = {
     val scalaOrSbtFile = file.extension.exists(Set(".scala", ".sbt"))
     val travisYmlFile = file.name === ".travis.yml"
+    val sbtPropertiesFile = file.name === "build.properties"
     val notInGitDir = !file.pathAsString.contains(".git/")
-    (scalaOrSbtFile || travisYmlFile) && notInGitDir
+    (scalaOrSbtFile || travisYmlFile || sbtPropertiesFile) && notInGitDir
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core
 
 import better.files.File
 import cats.implicits._
+import org.scalasteward.core.model.Update
 
 package object io {
   def isSourceFile(file: File): Boolean = {
@@ -27,4 +28,10 @@ package object io {
     val notInGitDir = !file.pathAsString.contains(".git/")
     (scalaOrSbtFile || travisYmlFile || sbtPropertiesFile) && notInGitDir
   }
+
+  def isFileSpecificTo(update: Update)(f: File): Boolean =
+    update match {
+      case Update.Single("org.scala-sbt", "sbt", _, _, _) => f.name === "build.properties"
+      case _                                              => true
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -111,10 +111,9 @@ object SbtAlg {
           maybeClearCredentials = if (config.keepCredentials) Nil else List(setCredentialsToNil)
           commands = maybeClearCredentials ++
             List(dependencyUpdates, reloadPlugins, dependencyUpdates)
-          sourceUpdates = exec(sbtCmd(commands), repoDir).map(parser.parseSingleUpdates)
-          buildPropUpdates = proposeBuildPropertiesUpdate()
-          updates <- sourceUpdates.product(buildPropUpdates).map(p => p._1 ::: p._2)
-        } yield updates
+          sourceUpdates <- exec(sbtCmd(commands), repoDir).map(parser.parseSingleUpdates)
+          buildPropUpdates <- proposeBuildPropertiesUpdate()
+        } yield sourceUpdates ++ buildPropUpdates
 
       override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] =
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -134,7 +134,7 @@ object SbtAlg {
       final private val latestSbtVersions = List(sbt.defaultSbtVersion, sbt.latestSbtVersion_0_13)
         .map(_.value)
 
-      def proposeBuildPropertiesUpdate(): F[List[Update.Single]] =
+      def proposeBuildPropertiesUpdate(): F[Option[Update.Single]] =
         buildPropertiesFile.flatMap { prop =>
           fileAlg
             .readFile(prop)
@@ -149,7 +149,6 @@ object SbtAlg {
                   sbt.defaultSbtVersion
               } yield Update.Single("org.scala-sbt", "sbt", currentVer, Nel.of(newVer.value))
             }
-            .map(_.toList)
         }
 
       def exec(command: Nel[String], repoDir: File): F[List[String]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -156,7 +156,7 @@ object SbtAlg {
       }
     }
 
-  final private val sbtVersionRegex = s"build.properties=(.+)".r
+  final private val sbtVersionRegex = s"sbt.version=(.+)".r
 
   def extractBuildPropertiesUpdate(content: String): Option[Update.Single] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -24,7 +24,7 @@ import org.scalasteward.core.application.Config
 import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Update, Version}
 import org.scalasteward.core.sbt
 import org.scalasteward.core.sbt.command._
 import org.scalasteward.core.sbt.data.ArtificialProject
@@ -144,10 +144,11 @@ object SbtAlg {
                 currentVer <- sbtVersionRegex.findFirstMatchIn(content).map(_.group(1))
                 if !latestSbtVersions.contains(currentVer)
                 newVer = if (currentVer.startsWith("0."))
-                  sbt.latestSbtVersion_0_13
+                  sbt.latestSbtVersion_0_13.value
                 else
-                  sbt.defaultSbtVersion
-              } yield Update.Single("org.scala-sbt", "sbt", currentVer, Nel.of(newVer.value))
+                  sbt.defaultSbtVersion.value
+                _ <- Some(()) if Version(newVer) > Version(currentVer)
+              } yield Update.Single("org.scala-sbt", "sbt", currentVer, Nel.of(newVer))
             }
         }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/data/SbtVersion.scala
@@ -17,8 +17,11 @@
 package org.scalasteward.core.sbt.data
 
 import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.model.Version
 
-final case class SbtVersion(value: String)
+final case class SbtVersion(value: String) {
+  def toVersion: Version = Version(value)
+}
 
 object SbtVersion {
   implicit val sbtVersionDecoder: Decoder[SbtVersion] =

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -17,6 +17,7 @@
 package org.scalasteward.core
 
 import cats.effect.{IO, Resource}
+import cats.implicits._
 import org.scalasteward.core.io.FileData
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import scala.io.Source
@@ -31,6 +32,13 @@ package object sbt {
 
   val defaultScalaVersion: ScalaVersion =
     ScalaVersion(BuildInfo.scalaVersion)
+
+  def findNewerSbtVersion(sbtVersion: SbtVersion): Option[SbtVersion] =
+    (sbtVersion.value match {
+      case v if v.startsWith("0.13.") => Some(latestSbtVersion_0_13)
+      case v if v.startsWith("1.")    => Some(defaultSbtVersion)
+      case _                          => None
+    }).filter(_.toVersion > sbtVersion.toVersion)
 
   def seriesToSpecificVersion(sbtSeries: SbtVersion): SbtVersion =
     sbtSeries.value match {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -25,12 +25,16 @@ package object sbt {
   val defaultSbtVersion: SbtVersion =
     SbtVersion(BuildInfo.sbtVersion)
 
+  // Needs manual update
+  val latestSbtVersion_0_13: SbtVersion =
+    SbtVersion("0.13.18")
+
   val defaultScalaVersion: ScalaVersion =
     ScalaVersion(BuildInfo.scalaVersion)
 
   def seriesToSpecificVersion(sbtSeries: SbtVersion): SbtVersion =
     sbtSeries.value match {
-      case "0.13" => SbtVersion("0.13.18")
+      case "0.13" => latestSbtVersion_0_13
       case "1.0"  => defaultSbtVersion
       case _      => defaultSbtVersion
     }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -27,10 +27,12 @@ class EditAlgTest extends FunSuite with Matchers {
         List("read", file2.pathAsString),
         List("read", file1.pathAsString),
         List("read", file1.pathAsString),
+        List("read", file1.pathAsString),
         List("write", file1.pathAsString)
       ),
       logs = Vector(
         (None, "Trying heuristic 'strict'"),
+        (None, "Trying heuristic 'sbt'"),
         (None, "Trying heuristic 'original'")
       ),
       files = Map(file1 -> """val catsVersion = "1.3.0"""", file2 -> "")

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -27,12 +27,10 @@ class EditAlgTest extends FunSuite with Matchers {
         List("read", file2.pathAsString),
         List("read", file1.pathAsString),
         List("read", file1.pathAsString),
-        List("read", file1.pathAsString),
         List("write", file1.pathAsString)
       ),
       logs = Vector(
         (None, "Trying heuristic 'strict'"),
-        (None, "Trying heuristic 'sbt'"),
         (None, "Trying heuristic 'original'")
       ),
       files = Map(file1 -> """val catsVersion = "1.3.0"""", file2 -> "")

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -60,4 +60,17 @@ class EditAlgTest extends FunSuite with Matchers {
     )
     runApplyUpdate(update, original) shouldBe expected
   }
+
+  test("file restriction when sbt update") {
+    val update = Update.Single("org.scala-sbt", "sbt", "1.1.2", Nel.of("1.2.8"))
+    val original = Map(
+      "build.properties" -> """sbt.version=1.1.2""",
+      "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""
+    )
+    val expected = Map(
+      "build.properties" -> """sbt.version=1.2.8""", // the version should have been updated here
+      "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""
+    )
+    runApplyUpdate(update, original) shouldBe expected
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -12,7 +12,7 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
     val original = """sbt.version=1.3.0-RC1"""
     val expected = """sbt.version=1.3.0"""
     Single("org.scala-sbt", "sbt", "1.3.0-RC1", Nel.of("1.3.0"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.sbt.name)
+      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("sbt plugins") {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -8,6 +8,13 @@ import org.scalatest.{FunSuite, Matchers}
 
 class UpdateHeuristicTest extends FunSuite with Matchers {
 
+  test("sbt: build.properties") {
+    val original = """sbt.version=1.3.0-RC1"""
+    val expected = """sbt.version=1.3.0"""
+    Single("org.scala-sbt", "sbt", "1.3.0-RC1", Nel.of("1.3.0"))
+      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.sbt.name)
+  }
+
   test("sbt plugins") {
     val original =
       """addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -47,7 +47,8 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-batch",
           "-no-colors",
           ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
-        )
+        ),
+        List("read", "/tmp/steward/project/build.properties")
       )
     )
   }
@@ -78,7 +79,8 @@ class SbtAlgTest extends FunSuite with Matchers {
         ),
         List("rm", (repoDir / ".jvmopts").toString),
         List("restore", (repoDir / ".sbtopts").toString),
-        List("restore", (repoDir / ".jvmopts").toString)
+        List("restore", (repoDir / ".jvmopts").toString),
+        List("read", "/tmp/steward/project/build.properties")
       )
     )
   }
@@ -103,7 +105,8 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-batch",
           "-no-colors",
           ";dependencyUpdates;reload plugins;dependencyUpdates"
-        )
+        ),
+        List("read", "/tmp/steward/project/build.properties")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -48,7 +48,7 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
         ),
-        List("read", "/tmp/steward/project/build.properties")
+        List("read", s"$repoDir/project/build.properties")
       )
     )
   }
@@ -80,7 +80,7 @@ class SbtAlgTest extends FunSuite with Matchers {
         List("rm", (repoDir / ".jvmopts").toString),
         List("restore", (repoDir / ".sbtopts").toString),
         List("restore", (repoDir / ".jvmopts").toString),
-        List("read", "/tmp/steward/project/build.properties")
+        List("read", s"$repoDir/project/build.properties")
       )
     )
   }
@@ -106,7 +106,7 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";dependencyUpdates;reload plugins;dependencyUpdates"
         ),
-        List("read", "/tmp/steward/project/build.properties")
+        List("read", s"$repoDir/project/build.properties")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
@@ -1,0 +1,23 @@
+package org.scalasteward.core.sbt
+
+import org.scalasteward.core.sbt.data.SbtVersion
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+class sbtTest extends FunSuite with Matchers {
+  test("findNewerSbtVersion") {
+    val versions = Table(
+      ("in", "out"),
+      (SbtVersion("1.2.6"), Some(defaultSbtVersion)),
+      (SbtVersion("1.1.0"), Some(defaultSbtVersion)),
+      (SbtVersion("0.13.16"), Some(latestSbtVersion_0_13)),
+      (defaultSbtVersion, None),
+      (latestSbtVersion_0_13, None),
+      (SbtVersion("1.3.0-RC1"), None)
+    )
+
+    forAll(versions) { (curr: SbtVersion, maybeNewer: Option[SbtVersion]) =>
+      findNewerSbtVersion(curr) shouldBe maybeNewer
+    }
+  }
+}


### PR DESCRIPTION
Closes #101.
Steward will propose update if they found `sbt.version=X.Y.Z-SOMETHING`.
It does not update `SbtVersion` that used for conditional build like below

```scala
sbtSeries.value match {
    case "0.13" => SbtVersion("0.13.17")
    case "1.0"  => defaultSbtVersion
    case _      => defaultSbtVersion
}
```
since such build requires cautious update.

I could not find how to perform system-test against actual repos...
How should I perform ?
