### PR TITLE
Gitlab 12.1.1 returns 404 instead of 409 (seems to be a bug)

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -109,6 +109,7 @@ class Http4sGitLabApiAlg[F[_]: MonadThrowable](
       .postWithBody[RepoOut, ForkPayload](url.createFork(repo), data, modify(repo))
       .recoverWith {
         case UnexpectedResponse(_, _, _, Status.Conflict, _) => getRepo(userOwnedRepo)
+        case UnexpectedResponse(_, _, _, Status.NotFound, _) => getRepo(userOwnedRepo)
       }
   }
 


### PR DESCRIPTION
bug reported at gitlab: https://gitlab.com/gitlab-org/gitlab-ee/issues/13050