### PR TITLE
Set 1.3.0-RC3 as latest sbt RC for 1.3.0

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -38,7 +38,7 @@ package object sbt {
   def findNewerSbtVersion(sbtVersion: SbtVersion): Option[SbtVersion] =
     (sbtVersion.value match {
       case v if v.startsWith("0.13.")    => Some(latestSbtVersion_0_13)
-      case v if v.startsWith("1.3.0-RC") => Some(SbtVersion("1.3.0-RC2"))
+      case v if v.startsWith("1.3.0-RC") => Some(SbtVersion("1.3.0-RC3"))
       case v if v.startsWith("1.")       => Some(defaultSbtVersion)
       case _                             => None
     }).filter(_.toVersion > sbtVersion.toVersion)

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/sbtTest.scala
@@ -13,8 +13,8 @@ class sbtTest extends FunSuite with Matchers {
       (SbtVersion("0.13.16"), Some(latestSbtVersion_0_13)),
       (defaultSbtVersion, None),
       (latestSbtVersion_0_13, None),
-      (SbtVersion("1.3.0-RC1"), Some(SbtVersion("1.3.0-RC2"))),
-      (SbtVersion("1.3.0-RC2"), None)
+      (SbtVersion("1.3.0-RC1"), Some(SbtVersion("1.3.0-RC3"))),
+      (SbtVersion("1.3.0-RC3"), None)
     )
 
     forAll(versions) { (curr: SbtVersion, maybeNewer: Option[SbtVersion]) =>


### PR DESCRIPTION
This will update sbt in all projects that use release candidates for 1.3.0.