### PR TITLE
introduce UnexpectedResponse and recoverWith instead of handleErrorWith

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -19,12 +19,11 @@ package org.scalasteward.core.gitlab.http4s
 import cats.implicits._
 import io.circe._
 import io.circe.generic.semiauto._
-import org.http4s.client.UnexpectedStatus
 import org.http4s.{Request, Status, Uri}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.gitlab._
-import org.scalasteward.core.util.{HttpJsonClient, MonadThrowable}
 import org.scalasteward.core.util.uri.uriDecoder
+import org.scalasteward.core.util.{HttpJsonClient, MonadThrowable, UnexpectedResponse}
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data._
 
@@ -117,8 +116,8 @@ class Http4sGitLabApiAlg[F[_]: MonadThrowable](
     val data = ForkPayload(url.encodedProjectId(userOwnedRepo), user.login)
     client
       .postWithBody[RepoOut, ForkPayload](url.createFork(repo), data, modify(repo))
-      .handleErrorWith {
-        case UnexpectedStatus(Status.Conflict) => getRepo(userOwnedRepo)
+      .recoverWith {
+        case UnexpectedResponse(_, _, _, Status.Conflict, _) => getRepo(userOwnedRepo)
       }
   }
 


### PR DESCRIPTION
its the first time I am using cats/fs2/http4s so maybe there is a simpler way to achieve the same.
I decided to re-throw the UnexpectedResponse in case of a match error so that I immediately see the obvious error (and not a MatchError)