### PR TITLE
Include sbt in update check

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -47,17 +47,7 @@ trait SbtAlg[F[_]] {
   def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit]
 
   final def getSbtUpdate(repo: Repo)(implicit F: Functor[F]): F[Option[Update.Single]] =
-    getSbtVersion(repo).map { maybeCurrentVersion =>
-      for {
-        currentVersion <- maybeCurrentVersion
-        newerVersion <- findNewerSbtVersion(currentVersion)
-      } yield Update.Single(
-        "org.scala-sbt",
-        "sbt",
-        currentVersion.value,
-        Nel.of(newerVersion.value)
-      )
-    }
+    getSbtVersion(repo).map(_.flatMap(findSbtUpdate))
 }
 
 object SbtAlg {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -19,7 +19,9 @@ package org.scalasteward.core
 import cats.effect.{IO, Resource}
 import cats.implicits._
 import org.scalasteward.core.io.FileData
+import org.scalasteward.core.model.Update
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
+import org.scalasteward.core.util.Nel
 import scala.io.Source
 
 package object sbt {
@@ -39,6 +41,11 @@ package object sbt {
       case v if v.startsWith("1.")    => Some(defaultSbtVersion)
       case _                          => None
     }).filter(_.toVersion > sbtVersion.toVersion)
+
+  def findSbtUpdate(currentVersion: SbtVersion): Option[Update.Single] =
+    findNewerSbtVersion(currentVersion).map { newerVersion =>
+      Update.Single("org.scala-sbt", "sbt", currentVersion.value, Nel.of(newerVersion.value))
+    }
 
   def seriesToSpecificVersion(sbtSeries: SbtVersion): SbtVersion =
     sbtSeries.value match {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -37,9 +37,10 @@ package object sbt {
 
   def findNewerSbtVersion(sbtVersion: SbtVersion): Option[SbtVersion] =
     (sbtVersion.value match {
-      case v if v.startsWith("0.13.") => Some(latestSbtVersion_0_13)
-      case v if v.startsWith("1.")    => Some(defaultSbtVersion)
-      case _                          => None
+      case v if v.startsWith("0.13.")    => Some(latestSbtVersion_0_13)
+      case v if v.startsWith("1.3.0-RC") => Some(SbtVersion("1.3.0-RC2"))
+      case v if v.startsWith("1.")       => Some(defaultSbtVersion)
+      case _                             => None
     }).filter(_.toVersion > sbtVersion.toVersion)
 
   def findSbtUpdate(currentVersion: SbtVersion): Option[Update.Single] =

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
@@ -13,7 +13,8 @@ class sbtTest extends FunSuite with Matchers {
       (SbtVersion("0.13.16"), Some(latestSbtVersion_0_13)),
       (defaultSbtVersion, None),
       (latestSbtVersion_0_13, None),
-      (SbtVersion("1.3.0-RC1"), None)
+      (SbtVersion("1.3.0-RC1"), Some(SbtVersion("1.3.0-RC2"))),
+      (SbtVersion("1.3.0-RC2"), None)
     )
 
     forAll(versions) { (curr: SbtVersion, maybeNewer: Option[SbtVersion]) =>


### PR DESCRIPTION
This includes sbt in the update check which prunes repositories so that
Scala Steward only looks at repositories where it does something.
With this change Scala Steward should update sbt in all repositories.