### PR TITLE
Label PR so users can automate their workflow depending on update type.

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -35,7 +35,9 @@ final case class Dependency(
       scalaVersion.map("scalaVersion" -> _.value).toMap
 
   def toUpdate: Update.Single =
-    Update.Single(groupId, artifactId, version, Nel.of(version), configurations)
+    Update.Single(groupId, artifactId, version, Nel.of(version), configurations.orElse {
+      sbtVersion.map(_ => "sbt-plugin")
+    })
 }
 
 object Dependency {

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -29,7 +29,14 @@ package object sbt {
 
   def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
     if (sbtVersion.toVersion >= Version("1.0.0"))
-      Some(Dependency(GroupId("org.scala-sbt"), ArtifactId("sbt"), sbtVersion.value))
+      Some(
+        Dependency(
+          GroupId("org.scala-sbt"),
+          ArtifactId("sbt"),
+          sbtVersion.value,
+          configurations = Some("sbt-plugin")
+        )
+      )
     else
       None
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -24,7 +24,8 @@ package object scalafmt {
     Dependency(
       GroupId(if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson"),
       ArtifactId("scalafmt-core", s"scalafmt-core_$scalaBinaryVersion"),
-      scalafmtVersion.value
+      scalafmtVersion.value,
+      configurations = Some("sbt-plugin")
     )
 
   def parseScalafmtConf(s: String): Option[Version] =

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -48,7 +48,8 @@ object NewPullRequestData {
     val artifacts = artifactsWithOptionalUrl(update, artifactIdToUrl)
     val (migrationLabel, appliedMigrations) = migrationNote(migrations)
     val details = ignoreFutureUpdates(update) :: appliedMigrations.toList
-    val labels = Nel.fromList(semVerLabel(update).toList ++ migrationLabel.toList)
+    val labels =
+      Nel.fromList(List(updateType(update)) ++ semVerLabel(update).toList ++ migrationLabel.toList)
 
     s"""|Updates $artifacts ${fromTo(update, branchCompareUrl)}.
         |${releaseNote(releaseNoteUrl).getOrElse("")}
@@ -63,6 +64,15 @@ object NewPullRequestData {
         |
         |${labels.fold("")(_.mkString_("labels: ", ", ", ""))}
         |""".stripMargin.trim
+  }
+
+  def updateType(update: Update): String = update match {
+    case s: Update.Single if s.configurations.contains("test") =>
+      "test-library-update"
+    case s: Update.Single if s.configurations.contains("sbt-plugin") =>
+      "sbt-plugin-update"
+    case _ =>
+      "library-update"
   }
 
   def releaseNote(releaseNoteUrl: Option[String]): Option[String] =

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -28,7 +28,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       .spaces2 shouldBe
       """|{
          |  "title" : "Update logback-classic to 1.2.3",
-         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n\nlabels: semver-patch",
+         |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n\nlabels: library-update, semver-patch",
          |  "head" : "scala-steward:update/logback-classic-1.2.3",
          |  "base" : "master"
          |}
@@ -108,5 +108,20 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
         |* I am a rewrite rule
         |</details>
       """.stripMargin.trim
+  }
+
+  test("updateType") {
+    val single = Update.Single(GroupId("com.example"), ArtifactId("foo"), "0.1", Nel.of("0.2"))
+    val group = Update.Group(
+      GroupId("com.example"),
+      Nel.of(ArtifactId("foo"), ArtifactId("bar")),
+      "0.1",
+      Nel.of("0.2")
+    )
+    NewPullRequestData.updateType(single) shouldBe "library-update"
+    NewPullRequestData.updateType(group) shouldBe "library-update"
+
+    NewPullRequestData.updateType(single.copy(configurations = Some("test"))) shouldBe "test-library-update"
+    NewPullRequestData.updateType(single.copy(configurations = Some("sbt-plugin"))) shouldBe "sbt-plugin-update"
   }
 }


### PR DESCRIPTION
Closes #404 

Added the below labels

* `sbt-plugin-update`
   * sbt plugins,  example PRs: [scala-js](https://github.com/exoego/scala-steward-test-project/pull/113) and [sbt-salafmt](https://github.com/exoego/scala-steward-test-project/pull/115)
   * scalafmt versions in `.scalafmt.conf`, example PR: https://github.com/exoego/scala-steward-test-project/pull/116
   * sbt itself, example PR: https://github.com/exoego/scala-steward-test-project/pull/104
* `test-library-update`
    * Example PRs: [scalatest](https://github.com/exoego/scala-steward-test-project/pull/119) and [scalacheck](https://github.com/exoego/scala-steward-test-project/pull/118)
* Otherwise `library-update`
    * Example PRs: [circe](https://github.com/exoego/scala-steward-test-project/pull/111) and [groovy](https://github.com/exoego/scala-steward-test-project/pull/112)



