### PR TITLE
Use nextVersion when looking for existing PRs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.nurture
 
 import org.http4s.Uri
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 import org.scalasteward.core.model.{Dependency, Update}
+import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 
 trait PullRequestRepository[F[_]] {
   def createOrUpdate(
@@ -30,7 +30,9 @@ trait PullRequestRepository[F[_]] {
       state: PullRequestState
   ): F[Unit]
 
-  def findUpdates(repo: Repo, baseSha1: Sha1): F[List[Update]]
-
-  def findPullRequest(repo: Repo, dependency: Dependency): F[Option[(Uri, Sha1, PullRequestState)]]
+  def findPullRequest(
+      repo: Repo,
+      dependency: Dependency,
+      newVersion: String
+  ): F[Option[(Uri, Sha1, PullRequestState)]]
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -143,7 +143,7 @@ final class UpdateService[F[_]](
     updates.find(UpdateService.isUpdateFor(_, dependency)) match {
       case None => F.pure(DependencyUpToDate(dependency))
       case Some(update) =>
-        pullRequestRepo.findPullRequest(repo, dependency).map {
+        pullRequestRepo.findPullRequest(repo, dependency, update.nextVersion).map {
           case None =>
             DependencyOutdated(dependency, update)
           case Some((uri, _, state)) if state === Closed =>


### PR DESCRIPTION
When searching for already existing PRs, we need to take the newest
version number into account so that we don't find PRs that update
to older versions.