### PR TITLE
Add Change datatype

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
@@ -23,6 +23,10 @@ import scala.collection.mutable
 import scala.util.matching.Regex
 
 package object edit {
+
+  /** Like `replaceSomeInChange` but does not change anything between
+    * `scala-steward:off` and `scala-steward:on` markers.
+    */
   def replaceSomeInAllowedParts(
       regex: Regex,
       target: CharSequence,

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/package.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core
+
+import cats.implicits._
+import org.scalasteward.core.util.Change.Unchanged
+import org.scalasteward.core.util.{Change, Nel}
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+package object edit {
+  def replaceSomeInAllowedParts(
+      regex: Regex,
+      target: CharSequence,
+      replacer: Regex.Match => Option[String]
+  ): Change[String] =
+    splitByOffOnMarker(target.toString).foldMap {
+      case (part, true)  => util.string.replaceSomeInChange(regex, part, replacer)
+      case (part, false) => Unchanged(part)
+    }
+
+  private[edit] def splitByOffOnMarker(target: String): Nel[(String, Boolean)] =
+    if (!target.contains("scala-steward:off")) {
+      Nel.of((target, true))
+    } else {
+      val buffer = mutable.ListBuffer.empty[(String, Boolean)]
+      val on = StringBuilder.newBuilder
+      val off = StringBuilder.newBuilder
+      val regexIgnoreMultiLinesBegins = "^\\s*//\\s*scala-steward:off".r
+      def flush(builder: StringBuilder, canReplace: Boolean): Unit =
+        if (builder.nonEmpty) {
+          buffer.append((builder.toString(), canReplace))
+          builder.clear()
+        }
+      target.linesWithSeparators.foreach { line =>
+        if (off.nonEmpty) {
+          if (line.contains("scala-steward:on")) {
+            flush(off, false)
+            on.append(line)
+          } else {
+            off.append(line)
+          }
+        } else if (line.contains("scala-steward:off")) {
+          flush(on, true)
+          if (regexIgnoreMultiLinesBegins.findFirstIn(line).isDefined) {
+            off.append(line)
+          } else {
+            // single line off
+            buffer.append((line, false))
+          }
+        } else on.append(line)
+      }
+      flush(on, true)
+      flush(off, false)
+      Nel.fromListUnsafe(buffer.toList)
+    }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Change.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Change.scala
@@ -19,10 +19,19 @@ package org.scalasteward.core.util
 import cats.{Eq, Monoid}
 import org.scalasteward.core.util.Change.Changed
 
-sealed trait Change[T] {
+/** Data type that indicates whether some value of type `T` has been changed
+  * or not via its two constructors `Changed` and `Unchanged`.
+  *
+  * It is isomorphic to `(T, Boolean)`.
+  *
+  * `Change[T]` is a monoid for any monoid `T` with `Unchanged(T.empty)` as
+  * empty element and `Changed` combined with any other `Change` results in a
+  * `Changed` of the combined `T` values.
+  */
+sealed trait Change[T] extends Product with Serializable {
   def value: T
 
-  def someIfChanged: Option[T] =
+  final def someIfChanged: Option[T] =
     this match {
       case Changed(t) => Some(t)
       case _          => None

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Change.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Change.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.util
+
+import cats.{Eq, Monoid}
+import org.scalasteward.core.util.Change.Changed
+
+sealed trait Change[T] {
+  def value: T
+
+  def someIfChanged: Option[T] =
+    this match {
+      case Changed(t) => Some(t)
+      case _          => None
+    }
+}
+
+object Change {
+  final case class Changed[T](value: T) extends Change[T]
+  final case class Unchanged[T](value: T) extends Change[T]
+
+  implicit def changeEq[T](implicit T: Eq[T]): Eq[Change[T]] =
+    Eq.instance { (c1, c2) =>
+      (c1, c2) match {
+        case (Changed(t1), Changed(t2))     => T.eqv(t1, t2)
+        case (Unchanged(t1), Unchanged(t2)) => T.eqv(t1, t2)
+        case _                              => false
+      }
+    }
+
+  implicit def changeMonoid[T](implicit T: Monoid[T]): Monoid[Change[T]] =
+    new Monoid[Change[T]] {
+      override def empty: Change[T] = Unchanged(T.empty)
+
+      override def combine(c1: Change[T], c2: Change[T]): Change[T] =
+        (c1, c2) match {
+          case (Unchanged(t1), Unchanged(t2)) => Unchanged(T.combine(t1, t2))
+          case _                              => Changed(T.combine(c1.value, c2.value))
+        }
+    }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -22,6 +22,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.MinSize
 import eu.timepit.refined.refineV
 import eu.timepit.refined.types.numeric.NonNegBigInt
+import org.scalasteward.core.util.Change.{Changed, Unchanged}
 import scala.util.Try
 import scala.util.matching.Regex
 import shapeless.Witness
@@ -63,26 +64,15 @@ object string {
   /** Like `Regex.replaceSomeIn` but indicates via the return type if there
     * was at least one match that has been replaced.
     */
-  def replaceSomeInOpt(
+  def replaceSomeInChange(
       regex: Regex,
       target: CharSequence,
-      splitter: String => Nel[(String, Boolean)],
       replacer: Regex.Match => Option[String]
-  ): Option[String] = {
+  ): Change[String] = {
     var changed = false
     val replacer1 = replacer.andThen(_.map(r => { changed = true; r }))
-    val targetString = target.toString
-    val result = splitter(targetString)
-      .map {
-        case (str, canReplace) =>
-          if (canReplace) {
-            regex.replaceSomeIn(str, replacer1)
-          } else {
-            str
-          }
-      }
-      .mkString_("")
-    if (changed) Some(result) else None
+    val result = regex.replaceSomeIn(target, replacer1)
+    if (changed) Changed(result) else Unchanged(result)
   }
 
   def removeSuffix(target: String, suffixes: List[String]): String =

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -2,9 +2,14 @@ package org.scalasteward.core
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalasteward.core.model.Version
+import org.scalasteward.core.util.Change
+import org.scalasteward.core.util.Change.{Changed, Unchanged}
 
 object TestInstances {
-  implicit val arbitraryVersion: Arbitrary[Version] = {
+  implicit def changeArbitrary[T](implicit arbT: Arbitrary[T]): Arbitrary[Change[T]] =
+    Arbitrary(arbT.arbitrary.flatMap(t => Gen.oneOf(Changed(t), Unchanged(t))))
+
+  implicit val versionArbitrary: Arbitrary[Version] = {
     val versionChar = Gen.frequency(
       (8, Gen.numChar),
       (5, Gen.const('.')),
@@ -14,6 +19,6 @@ object TestInstances {
     Arbitrary(Gen.listOf(versionChar).map(_.mkString).map(Version.apply))
   }
 
-  implicit val cogenVersion: Cogen[Version] =
+  implicit val versionCogen: Cogen[Version] =
     Cogen(_.numericComponents.map(_.toLong).sum)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -321,7 +321,7 @@ class UpdateHeuristicTest extends FunSuite with Matchers {
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.groupId.name)
   }
 
-  test("update multiple lines between `on` and `off") {
+  test("update multiple lines between `on` and `off`") {
     val original =
       """  // scala-steward:off
         |  "com.typesafe.akka" %% "akka-actor" % "2.4.20",

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/editTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/editTest.scala
@@ -16,7 +16,7 @@ class editTest extends FunSuite with Matchers with ScalaCheckPropertyChecks {
 
   test("splitByOffOnMarker") {
     forAll(contentGen) { s: String =>
-      splitByOffOnMarker(s).map(_._1).mkString_("") shouldBe s
+      splitByOffOnMarker(s).foldMap { case (part, _) => part } shouldBe s
     }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/editTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/editTest.scala
@@ -1,0 +1,22 @@
+package org.scalasteward.core.edit
+
+import cats.implicits._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class editTest extends FunSuite with Matchers with ScalaCheckPropertyChecks {
+  private val lineGen = Gen.frequency(
+    3 -> Arbitrary.arbString.arbitrary,
+    1 -> Gen.oneOf("scala-steward:off", "scala-steward:on"),
+    1 -> Gen.alphaNumStr.map(_ + " // scala-steward:off")
+  )
+
+  private val contentGen = Gen.listOf(lineGen).map(_.mkString("\n"))
+
+  test("splitByOffOnMarker") {
+    forAll(contentGen) { s: String =>
+      splitByOffOnMarker(s).map(_._1).mkString_("") shouldBe s
+    }
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/util/ChangeTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/ChangeTest.scala
@@ -1,0 +1,12 @@
+package org.scalasteward.core.util
+
+import cats.implicits._
+import cats.kernel.laws.discipline.MonoidTests
+import org.scalasteward.core.TestInstances._
+import org.scalasteward.core.util.Change._
+import org.scalatest.FunSuite
+import org.typelevel.discipline.scalatest.Discipline
+
+class ChangeTest extends FunSuite with Discipline {
+  checkAll("Monoid[Change[T]]", MonoidTests[Change[String]].monoid)
+}


### PR DESCRIPTION
`Change` indicates if some input value has been changed or not. I think
it is clearer than using `Option` in `replaceSomeInOpt` where `Some`
meant that the input was changed. It is also used in the implementation
of `replaceSomeInAllowedParts` where we're making use of its monoid
instance.

The ultimate goal here was to give `replaceSomeInChange` and
`replaceSomeInAllowedParts` the same signature so that one is a drop-in
replacement for the other.