### PR TITLE
Add scalafix migration for scalatest 3.1.0 

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -129,7 +129,13 @@ object SbtAlg {
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {
           for {
             repoDir <- workspaceAlg.repoDir(repo)
-            scalafixCmds = migrations.flatMap(_.rewriteRules).map(rule => s"$scalafix $rule").toList
+            scalafixCmds = migrations.flatMap { migration =>
+              val cmd = migration.configuration match {
+                case Some("test") => testScalafix
+                case _            => scalafix
+              }
+              migration.rewriteRules.map(rule => s"$cmd $rule")
+            }.toList
             _ <- exec(sbtCmd(scalafixEnable :: scalafixCmds), repoDir)
           } yield ()
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
@@ -21,6 +21,7 @@ object command {
   val libraryDependenciesAsJson = "show libraryDependenciesAsJson"
   val reloadPlugins = "reload plugins"
   val scalafix = "scalafix"
+  val testScalafix = "test:scalafix"
   val scalafixEnable = "scalafixEnable"
   val setCredentialsToNil = "set every credentials := Nil"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -24,5 +24,6 @@ final case class Migration(
     groupId: String,
     artifactIds: Nel[Regex],
     newVersion: Version,
-    rewriteRules: Nel[String]
+    rewriteRules: Nel[String],
+    configuration: Option[String] = None
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -51,6 +51,15 @@ package object scalafix {
         Nel.of("cats-core".r),
         Version("1.0.0"),
         Nel.of("github:fthomas/cats/Cats_v1_0_0?sha=update/scalafix")
+      ),
+      Migration(
+        "org.scalatest",
+        Nel.of("scalatest".r),
+        Version("3.1.0"),
+        Nel.of(
+          "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala",
+          "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala"
+        )
       )
     )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -59,7 +59,8 @@ package object scalafix {
         Nel.of(
           "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala",
           "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala"
-        )
+        ),
+        Some("test")
       )
     )
 


### PR DESCRIPTION
Closes #771 

Unfortunately, [`github:` scheme](https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-github) is not available for `scalatest/autofix`, since the repository has their arbitrary project structure (multiple scala projects in sub directories), IIUC.

So used [`https:` schema](https://scalacenter.github.io/scalafix/docs/developers/tutorial.html#using-http) to support arbitrary project structure.
Also, used a SHA1-marked immutable reference as stated in https://github.com/fthomas/scala-steward/issues/626 for security consideration.



