### PR TITLE
Document .scala-steward.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The [`docs`](docs) directory contains documentation about these topics:
 * [Running Scala Steward](docs/running.md)
 * [Scalafix Migrations](docs/scalafix-migrations.md)
 * [Frequently Asked Questions](docs/faq.md)
+* [Repository-specific configuration](docs/repo-specific-configuration.md)
 
 ## Contributors
 

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -1,0 +1,20 @@
+# Repository-specific configuration
+
+You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward updates your repository.
+
+```properties
+# The only dependencies which match the given pattern are updated.
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+updates.allow  = [ { groupId = "com.example" } ]
+
+# The dependencies which match the given pattern are NOT updated.
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
+updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
+
+# If true, Scala Steward will update the PR it created to resolve conflicts as
+# long as you don't change it yourself.
+# Default: true
+updatePullRequests = true
+```


### PR DESCRIPTION
This PR adds a document about `.scala-steward.conf` fille.
It will be a basis for upcoming new features like https://github.com/fthomas/scala-steward/issues/678