### PR TITLE
Filter Gitlab MRs on target branch

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/Url.scala
@@ -35,8 +35,10 @@ class Url(apiHost: Uri) {
   def mergeRequest(repo: Repo): Uri =
     repos(repo) / "merge_requests"
 
-  def listMergeRequests(repo: Repo, head: String): Uri =
-    mergeRequest(repo).withQueryParam("source_branch", head)
+  def listMergeRequests(repo: Repo, source: String, target: String): Uri =
+    mergeRequest(repo)
+      .withQueryParam("source_branch", source)
+      .withQueryParam("target_branch", target)
 
   def repos(repo: Repo): Uri =
     apiHost / "projects" / s"${repo.owner}/${repo.repo}"

--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -100,7 +100,7 @@ class Http4sGitLabApiAlg[F[_]: MonadThrowable](
   val url = new Url(gitlabApiHost)
 
   override def listPullRequests(repo: Repo, head: String, base: Branch): F[List[PullRequestOut]] =
-    client.get(url.listMergeRequests(repo, head), modify(repo))
+    client.get(url.listMergeRequests(repo, head, base.name), modify(repo))
 
   def createFork(repo: Repo): F[RepoOut] = {
     val userOwnedRepo = repo.copy(owner = user.login)


### PR DESCRIPTION
I noticed that for Gitlab, Steward will consider an outdated MR with the wrong target branch. 

For Github it was already taken into account.

I could not test this patch properly yet (different setup home/work) but I can probably test it during the week.