### PR TITLE
Rename Binding.scala-template to scalajs-all-in-one-template

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -25,7 +25,7 @@
 - alonsodomin/sbt-spark
 - alonsodomin/scala-colog
 - amarrella/fs2-elastic
-- Atry/Binding.scala-template
+- Atry/scalajs-all-in-one-template
 - Atry/Dsl.scala-akka-actor
 - Atry/fastring
 - AVSystem/scala-commons


### PR DESCRIPTION
Since I have renamed https://github.com/Atry/Binding.scala-template to https://github.com/Atry/scalajs-all-in-one-template, also make change here