### PR TITLE
Allow using a custom base image for docker builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val dockerSettings = Def.settings(
   dockerCommands := Seq(
-    Cmd("FROM", "openjdk:8"),
+    Cmd("FROM", Option(System.getenv("BASE_IMAGE")).getOrElse("openjdk:8")),
     Cmd("ARG", "DEBIAN_FRONTEND=noninteractive"),
     ExecCmd("RUN", "apt-get", "update"),
     ExecCmd("RUN", "apt-get", "install", "-y", "apt-transport-https", "firejail"),

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val metadataSettings = Def.settings(
 
 lazy val dockerSettings = Def.settings(
   dockerCommands := Seq(
-    Cmd("FROM", Option(System.getenv("BASE_IMAGE")).getOrElse("openjdk:8")),
+    Cmd("FROM", Option(System.getenv("DOCKER_BASE_IMAGE")).getOrElse("openjdk:8")),
     Cmd("ARG", "DEBIAN_FRONTEND=noninteractive"),
     ExecCmd("RUN", "apt-get", "update"),
     ExecCmd("RUN", "apt-get", "install", "-y", "apt-transport-https", "firejail"),


### PR DESCRIPTION
Reason: Custom resolvers that are usually added in our CI pipeline before `sbt` starts, as well as adding certificates. This change allows me to build a base image with all that myself and use it to build the scala-steward docker image that'll work in my gitlab org.

Let me know if the name needs changing or there's anything else wrong with this ;)