### PR TITLE
Update PRs only if there are conflicts with the base branch

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -148,7 +148,7 @@ final class NurtureAlg[F[_]](
     for {
       authors <- gitAlg.branchAuthors(data.repo, data.updateBranch, data.baseBranch)
       distinctAuthors = authors.distinct
-      isBehind <- gitAlg.isBehind(data.repo, data.updateBranch, data.baseBranch)
+      hasConflicts <- gitAlg.hasConflicts(data.repo, data.updateBranch, data.baseBranch)
       isMerged <- gitAlg.isMerged(data.repo, data.updateBranch, data.baseBranch)
       (result, msg) = {
         if (isMerged)
@@ -157,8 +157,8 @@ final class NurtureAlg[F[_]](
           (false, s"PR has commits by ${distinctAuthors.mkString(", ")}")
         else if (authors.length >= 2)
           (true, "PR has multiple commits")
-        else if (isBehind)
-          (true, s"PR is behind ${data.baseBranch.name}")
+        else if (hasConflicts)
+          (true, s"PR has conflicts with ${data.baseBranch.name}")
         else
           (false, s"PR is up-to-date with ${data.baseBranch.name}")
       }

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -1,12 +1,23 @@
 package org.scalasteward.core.git
 
+import better.files.File
+import cats.Monad
+import cats.effect.IO
+import cats.implicits._
 import org.http4s.Http4sLiteralSyntax
-import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.io.FileAlgTest._
+import org.scalasteward.core.io.ProcessAlgTest._
+import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.util.Nel
+import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.{FunSuite, Matchers}
 
 class GitAlgTest extends FunSuite with Matchers {
+  implicit val workspaceAlg: WorkspaceAlg[IO] = WorkspaceAlg.create[IO]
+  val ioGitAlg: GitAlg[IO] = GitAlg.create[IO]
+
   val repo = Repo("fthomas", "datapackage")
   val repoDir: String = (config.workspace / "fthomas/datapackage").toString
   val askPass = s"GIT_ASKPASS=${config.gitAskPass}"
@@ -83,4 +94,60 @@ class GitAlgTest extends FunSuite with Matchers {
       )
     )
   }
+
+  test("hasConflicts") {
+    val repo = Repo("merge", "conflict")
+    val p = for {
+      repoDir <- workspaceAlg.repoDir(repo)
+      _ <- GitAlgTest.createGitRepoWithConflict[IO](repoDir)
+      c1 <- ioGitAlg.hasConflicts(repo, Branch("branch-with-conflict"), Branch("master"))
+      c2 <- ioGitAlg.hasConflicts(repo, Branch("branch-without-conflict"), Branch("master"))
+    } yield (c1, c2)
+    p.unsafeRunSync() shouldBe ((true, false))
+  }
+}
+
+object GitAlgTest {
+  def createGitRepoWithConflict[F[_]](repoDir: File)(
+      implicit
+      fileAlg: FileAlg[F],
+      processAlg: ProcessAlg[F],
+      F: Monad[F]
+  ): F[Unit] =
+    for {
+      _ <- fileAlg.deleteForce(repoDir)
+      _ <- fileAlg.ensureExists(repoDir)
+      _ <- processAlg.exec(Nel.of("git", "init", "."), repoDir)
+      // work on master
+      _ <- fileAlg.writeFile(repoDir / "file1", "file1, line1")
+      _ <- fileAlg.writeFile(repoDir / "file2", "file2, line1")
+      _ <- processAlg.exec(Nel.of("git", "add", "file1"), repoDir)
+      _ <- processAlg.exec(Nel.of("git", "add", "file2"), repoDir)
+      _ <- processAlg.exec(Nel.of("git", "commit", "-m", "Initial commit"), repoDir)
+      // work on branch-without-conflict
+      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "branch-without-conflict"), repoDir)
+      _ <- fileAlg.writeFile(repoDir / "file3", "file3, line1")
+      _ <- processAlg.exec(Nel.of("git", "add", "file3"), repoDir)
+      _ <- processAlg.exec(
+        Nel.of("git", "commit", "-m", "Add file3 on branch-without-conflict"),
+        repoDir
+      )
+      _ <- processAlg.exec(Nel.of("git", "checkout", "master"), repoDir)
+      // work on branch-with-conflict
+      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "branch-with-conflict"), repoDir)
+      _ <- fileAlg.writeFile(
+        repoDir / "file2",
+        "file2, line1\nfile2, line2 on branch-with-conflict"
+      )
+      _ <- processAlg.exec(Nel.of("git", "add", "file2"), repoDir)
+      _ <- processAlg.exec(
+        Nel.of("git", "commit", "-m", "Modify file2 on branch-with-conflict"),
+        repoDir
+      )
+      _ <- processAlg.exec(Nel.of("git", "checkout", "master"), repoDir)
+      // work on master
+      _ <- fileAlg.writeFile(repoDir / "file2", "file2, line1\nfile2, line2 on master")
+      _ <- processAlg.exec(Nel.of("git", "add", "file2"), repoDir)
+      _ <- processAlg.exec(Nel.of("git", "commit", "-m", "Modify file2 on master"), repoDir)
+    } yield ()
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -100,8 +100,8 @@ class GitAlgTest extends FunSuite with Matchers {
     val p = for {
       repoDir <- workspaceAlg.repoDir(repo)
       _ <- GitAlgTest.createGitRepoWithConflict[IO](repoDir)
-      c1 <- ioGitAlg.hasConflicts(repo, Branch("branch-with-conflict"), Branch("master"))
-      c2 <- ioGitAlg.hasConflicts(repo, Branch("branch-without-conflict"), Branch("master"))
+      c1 <- ioGitAlg.hasConflicts(repo, Branch("conflicts-yes"), Branch("master"))
+      c2 <- ioGitAlg.hasConflicts(repo, Branch("conflicts-no"), Branch("master"))
     } yield (c1, c2)
     p.unsafeRunSync() shouldBe ((true, false))
   }
@@ -124,26 +124,17 @@ object GitAlgTest {
       _ <- processAlg.exec(Nel.of("git", "add", "file1"), repoDir)
       _ <- processAlg.exec(Nel.of("git", "add", "file2"), repoDir)
       _ <- processAlg.exec(Nel.of("git", "commit", "-m", "Initial commit"), repoDir)
-      // work on branch-without-conflict
-      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "branch-without-conflict"), repoDir)
+      // work on conflicts-no
+      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "conflicts-no"), repoDir)
       _ <- fileAlg.writeFile(repoDir / "file3", "file3, line1")
       _ <- processAlg.exec(Nel.of("git", "add", "file3"), repoDir)
-      _ <- processAlg.exec(
-        Nel.of("git", "commit", "-m", "Add file3 on branch-without-conflict"),
-        repoDir
-      )
+      _ <- processAlg.exec(Nel.of("git", "commit", "-m", "Add file3 on conflicts-no"), repoDir)
       _ <- processAlg.exec(Nel.of("git", "checkout", "master"), repoDir)
-      // work on branch-with-conflict
-      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "branch-with-conflict"), repoDir)
-      _ <- fileAlg.writeFile(
-        repoDir / "file2",
-        "file2, line1\nfile2, line2 on branch-with-conflict"
-      )
+      // work on conflicts-yes
+      _ <- processAlg.exec(Nel.of("git", "checkout", "-b", "conflicts-yes"), repoDir)
+      _ <- fileAlg.writeFile(repoDir / "file2", "file2, line1\nfile2, line2 on conflicts-yes")
       _ <- processAlg.exec(Nel.of("git", "add", "file2"), repoDir)
-      _ <- processAlg.exec(
-        Nel.of("git", "commit", "-m", "Modify file2 on branch-with-conflict"),
-        repoDir
-      )
+      _ <- processAlg.exec(Nel.of("git", "commit", "-m", "Modify file2 on conflicts-yes"), repoDir)
       _ <- processAlg.exec(Nel.of("git", "checkout", "master"), repoDir)
       // work on master
       _ <- fileAlg.writeFile(repoDir / "file2", "file2, line1\nfile2, line2 on master")

--- a/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/FileAlgTest.scala
@@ -4,13 +4,12 @@ import better.files.File
 import cats.effect.IO
 import cats.implicits._
 import org.scalacheck.Arbitrary
+import org.scalasteward.core.io.FileAlgTest.ioFileAlg
 import org.scalasteward.core.mock.MockContext.fileAlg
 import org.scalasteward.core.mock.MockState
 import org.scalatest.{FunSuite, Matchers}
 
 class FileAlgTest extends FunSuite with Matchers {
-  val ioFileAlg: FileAlg[IO] = FileAlg.create[IO]
-
   test("createTemporarily") {
     val file = File.temp / "test-scala-steward3.tmp"
     val content = Arbitrary.arbitrary[String].sample.getOrElse("")
@@ -84,4 +83,8 @@ class FileAlgTest extends FunSuite with Matchers {
     )
     edited shouldBe true
   }
+}
+
+object FileAlgTest {
+  implicit val ioFileAlg: FileAlg[IO] = FileAlg.create[IO]
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/io/ProcessAlgTest.scala
@@ -4,15 +4,13 @@ import better.files.File
 import cats.effect.IO
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.scalasteward.core.io.ProcessAlgTest.ioProcessAlg
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
 import org.scalatest.{FunSuite, Matchers}
 
 class ProcessAlgTest extends FunSuite with Matchers {
-  implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
-  val ioProcessAlg: ProcessAlg[IO] = ProcessAlg.create[IO]
-
   test("exec echo") {
     ioProcessAlg
       .exec(Nel.of("echo", "hello"), File.currentWorkingDirectory)
@@ -63,4 +61,9 @@ class ProcessAlgTest extends FunSuite with Matchers {
       )
     )
   }
+}
+
+object ProcessAlgTest {
+  implicit val ioLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val ioProcessAlg: ProcessAlg[IO] = ProcessAlg.create[IO]
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,18 +1,18 @@
 package org.scalasteward.core.mock
 
 import better.files.File
-import org.scalasteward.core.application.Cli.EnvVar
+import cats.effect.Sync
 import org.http4s.Uri
-import org.scalasteward.core.application.Config
+import org.scalasteward.core.application.Cli.EnvVar
+import org.scalasteward.core.application.{Config, SupportedVCS}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.{Author, GitAlg}
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.update.FilterAlg
-import org.scalasteward.core.util.{DateTimeAlg, LogAlg}
+import org.scalasteward.core.util.{BracketThrowable, DateTimeAlg, LogAlg}
 import org.scalasteward.core.vcs.VCSRepoAlg
-import org.scalasteward.core.application.SupportedVCS
 
 object MockContext {
   implicit val config: Config = Config(
@@ -36,6 +36,8 @@ object MockContext {
     ),
     pruneRepos = false
   )
+
+  implicit val mockEffBracketThrowable: BracketThrowable[MockEff] = Sync[MockEff]
 
   implicit val fileAlg: MockFileAlg = new MockFileAlg
   implicit val logger: MockLogger = new MockLogger


### PR DESCRIPTION
This changes when Scala Steward updates pull requests. Prior to this
change PRs were updated when they were behind the base branch. This
resolved potential merge conflicts but could also flood CI systems if
there were multiple open PRs by Scala Steward. With this change, only
PRs which are actually in conflict with the base branch are updated.
This should dramatically reduce the number of times Scala Steward
triggers CI builds by updating PRs.

closes: #384