### PR TITLE
Add markup to ignore lines

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -20,6 +20,7 @@ import cats.implicits._
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
+import scala.collection.mutable
 import scala.util.matching.Regex
 
 final case class UpdateHeuristic(
@@ -37,11 +38,48 @@ final case class UpdateHeuristic(
         s"(?i)(.*)($prefix$searchTerms.*?)$currentVersion(.?)".r
       }
 
+  def splitter(targetString: String): Nel[(String, Boolean)] =
+    if (!targetString.contains("scala-steward:off")) {
+      Nel.of((targetString, true))
+    } else {
+      val buffer = mutable.ListBuffer.empty[(String, Boolean)]
+      val on = StringBuilder.newBuilder
+      val off = StringBuilder.newBuilder
+      val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
+      def flush(builder: StringBuilder, canReplace: Boolean): Unit =
+        if (builder.nonEmpty) {
+          buffer.append((builder.toString(), canReplace))
+          builder.clear()
+        }
+      targetString.linesWithSeparators.foreach { s =>
+        if (off.nonEmpty) {
+          if (s.contains("scala-steward:on")) {
+            flush(off, false)
+            on.append(s)
+          } else {
+            off.append(s)
+          }
+        } else if (s.contains("scala-steward:off")) {
+          flush(on, true)
+          if (regexIgnoreMultiLinesBegins.findFirstIn(s).isDefined) {
+            off.append(s)
+          } else {
+            // single line off
+            buffer.append((s, false))
+          }
+        } else on.append(s)
+      }
+      flush(on, true)
+      flush(off, false)
+      Nel.fromListUnsafe(buffer.toList)
+    }
+
   def replaceF(update: Update): String => Option[String] =
     mkRegex(update).fold((_: String) => Option.empty[String]) { regex => target =>
       util.string.replaceSomeInOpt(
         regex,
         target,
+        splitter,
         match0 => {
           val group1 = match0.group(1)
           val group2 = match0.group(2)

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -77,7 +77,7 @@ object string {
       regex.replaceSomeIn(target, replacer1)
     } else {
       var ignoreLines = false
-      targetString.linesIterator
+      targetString.linesWithSeparators
         .map(s => {
           if (ignoreLines) {
             if (s.contains("scala-steward:on")) {
@@ -91,7 +91,7 @@ object string {
             s
           } else regex.replaceSomeIn(s, replacer1)
         })
-        .mkString(System.lineSeparator())
+        .mkString("")
     }
     if (changed) Some(result) else None
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -68,9 +68,24 @@ object string {
       target: CharSequence,
       replacer: Regex.Match => Option[String]
   ): Option[String] = {
+    var ignoreLines = false
     var changed = false
     val replacer1 = replacer.andThen(_.map(r => { changed = true; r }))
-    val result = regex.replaceSomeIn(target, replacer1)
+    val result = target.toString.linesIterator
+      .map(s => {
+        if (ignoreLines) {
+          if (s.contains("scala-steward:on")) {
+            ignoreLines = false
+            regex.replaceSomeIn(s, replacer1)
+          } else s
+        } else {
+          if (s.contains("scala-steward:off")) {
+            ignoreLines = true
+            s
+          } else regex.replaceSomeIn(s, replacer1)
+        }
+      })
+      .mkString(System.lineSeparator())
     if (changed) Some(result) else None
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -60,6 +60,8 @@ object string {
   ): Option[MinLengthString[N]] =
     refineV[MinSize[N]](xs.reduceLeft(longestCommonPrefix)).toOption
 
+  final private val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
+
   /** Like `Regex.replaceSomeIn` but indicates via the return type if there
     * was at least one match that has been replaced.
     */
@@ -82,12 +84,12 @@ object string {
               ignoreLines = false
               regex.replaceSomeIn(s, replacer1)
             } else s
-          } else {
-            if (s.contains("scala-steward:off")) {
+          } else if (s.contains("scala-steward:off")) {
+            if (!ignoreLines && regexIgnoreMultiLinesBegins.findFirstIn(s).isDefined) {
               ignoreLines = true
-              s
-            } else regex.replaceSomeIn(s, replacer1)
-          }
+            }
+            s
+          } else regex.replaceSomeIn(s, replacer1)
         })
         .mkString(System.lineSeparator())
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -68,24 +68,29 @@ object string {
       target: CharSequence,
       replacer: Regex.Match => Option[String]
   ): Option[String] = {
-    var ignoreLines = false
     var changed = false
     val replacer1 = replacer.andThen(_.map(r => { changed = true; r }))
-    val result = target.toString.linesIterator
-      .map(s => {
-        if (ignoreLines) {
-          if (s.contains("scala-steward:on")) {
-            ignoreLines = false
-            regex.replaceSomeIn(s, replacer1)
-          } else s
-        } else {
-          if (s.contains("scala-steward:off")) {
-            ignoreLines = true
-            s
-          } else regex.replaceSomeIn(s, replacer1)
-        }
-      })
-      .mkString(System.lineSeparator())
+    val targetString = target.toString
+    val result = if (!targetString.contains("scala-steward:off")) {
+      regex.replaceSomeIn(target, replacer1)
+    } else {
+      var ignoreLines = false
+      targetString.linesIterator
+        .map(s => {
+          if (ignoreLines) {
+            if (s.contains("scala-steward:on")) {
+              ignoreLines = false
+              regex.replaceSomeIn(s, replacer1)
+            } else s
+          } else {
+            if (s.contains("scala-steward:off")) {
+              ignoreLines = true
+              s
+            } else regex.replaceSomeIn(s, replacer1)
+          }
+        })
+        .mkString(System.lineSeparator())
+    }
     if (changed) Some(result) else None
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -297,6 +297,41 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
       Nel.of("1.2.4")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
+
+  test("disable updates on the lines after `off` (no `on`)") {
+    val original =
+      """  // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
+        |  "com.typesafe.akka" %% "akka-testkit" % "2.4.0",
+        |  """.stripMargin.trim
+    Group("com.typesafe.akka", Nel.of("akka-actor", "akka-testkit"), "2.4.0", Nel.of("2.5.0"))
+      .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.groupId.name)
+  }
+
+  test("update the lines between `on` and `off") {
+    val original =
+      """  // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-actor" % "2.4.20",
+        |  // scala-steward:on
+        |  "com.typesafe.akka" %% "akka-slf4j" % "2.4.20" % "test"
+        |  // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-testkit" % "2.4.20" % "test"
+        |  """.stripMargin.trim
+    val expected =
+      """  // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-actor" % "2.4.20",
+        |  // scala-steward:on
+        |  "com.typesafe.akka" %% "akka-slf4j" % "2.5.0" % "test"
+        |  // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-testkit" % "2.4.20" % "test"
+        |  """.stripMargin.trim
+    Group(
+      "com.typesafe.akka",
+      Nel.of("akka-actor", "akka-testkit", "akka-slf4j"),
+      "2.4.20",
+      Nel.of("2.5.0")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
+  }
 }
 
 object UpdateHeuristicTest {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -298,7 +298,20 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
-  test("disable updates on the lines after `off` (no `on`)") {
+  test("disable updates on single lines with `off` (no `on`)") {
+    val original =
+      """  "com.typesafe.akka" %% "akka-actor" % "2.4.0", // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-testkit" % "2.4.0",
+        |  """.stripMargin.trim
+    val expected =
+      """  "com.typesafe.akka" %% "akka-actor" % "2.4.0", // scala-steward:off
+        |  "com.typesafe.akka" %% "akka-testkit" % "2.5.0",
+        |  """.stripMargin.trim
+    Group("com.typesafe.akka", Nel.of("akka-actor", "akka-testkit"), "2.4.0", Nel.of("2.5.0"))
+      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
+  }
+
+  test("disable updates on multiple lines after `off` (no `on`)") {
     val original =
       """  // scala-steward:off
         |  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
@@ -308,7 +321,7 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.groupId.name)
   }
 
-  test("update the lines between `on` and `off") {
+  test("update multiple lines between `on` and `off") {
     val original =
       """  // scala-steward:off
         |  "com.typesafe.akka" %% "akka-actor" % "2.4.20",


### PR DESCRIPTION
Closes #192

Adding two markups to control lines to be ignored.

# Ignoring single-line
A line ends with `// scala-steward:off` is ignored solely.
```scala
"com.typesafe.akka" %% "akka-actor" % "2.4.0", // scala-steward:off
"com.typesafe.akka" %% "akka-testkit" % "2.4.0", // Update should happen on this line
```

# Ignoring multiple-lines
Once a line starts with `// scala-steward:off` found, Steward won't edit lines until `scala-steward:on` found.

```scala
// scala-steward:off
"com.typesafe.akka" %% "akka-actor" % "2.4.0",
"com.typesafe.akka" %% "akka-testkit" % "2.4.0",
// scala-steward:on
"com.typesafe.akka" %% "akka-stream" % "2.4.0", // Update should happen on this line
```

# Note for staying specific range

A range markup like `// scala-steward:only 2.4.x` was suggested in #192. 
I think we do not need such, since sbt already supports [version range in the form of `2.4.+` or `[2.4,2.5)`](https://www.scala-sbt.org/release/docs/Library-Dependencies.html#Ivy+revisions).
So, IIUC, if one want to stay in specific range, one can write:
```scala
// scala-steward:off
"com.typesafe.akka" %% "akka-actor" % "2.4.+",
"com.typesafe.akka" %% "akka-testkit" % "2.4.+",
// scala-steward:on
```


