### PR TITLE
Check multiple compare URLs

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -36,13 +36,6 @@ object VCSExtraAlg {
         maybeRepoUrl: Option[String],
         update: Update
     ): F[Option[String]] =
-      maybeRepoUrl
-        .flatMap(vcs.createCompareUrl(_, update))
-        .fold(F.pure(Option.empty[String])) { url =>
-          existenceClient.exists(url).map {
-            case true  => Some(url)
-            case false => None
-          }
-        }
+      maybeRepoUrl.toList.flatMap(vcs.possibleCompareUrls(_, update)).findM(existenceClient.exists)
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -53,8 +53,8 @@ package object vcs {
     val canonicalized = repoUrl.replaceAll("/$", "")
     if (repoUrl.startsWith("https://github.com/") || repoUrl.startsWith("https://gitlab.com/"))
       List(
-        s"${canonicalized}/compare/${from}...${to}",
-        s"${canonicalized}/compare/v${from}...v${to}"
+        s"${canonicalized}/compare/v${from}...v${to}",
+        s"${canonicalized}/compare/${from}...${to}"
       )
     else if (repoUrl.startsWith("https://bitbucket.org/"))
       List(s"${canonicalized}/compare/${to}..${from}#diff")

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -47,16 +47,18 @@ package object vcs {
         git.branchFor(update).name
     }
 
-  def createCompareUrl(repoUrl: String, update: Update): Option[String] = {
+  def possibleCompareUrls(repoUrl: String, update: Update): List[String] = {
     val from = update.currentVersion
     val to = update.nextVersion
     val canonicalized = repoUrl.replaceAll("/$", "")
     if (repoUrl.startsWith("https://github.com/") || repoUrl.startsWith("https://gitlab.com/"))
-      Some(s"${canonicalized}/compare/v${from}...v${to}")
+      List(
+        s"${canonicalized}/compare/${from}...${to}",
+        s"${canonicalized}/compare/v${from}...v${to}"
+      )
     else if (repoUrl.startsWith("https://bitbucket.org/"))
-      Some(s"${canonicalized}/compare/${to}..${from}#diff")
+      List(s"${canonicalized}/compare/${to}..${from}#diff")
     else
-      // unsupported VCS or just homepage
-      None
+      List.empty
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -24,18 +24,18 @@ class VCSPackageTest extends FunSuite with Matchers {
 
   test("possibleCompareUrls") {
     possibleCompareUrls("https://github.com/foo/bar", update) shouldBe List(
-      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
-      "https://github.com/foo/bar/compare/v1.2.0...v1.2.3"
+      "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3"
     )
     // should canonicalize (drop last slash)
     possibleCompareUrls("https://github.com/foo/bar/", update) shouldBe List(
-      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
-      "https://github.com/foo/bar/compare/v1.2.0...v1.2.3"
+      "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3"
     )
 
     possibleCompareUrls("https://gitlab.com/foo/bar", update) shouldBe List(
-      "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
-      "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3"
+      "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
+      "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3"
     )
     possibleCompareUrls("https://bitbucket.org/foo/bar", update) shouldBe List(
       "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff"

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -8,7 +8,7 @@ import org.scalasteward.core.data.Update
 
 import org.scalatest.{FunSuite, Matchers}
 
-class BranchOutTest extends FunSuite with Matchers {
+class VCSPackageTest extends FunSuite with Matchers {
   val repo = Repo("foo", "bar")
   val update = Update.Single("ch.qos.logback", "logback-classic", "1.2.0", Nel.of("1.2.3"))
 
@@ -22,22 +22,25 @@ class BranchOutTest extends FunSuite with Matchers {
     createBranch(Gitlab, repo, update) shouldBe "update/logback-classic-1.2.3"
   }
 
-  test("createCompareUrl") {
-    createCompareUrl("https://github.com/foo/bar", update) shouldBe Some(
+  test("possibleCompareUrls") {
+    possibleCompareUrls("https://github.com/foo/bar", update) shouldBe List(
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3"
     )
     // should canonicalize (drop last slash)
-    createCompareUrl("https://github.com/foo/bar/", update) shouldBe Some(
+    possibleCompareUrls("https://github.com/foo/bar/", update) shouldBe List(
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3"
     )
 
-    createCompareUrl("https://gitlab.com/foo/bar", update) shouldBe Some(
+    possibleCompareUrls("https://gitlab.com/foo/bar", update) shouldBe List(
+      "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
       "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3"
     )
-    createCompareUrl("https://bitbucket.org/foo/bar", update) shouldBe Some(
+    possibleCompareUrls("https://bitbucket.org/foo/bar", update) shouldBe List(
       "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff"
     )
 
-    createCompareUrl("https://scalacenter.github.io/scalafix/", update) shouldBe None
+    possibleCompareUrls("https://scalacenter.github.io/scalafix/", update) shouldBe List()
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/fthomas/scala-steward/pull/814

It allows to check multiple possible compare URLs for existence. In
particular, it also supports tags without leading "v".

Example PR: https://github.com/fthomas/refined-sjs-example/pull/16