### PR TITLE
Rename package "model" to "data"

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -21,8 +21,8 @@ import cats.effect.Sync
 import org.http4s.Uri
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
-import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.util
+import org.scalasteward.core.vcs.data.AuthenticatedUser
 import scala.sys.process.Process
 
 /** Configuration for scala-steward.

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -21,13 +21,13 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
-import org.scalasteward.core.repocache.json.JsonRepoCacheRepository
-import org.scalasteward.core.repocache.{RepoCacheAlg, RepoCacheRepository}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.json.JsonPullRequestRepo
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository}
+import org.scalasteward.core.repocache.json.JsonRepoCacheRepository
+import org.scalasteward.core.repocache.{RepoCacheAlg, RepoCacheRepository}
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.json.JsonUpdateRepository
@@ -35,7 +35,6 @@ import org.scalasteward.core.update.{FilterAlg, UpdateRepository, UpdateService}
 import org.scalasteward.core.util.{DateTimeAlg, HttpJsonClient, LogAlg}
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg, VCSSelection}
-
 import scala.concurrent.ExecutionContext
 
 object Context {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -21,9 +21,9 @@ import cats.Monad
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.repocache.RepoCacheAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg
+import org.scalasteward.core.repocache.RepoCacheAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.UpdateService
 import org.scalasteward.core.util.LogAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SupportedVCS.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SupportedVCS.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.application
 
-import cats.Eq
-import cats.implicits._
 import caseapp.core.Error.MalformedValue
 import caseapp.core.argparser.ArgParser
+import cats.Eq
+import cats.implicits._
 
 sealed trait SupportedVCS {
   import SupportedVCS.{Bitbucket, GitHub, Gitlab}

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucket/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucket/Url.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.bitbucket
 
 import org.http4s.Uri
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.git.Branch
+import org.scalasteward.core.vcs.data.Repo
 
 private[bitbucket] class Url(apiHost: Uri) {
 

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/Http4sBitbucketApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/Http4sBitbucketApiAlg.scala
@@ -18,21 +18,14 @@ package org.scalasteward.core.bitbucket.http4s
 
 import cats.effect.Sync
 import cats.implicits._
-import org.http4s.{Request, Status, Uri}
 import org.http4s.client.UnexpectedStatus
-import org.scalasteward.core.git.Branch
+import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.bitbucket.Url
 import org.scalasteward.core.bitbucket.http4s.json._
+import org.scalasteward.core.git.Branch
 import org.scalasteward.core.util.HttpJsonClient
-import org.scalasteward.core.vcs.data.{
-  AuthenticatedUser,
-  BranchOut,
-  NewPullRequestData,
-  PullRequestOut,
-  Repo,
-  RepoOut
-}
 import org.scalasteward.core.vcs.VCSApiAlg
+import org.scalasteward.core.vcs.data._
 
 class Http4sBitbucketApiAlg[F[_]: Sync](
     bitbucketApiHost: Uri,

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/authentication.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/authentication.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.bitbucket.http4s
 
 import cats.Applicative
 import cats.implicits._
-import org.http4s.{BasicCredentials, Request}
 import org.http4s.headers.Authorization
+import org.http4s.{BasicCredentials, Request}
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 
 object authentication {

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucket/http4s/json.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.bitbucket.http4s
 
-import io.circe.{Decoder}
+import io.circe.Decoder
 import org.http4s.Uri
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.uri.uriDecoder

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}

--- a/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import cats.implicits._
 import eu.timepit.refined.cats.refTypeEq
 import eu.timepit.refined.types.numeric.NonNegBigInt
 import eu.timepit.refined.types.string.NonEmptyString
-import org.scalasteward.core.model.SemVer.Change._
+import org.scalasteward.core.data.SemVer.Change._
 import org.scalasteward.core.util.string.parseNonNegBigInt
 
 final case class SemVer(

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import cats.implicits._
 import eu.timepit.refined.W
 import io.circe.{Decoder, Encoder}
 import monocle.Lens
-import org.scalasteward.core.model.Update.{Group, Single}
+import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.string.MinLengthString

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import cats.Order
 import cats.implicits._

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -21,8 +21,8 @@ import cats.Traverse
 import cats.effect.Sync
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{isFileSpecificTo, isSourceFile, FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.scalafix
 import org.scalasteward.core.util._

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit
 
 import cats.implicits._
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex

--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -21,9 +21,9 @@ import cats.effect.Bracket
 import cats.implicits._
 import org.http4s.Uri
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.util.{MonadThrowable, Nel}
+import org.scalasteward.core.vcs.data.Repo
 
 trait GitAlg[F[_]] {
   def branchAuthors(repo: Repo, branch: Branch, base: Branch): F[List[String]]

--- a/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/package.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core
 
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.update.show
 
 package object git {

--- a/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/github/http4s/Http4sGitHubApiAlg.scala
@@ -20,8 +20,8 @@ import org.http4s.{Request, Uri}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.github._
 import org.scalasteward.core.util.HttpJsonClient
-import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.vcs.VCSApiAlg
+import org.scalasteward.core.vcs.data._
 
 final class Http4sGitHubApiAlg[F[_]](
     gitHubApiHost: Uri,

--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -19,15 +19,14 @@ package org.scalasteward.core.gitlab.http4s
 import cats.implicits._
 import io.circe._
 import io.circe.generic.semiauto._
-import org.scalasteward.core.util.HttpJsonClient
 import org.http4s.client.UnexpectedStatus
 import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.vcs.data._
-import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.gitlab._
+import org.scalasteward.core.util.{HttpJsonClient, MonadThrowable}
 import org.scalasteward.core.util.uri.uriDecoder
-import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.vcs.VCSApiAlg
+import org.scalasteward.core.vcs.data._
 
 final private[http4s] case class ForkPayload(id: String, namespace: String)
 final private[http4s] case class MergeRequestPayload(

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import better.files.File
 import cats.implicits._
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 package object io {
   def isSourceFile(file: File): Boolean = {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -19,14 +19,14 @@ package org.scalasteward.core.nurture
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.{Branch, GitAlg}
-import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.FilterAlg
 import org.scalasteward.core.util.{BracketThrowable, LogAlg}
+import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 import org.scalasteward.core.{git, util, vcs}
 

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.nurture
 
 import org.http4s.Uri
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 
 trait PullRequestRepository[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/UpdateData.scala
@@ -16,10 +16,10 @@
 
 package org.scalasteward.core.nurture
 
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.vcs.data.Repo
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.vcs.data.Repo
 
 final case class UpdateData(
     repo: Repo,

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/JsonPullRequestRepo.scala
@@ -21,9 +21,9 @@ import cats.implicits._
 import io.circe.parser.decode
 import io.circe.syntax._
 import org.http4s.Uri
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.update.UpdateService
 import org.scalasteward.core.util.MonadThrowable

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/json/PullRequestData.scala
@@ -18,9 +18,9 @@ package org.scalasteward.core.nurture.json
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.vcs.data.PullRequestState
-import org.scalasteward.core.model.Update
 
 final case class PullRequestData(
     baseSha1: Sha1,

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.repocache
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.data.Dependency
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.sbt.data.SbtVersion
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheRepository.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core.repocache
 
 import cats.Functor
 import cats.implicits._
+import org.scalasteward.core.data.Dependency
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.vcs.data.Repo
 
 trait RepoCacheRepository[F[_]] {

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/json/JsonRepoCacheRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/json/JsonRepoCacheRepository.scala
@@ -20,8 +20,8 @@ import better.files.File
 import cats.implicits._
 import io.circe.parser.decode
 import io.circe.syntax._
+import org.scalasteward.core.data.Dependency
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
 import org.scalasteward.core.util.MonadThrowable
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -20,8 +20,8 @@ import cats.data.OptionT
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import io.circe.config.parser
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.repoconfig.RepoConfigAlg._
 import org.scalasteward.core.util.MonadThrowable
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repoconfig
 import cats.implicits._
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 final case class UpdatePattern(
     groupId: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig}
 
 final case class UpdatesConfig(

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -21,8 +21,8 @@ import cats.implicits._
 import cats.{Functor, Monad}
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
-import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.sbt.command._
 import org.scalasteward.core.sbt.data.{ArtificialProject, SbtVersion}
 import org.scalasteward.core.scalafix.Migration

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/data/ArtificialProject.scala
@@ -16,8 +16,8 @@
 
 package org.scalasteward.core.sbt.data
 
+import org.scalasteward.core.data.Dependency
 import org.scalasteward.core.io.FileData
-import org.scalasteward.core.model.Dependency
 import org.scalasteward.core.sbt.command.{dependencyUpdates, reloadPlugins}
 import org.scalasteward.core.util
 import scala.collection.mutable.ListBuffer

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/data/SbtVersion.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.sbt.data
 
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.model.Version
+import org.scalasteward.core.data.Version
 
 final case class SbtVersion(value: String) {
   def toVersion: Version = Version(value)

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -18,8 +18,8 @@ package org.scalasteward.core
 
 import cats.effect.{IO, Resource}
 import cats.implicits._
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.FileData
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.util.Nel
 import scala.io.Source

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.sbt
 
 import cats.implicits._
 import io.circe.parser.decode
-import org.scalasteward.core.model.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.util.Nel
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.scalafix
 
-import org.scalasteward.core.model.Version
+import org.scalasteward.core.data.Version
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core
 
 import cats.implicits._
-import org.scalasteward.core.model.{Update, Version}
+import org.scalasteward.core.data.{Update, Version}
 import org.scalasteward.core.util.Nel
 
 package object scalafix {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.update
 import cats.implicits._
 import cats.{Monad, TraverseFilter}
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.FilterAlg._
 import org.scalasteward.core.util

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateRepository.scala
@@ -16,7 +16,7 @@
 
 package org.scalasteward.core.update
 
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 trait UpdateRepository[F[_]] {
   def deleteAll: F[Unit]

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -18,18 +18,18 @@ package org.scalasteward.core.update
 
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.model.{Dependency, Update}
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.RepoCacheRepository
 import org.scalasteward.core.sbt._
 import org.scalasteward.core.sbt.data.ArtificialProject
 import org.scalasteward.core.update.data.UpdateState
 import org.scalasteward.core.update.data.UpdateState._
-import org.scalasteward.core.{sbt, util}
 import org.scalasteward.core.util.MonadThrowable
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.{sbt, util}
 
 final class UpdateService[F[_]](
     implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.update.data
 
 import org.http4s.Uri
-import org.scalasteward.core.model.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, Update}
 
 sealed trait UpdateState extends Product with Serializable {
   def dependency: Dependency

--- a/modules/core/src/main/scala/org/scalasteward/core/update/json/JsonUpdateRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/json/JsonUpdateRepository.scala
@@ -20,8 +20,8 @@ import better.files.File
 import cats.implicits._
 import io.circe.parser.decode
 import io.circe.syntax._
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
-import org.scalasteward.core.model.Update
 import org.scalasteward.core.update.UpdateRepository
 import org.scalasteward.core.util.MonadThrowable
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/json/UpdateStore.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/json/UpdateStore.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update.json
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 final case class UpdateStore(store: Set[Update.Single])
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.Traverse
 import cats.implicits._
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/splitter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/splitter.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.implicits._
 import eu.timepit.refined.types.numeric.PosInt
-import org.scalasteward.core.model.Dependency
+import org.scalasteward.core.data.Dependency
 import org.scalasteward.core.util
 
 object splitter {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/logger.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.util
 
 import cats.implicits._
 import cats.{Foldable, Functor}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 object logger {
   def showUpdates[F[_]: Foldable: Functor](updates: F[Update]): String = {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -16,9 +16,9 @@
 
 package org.scalasteward.core
 
+import cats._
 import cats.effect.Bracket
 import cats.implicits._
-import cats._
 import eu.timepit.refined.types.numeric.PosInt
 import fs2.Pipe
 import scala.annotation.tailrec

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSApiAlg.scala
@@ -20,8 +20,8 @@ import cats.Monad
 import cats.implicits._
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.vcs.data._
 import org.scalasteward.core.util.MonadThrowable
+import org.scalasteward.core.vcs.data._
 
 trait VCSApiAlg[F[_]] {
 

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -19,10 +19,10 @@ package org.scalasteward.core.vcs
 import cats.effect.Sync
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.application.SupportedVCS.{Bitbucket, GitHub, Gitlab}
-import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.bitbucket.http4s.Http4sBitbucketApiAlg
 import org.scalasteward.core.github.http4s.Http4sGitHubApiAlg
 import org.scalasteward.core.gitlab.http4s.Http4sGitLabApiAlg
+import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 
 class VCSSelection[F[_]: Sync](implicit client: HttpJsonClient[F], user: AuthenticatedUser) {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -19,8 +19,8 @@ package org.scalasteward.core.vcs.data
 import cats.implicits._
 import io.circe.Encoder
 import io.circe.generic.semiauto._
+import org.scalasteward.core.data.{SemVer, Update}
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.model.{SemVer, Update}
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.{git, scalafix}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestOut.scala
@@ -20,8 +20,8 @@ import cats.implicits._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import org.http4s.Uri
-import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.util.uri.uriDecoder
+import org.scalasteward.core.vcs.data.PullRequestState.Closed
 
 final case class PullRequestOut(
     html_url: Uri,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -17,11 +17,9 @@
 package org.scalasteward.core
 
 import org.scalasteward.core.application.SupportedVCS
-import org.scalasteward.core.application.SupportedVCS.Bitbucket
-import org.scalasteward.core.application.SupportedVCS.GitHub
-import org.scalasteward.core.application.SupportedVCS.Gitlab
+import org.scalasteward.core.application.SupportedVCS.{Bitbucket, GitHub, Gitlab}
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.vcs.data.Repo
-import org.scalasteward.core.model.Update
 
 package object vcs {
 

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalasteward.core.model.Version
+import org.scalasteward.core.data.Version
 
 object TestInstances {
   implicit val arbitraryVersion: Arbitrary[Version] = {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
@@ -1,7 +1,7 @@
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import org.scalasteward.core.edit.UpdateHeuristicTest.UpdateOps
-import org.scalasteward.core.model.Update.Single
+import org.scalasteward.core.data.Update.Single
 import org.scalasteward.core.util.Nel
 import org.scalatest.{Matchers, WordSpec}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/SemVerTest.scala
@@ -1,8 +1,8 @@
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import eu.timepit.refined.types.numeric.NonNegBigInt
 import eu.timepit.refined.types.string.NonEmptyString
-import org.scalasteward.core.model.SemVer.Change
+import org.scalasteward.core.data.SemVer.Change
 import org.scalatest.{FunSuite, Matchers}
 
 class SemVerTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -1,6 +1,6 @@
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
-import org.scalasteward.core.model.Update.{Group, Single}
+import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.model
+package org.scalasteward.core.data
 
 import cats.implicits._
 import cats.kernel.Comparison.{EqualTo, GreaterThan, LessThan}

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.edit
 import better.files.File
 import org.scalasteward.core.mock.MockContext.editAlg
 import org.scalasteward.core.mock.MockState
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.{FunSuite, Matchers}

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -1,8 +1,8 @@
 package org.scalasteward.core.edit
 
 import org.scalasteward.core.edit.UpdateHeuristicTest.UpdateOps
-import org.scalasteward.core.model.Update
-import org.scalasteward.core.model.Update.{Group, Single}
+import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -4,7 +4,7 @@ import better.files.File
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.mock.MockContext.repoConfigAlg
 import org.scalasteward.core.mock.MockState
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -4,7 +4,7 @@ import better.files.File
 import org.scalasteward.core.application.Config
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.{MockContext, MockState}
-import org.scalasteward.core.model.{Update, Version}
+import org.scalasteward.core.data.{Update, Version}
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.sbt.data
 
-import org.scalasteward.core.model.Dependency
+import org.scalasteward.core.data.Dependency
 import org.scalatest.{FunSuite, Matchers}
 
 class ArtificialProjectTest extends FunSuite with Matchers {

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.sbt
 
-import org.scalasteward.core.model.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.sbt.parser._
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -3,7 +3,7 @@ package org.scalasteward.core.update
 import cats.implicits._
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
 import org.scalasteward.core.update.FilterAlg.{BadVersions, NonSnapshotToSnapshotUpdate}
 import org.scalasteward.core.util.Nel

--- a/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.update
 
-import org.scalasteward.core.model.Update.{Group, Single}
+import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -4,7 +4,7 @@ import org.scalasteward.core.application.SupportedVCS.GitHub
 import org.scalasteward.core.application.SupportedVCS.Gitlab
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 
 import org.scalatest.{FunSuite, Matchers}
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
 import org.scalasteward.core.git.{Branch, Sha1}
-import org.scalasteward.core.model.Update
+import org.scalasteward.core.data.Update
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel


### PR DESCRIPTION
To be consistent with other packages that use `data` subpackages for
organizing data classes.