### PR TITLE
Change groupId when dependencies published under a different groupId

### DIFF
--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -64,7 +64,8 @@ object StewardPlugin extends AutoPlugin {
     sourcePositions.get(moduleId) match {
       case Some(fp: FilePosition) if fp.path.startsWith("(sbt.Classpaths") => true
       case Some(fp: FilePosition) if fp.path.startsWith("(")               => false
-      case Some(fp: FilePosition) if fp.path.startsWith("Defaults.scala")  => false
+      case Some(fp: FilePosition) if fp.path.startsWith("Defaults.scala")
+        && !moduleId.configurations.contains("plugin->default(compile)")   => false
       case _                                                               => true
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -62,7 +62,8 @@ object Update {
       artifactId: String,
       currentVersion: String,
       newerVersions: Nel[String],
-      configurations: Option[String] = None
+      configurations: Option[String] = None,
+      newerGroupId: Option[String] = None
   ) extends Update {
     override def artifactIds: Nel[String] =
       Nel.one(artifactId)

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -32,8 +32,9 @@ package object io {
 
   def isFileSpecificTo(update: Update)(f: File): Boolean =
     update match {
-      case Update.Single("org.scala-sbt", "sbt", _, _, _)           => f.name === "build.properties"
-      case Update.Single("org.scalameta", "scalafmt-core", _, _, _) => f.name === ".scalafmt.conf"
-      case _                                                        => true
+      case Update.Single("org.scala-sbt", "sbt", _, _, _, _) => f.name === "build.properties"
+      case Update.Single("org.scalameta", "scalafmt-core", _, _, _, _) =>
+        f.name === ".scalafmt.conf"
+      case _ => true
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -167,7 +167,7 @@ final class NurtureAlg[F[_]](
       update: Update
   ): List[Dependency] =
     update match {
-      case Update.Single(groupId, artifactId, _, _, _) =>
+      case Update.Single(groupId, artifactId, _, _, _, _) =>
         dependencies.filter(dep => dep.groupId === groupId && dep.artifactId === artifactId)
       case Update.Group(groupId, artifactIds, _, _) =>
         val artifactIdSet = artifactIds.toList.toSet

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -23,6 +23,7 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
+import org.scalasteward.core.repocache.RepoCacheRepository
 import org.scalasteward.core.sbt.command._
 import org.scalasteward.core.sbt.data.{ArtificialProject, SbtVersion}
 import org.scalasteward.core.scalafix.Migration
@@ -58,6 +59,7 @@ object SbtAlg {
       processAlg: ProcessAlg[F],
       workspaceAlg: WorkspaceAlg[F],
       scalafmtAlg: ScalafmtAlg[F],
+      cacheRepository: RepoCacheRepository[F],
       F: Monad[F]
   ): SbtAlg[F] =
     new SbtAlg[F] {
@@ -136,7 +138,7 @@ object SbtAlg {
           updates <- withTemporarySbtDependency(repo) {
             exec(sbtCmd(commands), repoDir).map(parser.parseSingleUpdates)
           }
-          originalDependencies <- getOriginalDependencies(repo)
+          originalDependencies <- cacheRepository.getDependencies(List(repo))
           updatesUnderNewGroupId = originalDependencies.flatMap(
             UpdateService.findUpdateUnderNewGroup
           )

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -27,6 +27,7 @@ import org.scalasteward.core.sbt.command._
 import org.scalasteward.core.sbt.data.{ArtificialProject, SbtVersion}
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.scalafmt.{scalafmtDependency, ScalafmtAlg}
+import org.scalasteward.core.update.UpdateService
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
@@ -91,9 +92,7 @@ object SbtAlg {
 
       override def getDependencies(repo: Repo): F[List[Dependency]] =
         for {
-          repoDir <- workspaceAlg.repoDir(repo)
-          cmd = sbtCmd(List(libraryDependenciesAsJson, reloadPlugins, libraryDependenciesAsJson))
-          lines <- exec(cmd, repoDir)
+          originalDependencies <- getOriginalDependencies(repo)
           maybeSbtVersion <- getSbtVersion(repo)
           maybeSbtDependency = maybeSbtVersion.flatMap(sbtDependency)
           maybeScalafmtVersion <- scalafmtAlg.getScalafmtVersion(repo)
@@ -101,7 +100,14 @@ object SbtAlg {
             scalafmtDependency(defaultScalaBinaryVersion)
           )
         } yield (maybeSbtDependency.toList ++ maybeScalafmtDependency.toList ++
-          parser.parseDependencies(lines)).distinct
+          originalDependencies).distinct
+
+      def getOriginalDependencies(repo: Repo): F[List[Dependency]] =
+        for {
+          repoDir <- workspaceAlg.repoDir(repo)
+          cmd = sbtCmd(List(libraryDependenciesAsJson, reloadPlugins, libraryDependenciesAsJson))
+          lines <- exec(cmd, repoDir)
+        } yield parser.parseDependencies(lines)
 
       override def getUpdatesForProject(project: ArtificialProject): F[List[Update.Single]] =
         for {
@@ -130,7 +136,11 @@ object SbtAlg {
           updates <- withTemporarySbtDependency(repo) {
             exec(sbtCmd(commands), repoDir).map(parser.parseSingleUpdates)
           }
-        } yield updates
+          originalDependencies <- getOriginalDependencies(repo)
+          updatesUnderNewGroupId = originalDependencies.flatMap(
+            UpdateService.findUpdateUnderNewGroup
+          )
+        } yield updates ++ updatesUnderNewGroupId
 
       override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] =
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -177,4 +177,17 @@ object UpdateService {
       case ("org.xerial.sbt", "sbt-pack")                    => false
       case _                                                 => true
     }
+
+  def getNewerGroupId(currentGroupId: String, artifactId: String): Option[(String, String)] =
+    Option((currentGroupId, artifactId) match {
+      case ("org.spire-math", "kind-projector") => ("org.typelevel", "0.10.0")
+      case ("com.geirsson", "sbt-scalafmt")     => ("org.scalameta", "2.0.0")
+      case _                                    => ("", "")
+    }).filter(_._1.nonEmpty)
+
+  def findUpdateUnderNewGroup(dep: Dependency): Option[Update.Single] =
+    getNewerGroupId(dep.groupId, dep.artifactId).map {
+      case (newId, fromVersion) =>
+        dep.toUpdate.copy(newerGroupId = Some(newId), newerVersions = util.Nel.of(fromVersion))
+    }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -183,7 +183,7 @@ object UpdateService {
       case ("org.spire-math", "kind-projector") => ("org.typelevel", "0.10.0")
       case ("com.geirsson", "sbt-scalafmt")     => ("org.scalameta", "2.0.0")
       case _                                    => ("", "")
-    }).filter(_._1.nonEmpty)
+    }).filter { case (groupId, _) => groupId.nonEmpty }
 
   def findUpdateUnderNewGroup(dep: Dependency): Option[Update.Single] =
     getNewerGroupId(dep.groupId, dep.artifactId).map {

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -109,6 +109,18 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
+  test("update under different group id") {
+    val original = """ "org.spire-math" %% "kind-projector" % "0.9.0""""
+    val expected = """ "org.typelevel" %% "kind-projector" % "0.10.0""""
+    Single(
+      "org.spire-math",
+      "kind-projector",
+      "0.9.0",
+      Nel.of("0.10.0"),
+      newerGroupId = Some("org.typelevel")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
+  }
+
   test("group with repeated version") {
     val original =
       """ "com.pepegar" %% "hammock-core"  % "0.8.1",

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -9,6 +9,8 @@ import org.scalasteward.core.coursier.CoursierAlg
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.{Author, GitAlg}
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
+import org.scalasteward.core.repocache.RepoCacheRepository
+import org.scalasteward.core.repocache.json.JsonRepoCacheRepository
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.scalafmt.ScalafmtAlg
@@ -56,6 +58,8 @@ object MockContext {
   implicit val gitHubRepoAlg: VCSRepoAlg[MockEff] = VCSRepoAlg.create(config, gitAlg)
   implicit val logAlg: LogAlg[MockEff] = new LogAlg[MockEff]
   implicit val scalafmtAlg: ScalafmtAlg[MockEff] = ScalafmtAlg.create
+  implicit val cacheRepository: RepoCacheRepository[MockEff] =
+    new JsonRepoCacheRepository[MockEff]()
   implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
   implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -59,7 +59,18 @@ class SbtAlgTest extends FunSuite with Matchers {
               "-no-colors",
               ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
             ),
-            List("rm", s"$repoDir/project/tmp-sbt-dep.sbt")
+            List("rm", s"$repoDir/project/tmp-sbt-dep.sbt"),
+            List(
+              "TEST_VAR=GREAT",
+              "ANOTHER_TEST_VAR=ALSO_GREAT",
+              repoDir.toString,
+              "firejail",
+              s"--whitelist=$repoDir",
+              "sbt",
+              "-batch",
+              "-no-colors",
+              ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
+            )
           )
         )
     }
@@ -91,6 +102,21 @@ class SbtAlgTest extends FunSuite with Matchers {
           ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
         ),
         List("restore", (repoDir / ".sbtopts").toString),
+        List("restore", (repoDir / ".jvmopts").toString),
+        List("rm", (repoDir / ".jvmopts").toString),
+        List("rm", (repoDir / ".sbtopts").toString),
+        List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
+          repoDir.toString,
+          "firejail",
+          s"--whitelist=$repoDir",
+          "sbt",
+          "-batch",
+          "-no-colors",
+          ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
+        ),
+        List("restore", (repoDir / ".sbtopts").toString),
         List("restore", (repoDir / ".jvmopts").toString)
       )
     )
@@ -118,6 +144,17 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-batch",
           "-no-colors",
           ";dependencyUpdates;reload plugins;dependencyUpdates"
+        ),
+        List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
+          repoDir.toString,
+          "firejail",
+          s"--whitelist=$repoDir",
+          "sbt",
+          "-batch",
+          "-no-colors",
+          ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
         )
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -60,17 +60,7 @@ class SbtAlgTest extends FunSuite with Matchers {
               ";set every credentials := Nil;dependencyUpdates;reload plugins;dependencyUpdates"
             ),
             List("rm", s"$repoDir/project/tmp-sbt-dep.sbt"),
-            List(
-              "TEST_VAR=GREAT",
-              "ANOTHER_TEST_VAR=ALSO_GREAT",
-              repoDir.toString,
-              "firejail",
-              s"--whitelist=$repoDir",
-              "sbt",
-              "-batch",
-              "-no-colors",
-              ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
-            )
+            List("read", s"/tmp/ws/repos_v05.json")
           )
         )
     }
@@ -103,21 +93,7 @@ class SbtAlgTest extends FunSuite with Matchers {
         ),
         List("restore", (repoDir / ".sbtopts").toString),
         List("restore", (repoDir / ".jvmopts").toString),
-        List("rm", (repoDir / ".jvmopts").toString),
-        List("rm", (repoDir / ".sbtopts").toString),
-        List(
-          "TEST_VAR=GREAT",
-          "ANOTHER_TEST_VAR=ALSO_GREAT",
-          repoDir.toString,
-          "firejail",
-          s"--whitelist=$repoDir",
-          "sbt",
-          "-batch",
-          "-no-colors",
-          ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
-        ),
-        List("restore", (repoDir / ".sbtopts").toString),
-        List("restore", (repoDir / ".jvmopts").toString)
+        List("read", s"/tmp/ws/repos_v05.json")
       )
     )
   }
@@ -145,17 +121,7 @@ class SbtAlgTest extends FunSuite with Matchers {
           "-no-colors",
           ";dependencyUpdates;reload plugins;dependencyUpdates"
         ),
-        List(
-          "TEST_VAR=GREAT",
-          "ANOTHER_TEST_VAR=ALSO_GREAT",
-          repoDir.toString,
-          "firejail",
-          s"--whitelist=$repoDir",
-          "sbt",
-          "-batch",
-          "-no-colors",
-          ";show libraryDependenciesAsJson;reload plugins;show libraryDependenciesAsJson"
-        )
+        List("read", s"/tmp/ws/repos_v05.json")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateServiceTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateServiceTest.scala
@@ -1,0 +1,27 @@
+package org.scalasteward.core.update
+
+import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.util.Nel
+import org.scalatest.{FunSuite, Matchers}
+
+class UpdateServiceTest extends FunSuite with Matchers {
+
+  test("findUpdateUnderNewGroup: returns empty if dep is not listed") {
+    val original = new Dependency("org.spire-math", "UNKNOWN", "_2.12", "1.0.0")
+    UpdateService.findUpdateUnderNewGroup(original) shouldBe None
+  }
+
+  test("findUpdateUnderNewGroup: returns Update.Single for updateing groupId") {
+    val original = new Dependency("org.spire-math", "kind-projector", "_2.12", "0.9.0")
+    UpdateService.findUpdateUnderNewGroup(original) shouldBe Some(
+      Update.Single(
+        "org.spire-math",
+        "kind-projector",
+        "0.9.0",
+        Nel.of("0.10.0"),
+        newerGroupId = Some("org.typelevel")
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
Closes #613

## kind-projector

```sbt
"org.spire-math" %% "kind-projector" % "0.9.10" ->
"org.typelevel"  %% "kind-projector" % "0.10.0" 
```
Example PR  https://github.com/exoego/scala-steward-test-project/pull/91

##  sbt-scalafmt

```sbt
"com.geirsson"  %% "sbt-scalafmt" % "1.6.0-RC3" ->
"org.scalameta" %% "sbt-scalafmt" % "2.0.2"
```
Example PR https://github.com/exoego/scala-steward-test-project/pull/90


## Note
For 1st iteration, these old-to-newer relations are stored in `UpdateService.getNewerGroupId` and needs manually updated.

