### PR TITLE
Split refreshCache into two functions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.repocache
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.git.{GitAlg, Sha1}
+import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.scalafmt.ScalafmtAlg
@@ -49,15 +49,23 @@ final class RepoCacheAlg[F[_]](
         cachedSha1 <- repoCacheRepository.findSha1(repo)
         latestSha1 = branchOut.commit.sha
         refreshRequired = cachedSha1.forall(_ =!= latestSha1)
-        _ <- if (refreshRequired) refreshCache(repo, repoOut, latestSha1) else F.unit
+        _ <- if (refreshRequired) cloneAndRefreshCache(repo, repoOut) else F.unit
       } yield ()
     }
 
-  private def refreshCache(repo: Repo, repoOut: RepoOut, latestSha1: Sha1): F[Unit] =
+  private def cloneAndRefreshCache(repo: Repo, repoOut: RepoOut): F[Unit] =
     for {
       _ <- logger.info(s"Refresh cache of ${repo.show}")
       _ <- vcsRepoAlg.clone(repo, repoOut)
       _ <- vcsRepoAlg.syncFork(repo, repoOut)
+      _ <- refreshCache(repo)
+      _ <- gitAlg.removeClone(repo)
+    } yield ()
+
+  private def refreshCache(repo: Repo): F[RepoCache] =
+    for {
+      branch <- gitAlg.currentBranch(repo)
+      latestSha1 <- gitAlg.latestSha1(repo, branch)
       dependencies <- sbtAlg.getDependencies(repo)
       maybeSbtVersion <- sbtAlg.getSbtVersion(repo)
       maybeScalafmtVersion <- scalafmtAlg.getScalafmtVersion(repo)
@@ -70,6 +78,5 @@ final class RepoCacheAlg[F[_]](
         maybeRepoConfig
       )
       _ <- repoCacheRepository.updateCache(repo, cache)
-      _ <- gitAlg.removeClone(repo)
-    } yield ()
+    } yield cache
 }


### PR DESCRIPTION
... and get the latest sha1 from the local clone instead of the Git repo
manager which could already be outdated by the time the repo is cloned.