### PR TITLE
Rename DependencyService to RepoCacheAlg and store sbt versions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -21,8 +21,8 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.scalasteward.core.dependency.json.JsonDependencyRepository
-import org.scalasteward.core.dependency.{DependencyRepository, DependencyService}
+import org.scalasteward.core.repocache.json.JsonRepoCacheRepository
+import org.scalasteward.core.repocache.{RepoCacheAlg, RepoCacheRepository}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -54,17 +54,17 @@ object Context {
       implicit val workspaceAlg: WorkspaceAlg[F] = WorkspaceAlg.create[F]
       implicit val repoConfigAlg: RepoConfigAlg[F] = new RepoConfigAlg[F]
       implicit val filterAlg: FilterAlg[F] = new FilterAlg[F]
-      implicit val dependencyRepository: DependencyRepository[F] = new JsonDependencyRepository[F]
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
+      implicit val repoCacheRepository: RepoCacheRepository[F] = new JsonRepoCacheRepository[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
       implicit val pullRequestRepo: PullRequestRepository[F] = new JsonPullRequestRepo[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
+      implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F]
       implicit val editAlg: EditAlg[F] = new EditAlg[F]
       implicit val updateRepository: UpdateRepository[F] = new JsonUpdateRepository[F]
-      implicit val dependencyService: DependencyService[F] = new DependencyService[F]
       implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F]
       implicit val updateService: UpdateService[F] = new UpdateService[F]
       new StewardAlg[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -21,7 +21,7 @@ import cats.Monad
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.dependency.DependencyService
+import org.scalasteward.core.repocache.RepoCacheAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
 import org.scalasteward.core.sbt.SbtAlg
@@ -32,11 +32,11 @@ import org.scalasteward.core.vcs.data.Repo
 final class StewardAlg[F[_]](
     implicit
     config: Config,
-    dependencyService: DependencyService[F],
     fileAlg: FileAlg[F],
     logAlg: LogAlg[F],
     logger: Logger[F],
     nurtureAlg: NurtureAlg[F],
+    repoCacheAlg: RepoCacheAlg[F],
     sbtAlg: SbtAlg[F],
     updateService: UpdateService[F],
     workspaceAlg: WorkspaceAlg[F],
@@ -58,7 +58,7 @@ final class StewardAlg[F[_]](
   def pruneRepos(repos: List[Repo]): F[List[Repo]] =
     logAlg.infoTotalTime("pruning repos") {
       for {
-        _ <- repos.traverse(dependencyService.checkDependencies)
+        _ <- repos.traverse(repoCacheAlg.checkCache)
         allUpdates <- updateService.checkForUpdates(repos)
         filteredRepos <- updateService.filterByApplicableUpdates(repos, allUpdates)
         countTotal = repos.size

--- a/modules/core/src/main/scala/org/scalasteward/core/model/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/model/Dependency.scala
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.dependency
+package org.scalasteward.core.model
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.util.Nel
 

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -17,10 +17,9 @@
 package org.scalasteward.core.nurture
 
 import org.http4s.Uri
-import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 
 trait PullRequestRepository[F[_]] {
   def createOrUpdate(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
@@ -21,11 +21,10 @@ import cats.implicits._
 import io.circe.parser.decode
 import io.circe.syntax._
 import org.http4s.Uri
-import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.update.UpdateService
 import org.scalasteward.core.util.MonadThrowable

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -20,12 +20,14 @@ import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.model.Dependency
+import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.sbt.data.SbtVersion
 
 final case class RepoCache(
     sha1: Sha1,
     dependencies: List[Dependency],
-    maybeSbtVersion: Option[SbtVersion]
+    maybeSbtVersion: Option[SbtVersion],
+    maybeRepoConfig: Option[RepoConfig]
 )
 
 object RepoCache {

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.dependency.json
+package org.scalasteward.core.repocache
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.git.Sha1
+import org.scalasteward.core.model.Dependency
+import org.scalasteward.core.sbt.data.SbtVersion
 
-final case class RepoStore(store: Map[Repo, RepoData])
+final case class RepoCache(
+    sha1: Sha1,
+    dependencies: List[Dependency],
+    maybeSbtVersion: Option[SbtVersion]
+)
 
-object RepoStore {
-  implicit val repoStoreDecoder: Decoder[RepoStore] =
+object RepoCache {
+  implicit val repoCacheDecoder: Decoder[RepoCache] =
     deriveDecoder
 
-  implicit val repoStoreEncoder: Encoder[RepoStore] =
+  implicit val repoCacheEncoder: Encoder[RepoCache] =
     deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.dependency
+package org.scalasteward.core.repocache
 
+import cats.Functor
+import cats.implicits._
 import org.scalasteward.core.git.Sha1
+import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.vcs.data.Repo
 
-trait DependencyRepository[F[_]] {
-  def findSha1(repo: Repo): F[Option[Sha1]]
+trait RepoCacheRepository[F[_]] {
+  def findCache(repo: Repo): F[Option[RepoCache]]
+
+  def updateCache(repo: Repo, repoCache: RepoCache): F[Unit]
 
   def getDependencies(repos: List[Repo]): F[List[Dependency]]
 
-  def setDependencies(repo: Repo, sha1: Sha1, dependencies: List[Dependency]): F[Unit]
+  final def findSha1(repo: Repo)(implicit F: Functor[F]): F[Option[Sha1]] =
+    findCache(repo).map(_.map(_.sha1))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/json/RepoStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/json/RepoStore.scala
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.dependency.json
+package org.scalasteward.core.repocache.json
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.dependency.Dependency
-import org.scalasteward.core.git.Sha1
+import org.scalasteward.core.repocache.RepoCache
+import org.scalasteward.core.vcs.data.Repo
 
-final case class RepoData(
-    sha1: Sha1,
-    dependencies: List[Dependency]
-)
+final case class RepoStore(store: Map[Repo, RepoCache])
 
-object RepoData {
-  implicit val repoDataDecoder: Decoder[RepoData] =
+object RepoStore {
+  implicit val repoStoreDecoder: Decoder[RepoStore] =
     deriveDecoder
 
-  implicit val repoDataEncoder: Encoder[RepoData] =
+  implicit val repoStoreEncoder: Encoder[RepoStore] =
     deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core.repoconfig
 
-import io.circe.Decoder
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveDecoder
+import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
 
 final case class RepoConfig(
     updates: UpdatesConfig = UpdatesConfig(),
@@ -33,4 +33,7 @@ object RepoConfig {
 
   implicit val repoConfigDecoder: Decoder[RepoConfig] =
     deriveDecoder
+
+  implicit val repoConfigEncoder: Encoder[RepoConfig] =
+    deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.repoconfig
 
 import cats.implicits._
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.model.Update
 
 final case class UpdatePattern(
@@ -42,4 +42,7 @@ object UpdatePattern {
 
   implicit val updatePatternDecoder: Decoder[UpdatePattern] =
     deriveDecoder
+
+  implicit val updatePatternEncoder: Encoder[UpdatePattern] =
+    deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -17,9 +17,9 @@
 package org.scalasteward.core.repoconfig
 
 import cats.implicits._
-import io.circe.Decoder
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveDecoder
+import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.model.Update
 import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig}
 
@@ -48,4 +48,7 @@ object UpdatesConfig {
 
   implicit val updatesConfigDecoder: Decoder[UpdatesConfig] =
     deriveDecoder
+
+  implicit val updatesConfigEncoder: Encoder[UpdatesConfig] =
+    deriveEncoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -21,9 +21,8 @@ import cats.implicits._
 import cats.{Functor, Monad}
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.sbt.command._
 import org.scalasteward.core.sbt.data.{ArtificialProject, SbtVersion}
 import org.scalasteward.core.scalafix.Migration

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.sbt.data
 
-import org.scalasteward.core.dependency.Dependency
 import org.scalasteward.core.io.FileData
+import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.sbt.command.{dependencyUpdates, reloadPlugins}
 import org.scalasteward.core.util
 import scala.collection.mutable.ListBuffer

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -18,8 +18,7 @@ package org.scalasteward.core.sbt
 
 import cats.implicits._
 import io.circe.parser.decode
-import org.scalasteward.core.dependency.Dependency
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.util.Nel
 
 object parser {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -17,8 +17,7 @@
 package org.scalasteward.core.update.data
 
 import org.http4s.Uri
-import org.scalasteward.core.dependency.Dependency
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 
 sealed trait UpdateState extends Product with Serializable {
   def dependency: Dependency

--- a/modules/core/src/main/scala/org/scalasteward/core/update/splitter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/splitter.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.implicits._
 import eu.timepit.refined.types.numeric.PosInt
-import org.scalasteward.core.dependency.Dependency
+import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.util
 
 object splitter {

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.sbt.data
 
-import org.scalasteward.core.dependency.Dependency
+import org.scalasteward.core.model.Dependency
 import org.scalatest.{FunSuite, Matchers}
 
 class ArtificialProjectTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -1,7 +1,6 @@
 package org.scalasteward.core.sbt
 
-import org.scalasteward.core.dependency.Dependency
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.sbt.parser._
 import org.scalasteward.core.util.Nel


### PR DESCRIPTION
Storing the sbt versions will be useful later to determine which repos
use an outdated sbt version.