### PR TITLE
git clone with a depth of 500 to fix the version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ scala:
 services:
 - docker
 
+git:
+  depth: 500
 before_install:
 - git fetch --tags
 cache:


### PR DESCRIPTION
Current Travis CI builds use a version that starts with "0.0.0" instead
of "0.3.0":

> [info] Packaging /home/travis/build/fthomas/scala-steward/modules/core/.jvm/target/scala-2.12/scala-steward-core_2.12-0.0.0-167-fe8f4da7.jar ...

I guess sbt-dynver can't correctly determine the version with a clone
depth of 50 (which is the default). This sets the git clone depth to
500 to fix the version.