### PR TITLE
Travis Publish Docker Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,20 @@ cache:
   - "$HOME/.ivy2/cache"
   - "$HOME/.sbt/boot/"
 
-install:
-- pip install --user codecov
-script: sbt ++$TRAVIS_SCALA_VERSION validate
-after_success:
-- codecov
+stages:
+- name: test
+- name: release
+  if: (branch = master AND type = push) OR (tag IS present)
+
+jobs:
+  include:
+  - install:
+    - pip install --user codecov
+    script: sbt ++$TRAVIS_SCALA_VERSION validate
+    after_success:
+    - codecov
+  - stage: release
+    script: docker login -u $DOCKER_USER -p $DOCKER_PASS && sbt docker:publish
 
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/4573461025c642daa4128b659ee54fc9)](https://www.codacy.com/app/fthomas/scala-steward?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fthomas/scala-steward&amp;utm_campaign=Badge_Grade)
 [![Typelevel project](https://img.shields.io/badge/typelevel-project-brightgreen.svg)](https://typelevel.org/projects/#scala-steward)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-brightgreen.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
+[![Docker Pulls](https://img.shields.io/docker/pulls/fthomas/scala-steward.svg?style=flat)](https://hub.docker.com/r/fthomas/scala-steward/)
 
 Scala Steward is a robot that helps you keeping library dependencies
 and sbt plugins up-to-date.

--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,8 @@ def myCrossProject(name: String): CrossProject =
       }
     }))
 
+ThisBuild / dynverSeparator := "-"
+
 lazy val commonSettings = Def.settings(
   compileSettings,
   metadataSettings,
@@ -147,7 +149,10 @@ lazy val dockerSettings = Def.settings(
     Cmd("ADD", "opt", "/opt"),
     ExecCmd("ENTRYPOINT", "/opt/docker/bin/scala-steward"),
     ExecCmd("CMD", "")
-  )
+  ),
+  // TODO: change owner to gitHubOwner
+  Docker / packageName := s"slakah/${name.value}",
+  dockerUpdateLatest := true
 )
 
 lazy val noPublishSettings = Def.settings(

--- a/build.sbt
+++ b/build.sbt
@@ -150,8 +150,7 @@ lazy val dockerSettings = Def.settings(
     ExecCmd("ENTRYPOINT", "/opt/docker/bin/scala-steward"),
     ExecCmd("CMD", "")
   ),
-  // TODO: change owner to gitHubOwner
-  Docker / packageName := s"slakah/${name.value}",
+  Docker / packageName := s"${gitHubOwner}/${name.value}",
   dockerUpdateLatest := true
 )
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -20,7 +20,7 @@ Or,
 ```bash
 sbt docker:publishLocal
 
-docker run -v $STEWARD_DIR:/opt/scala-steward -it scala-steward:0.1.0-SNAPSHOT \
+docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
   --workspace  "/opt/scala-steward/workspace" \
   --repos-file "/opt/scala-steward/repos.md" \
   --git-author-name "Scala steward" \

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Based on the ask in #407 

## Description

This PR does the following:
* Set the tag of the sbt build docker image to be `latest` + version determine by [sbt-dynver](https://github.com/dwijnand/sbt-dynver).
* Docker image name updated to be `fthomas/scala-steward` (allows it to be published to dockerhub).
* Release stage added to `.travis.yml` which does a `docker login` using travis set environment variables `DOCKER_USER` and `DOCKER_PASS`. Changes to the travis build are inspired by 
other project https://github.com/fthomas/refined/blob/master/.travis.yml#L16 .
* Docker badge added to repo README.md

## Testing

I tested the travis build [on my fork](https://github.com/slakah/scala-steward), the test run of the release job can be seen [on travis](https://travis-ci.org/Slakah/scala-steward/jobs/556422648).

The docker image was successfully released and can be seen on [dockerhub](https://hub.docker.com/r/slakah/scala-steward).

## Next Steps

If we want to proceed with this PR, then the following will need to be done:

- [x] Set up the docker hub repo https://hub.docker.com/r/fthomas/scala-steward.
- [x] Add `DOCKER_USER` and `DOCKER_PASS` environment variables to travis.
