### PR TITLE
Update the url of scalafix rule for cats v1.0.0

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -50,7 +50,9 @@ package object scalafix {
         "org.typelevel",
         Nel.of("cats-core".r),
         Version("1.0.0"),
-        Nel.of("https://raw.githubusercontent.com/typelevel/cats/master/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala")
+        Nel.of(
+          "https://raw.githubusercontent.com/typelevel/cats/master/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala"
+        )
       ),
       Migration(
         "org.scalatest",

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -50,7 +50,7 @@ package object scalafix {
         "org.typelevel",
         Nel.of("cats-core".r),
         Version("1.0.0"),
-        Nel.of("github:fthomas/cats/Cats_v1_0_0?sha=update/scalafix")
+        Nel.of("https://raw.githubusercontent.com/typelevel/cats/master/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala")
       ),
       Migration(
         "org.scalatest",


### PR DESCRIPTION
This PR updates the URL of scalafix rule for `cats v1.0.0` from https://raw.githubusercontent.com/fthomas/cats/update/scalafix/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala to https://raw.githubusercontent.com/typelevel/cats/master/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala

Currently, `update/scalafix` branch in `fthomas/cats` had already
deleted(?), and as a result, running scala-steward to the repository that contains an update for cats to v1.0.0 ends up with 404 error like this.

```
[error] (types / Compile / scalafix) scalafix.sbt.InvalidArgument: 404 -
not found
https://raw.githubusercontent.com/fthomas/cats/update/scalafix/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
```