### PR TITLE
Clean up UpdateHeuristic

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -57,7 +57,7 @@ final class EditAlg[F[_]](
   def applyUpdateTo[G[_]: Traverse](files: G[File], update: Update): F[Unit] = {
     val actions = UpdateHeuristic.all.map { heuristic =>
       logger.info(s"Trying heuristic '${heuristic.name}'") >>
-        fileAlg.editFiles(files, heuristic.replaceF(update))
+        fileAlg.editFiles(files, heuristic.replaceVersion(update))
     }
     bindUntilTrue(actions).void
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -22,93 +22,95 @@ import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex
 
+/** `UpdateHeuristic` is a wrapper for a function that takes an `Update` and
+  * returns a new function that replaces the current version with the next
+  * version in its input. The result type indicates whether the input was
+  * modified or not.
+  */
 final case class UpdateHeuristic(
     name: String,
-    order: Int,
-    getSearchTerms: Update => List[String],
-    getPrefixRegex: Update => Option[String] = _ => None
-) {
-  def mkRegex(update: Update): Option[Regex] =
-    UpdateHeuristic
-      .searchTermsToAlternation(getSearchTerms(update).map(Update.removeCommonSuffix))
-      .map { searchTerms =>
-        val prefix = getPrefixRegex(update).getOrElse("")
-        val currentVersion = Regex.quote(update.currentVersion)
-        s"(?i)(.*)($prefix$searchTerms.*?)$currentVersion(.?)".r
-      }
-
-  def replaceF(update: Update): String => Option[String] =
-    mkRegex(update).fold((_: String) => Option.empty[String]) { regex => target =>
-      replaceSomeInAllowedParts(
-        regex,
-        target,
-        match0 => {
-          val group1 = match0.group(1)
-          val group2 = match0.group(2)
-          val lastGroup = match0.group(match0.groupCount)
-          val versionInQuotes =
-            group2.lastOption.filter(_ === '"').fold(true)(lastGroup.headOption.contains_)
-          if (group1.toLowerCase.contains("previous")
-              || group1.trim.startsWith("//")
-              || !versionInQuotes) None
-          else Some(Regex.quoteReplacement(group1 + group2 + update.nextVersion + lastGroup))
-        }
-      ).someIfChanged
-    }
-}
+    replaceVersion: Update => String => Option[String]
+)
 
 object UpdateHeuristic {
-  def searchTermsToAlternation(terms: List[String]): Option[String] = {
-    val ignoreChar = ".?"
-    val ignorableStrings = List(".", "-")
-    val terms1 = terms
-      .filterNot(term => term.isEmpty || ignorableStrings.contains(term))
-      .map { term =>
-        ignorableStrings.foldLeft(term) {
-          case (term1, ignorable) => term1.replace(ignorable, ignoreChar)
+  private def defaultReplaceVersion(
+      getSearchTerms: Update => List[String],
+      getPrefixRegex: Update => Option[String] = _ => None
+  ): Update => String => Option[String] = {
+
+    def searchTermsToAlternation(terms: List[String]): Option[String] = {
+      val ignoreChar = ".?"
+      val ignorableStrings = List(".", "-")
+      val terms1 = terms
+        .filterNot(term => term.isEmpty || ignorableStrings.contains(term))
+        .map { term =>
+          ignorableStrings.foldLeft(term) {
+            case (term1, ignorable) => term1.replace(ignorable, ignoreChar)
+          }
         }
+
+      if (terms1.nonEmpty) Some(terms1.mkString("(", "|", ")")) else None
+    }
+
+    def mkRegex(update: Update): Option[Regex] =
+      searchTermsToAlternation(getSearchTerms(update).map(Update.removeCommonSuffix)).map {
+        searchTerms =>
+          val prefix = getPrefixRegex(update).getOrElse("")
+          val currentVersion = Regex.quote(update.currentVersion)
+          s"(?i)(.*)($prefix$searchTerms.*?)$currentVersion(.?)".r
       }
 
-    if (terms1.nonEmpty) Some(terms1.mkString("(", "|", ")")) else None
+    def replaceF(update: Update): String => Option[String] =
+      mkRegex(update).fold((_: String) => Option.empty[String]) { regex => target =>
+        replaceSomeInAllowedParts(
+          regex,
+          target,
+          match0 => {
+            val group1 = match0.group(1)
+            val group2 = match0.group(2)
+            val lastGroup = match0.group(match0.groupCount)
+            val versionInQuotes =
+              group2.lastOption.filter(_ === '"').fold(true)(lastGroup.headOption.contains_)
+            if (group1.toLowerCase.contains("previous")
+                || group1.trim.startsWith("//")
+                || !versionInQuotes) None
+            else Some(Regex.quoteReplacement(group1 + group2 + update.nextVersion + lastGroup))
+          }
+        ).someIfChanged
+      }
+
+    replaceF
   }
 
   val strict = UpdateHeuristic(
     name = "strict",
-    order = 1,
-    getSearchTerms = update => update.searchTerms.toList,
-    getPrefixRegex = update => Some(s"${update.groupId}.*?")
+    replaceVersion =
+      defaultReplaceVersion(_.searchTerms.toList, update => Some(s"${update.groupId}.*?"))
   )
 
   val original = UpdateHeuristic(
     name = "original",
-    order = 2,
-    getSearchTerms = update => update.searchTerms.toList
+    replaceVersion = defaultReplaceVersion(_.searchTerms.toList)
   )
 
   val relaxed = UpdateHeuristic(
     name = "relaxed",
-    order = 3,
-    getSearchTerms = update => util.string.extractWords(update.artifactId)
+    replaceVersion = defaultReplaceVersion(update => util.string.extractWords(update.artifactId))
   )
 
   val sliding = UpdateHeuristic(
     name = "sliding",
-    order = 4,
-    getSearchTerms = update => update.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList
+    replaceVersion =
+      defaultReplaceVersion(_.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList)
   )
 
   val groupId = UpdateHeuristic(
     name = "groupId",
-    order = 5,
-    getSearchTerms = update =>
-      update.groupId
-        .split('.')
-        .toList
-        .drop(1)
-        .flatMap(util.string.extractWords)
-        .filter(_.length > 3)
+    replaceVersion = defaultReplaceVersion(
+      _.groupId.split('.').toList.drop(1).flatMap(util.string.extractWords).filter(_.length > 3)
+    )
   )
 
   val all: Nel[UpdateHeuristic] =
-    Nel.of(strict, original, relaxed, sliding, groupId).sortBy(_.order)
+    Nel.of(strict, original, relaxed, sliding, groupId)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -351,7 +351,7 @@ object UpdateHeuristicTest {
   implicit class UpdateOps(update: Update) {
     def replaceVersionIn(target: String): (Option[String], String) =
       UpdateHeuristic.all.foldLeft((Option.empty[String], "")) {
-        case ((None, _), heuristic) => (heuristic.replaceF(update)(target), heuristic.name)
+        case ((None, _), heuristic) => (heuristic.replaceVersion(update)(target), heuristic.name)
         case (result, _)            => result
       }
   }


### PR DESCRIPTION
The current implementation of `UpdateHeuristic` is tightly coupled to
the existing heuristics. This reduces `UpdateHeuristic` to the bare minimum
required by `EditAlg` and allows to have implementations that are much
different to the already existing heuristics.