### PR TITLE
Better handling scm url 

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -59,14 +59,13 @@ object CoursierAlg {
               case _: coursier.error.ResolutionError => None
             }
         } yield {
-          maybeFetchResult.flatMap(
-            _.resolution.projectCache.get((module, dependency.version)).flatMap {
-              case (_, project) =>
-                val maybeScmUrl = project.info.scm.flatMap(_.url).filter(_.nonEmpty)
-                val maybeHomepage = Option(project.info.homePage).filter(_.nonEmpty)
-                maybeScmUrl.orElse(maybeHomepage)
-            }
-          )
+          for {
+            result <- maybeFetchResult
+            (_, project) <- result.resolution.projectCache.get((module, dependency.version))
+            maybeScmUrl = project.info.scm.flatMap(_.url).filter(_.nonEmpty)
+            maybeHomepage = Option(project.info.homePage).filter(_.nonEmpty)
+            url <- maybeScmUrl.orElse(maybeHomepage)
+          } yield url
         }
       }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -62,7 +62,7 @@ object CoursierAlg {
           maybeFetchResult.flatMap(
             _.resolution.projectCache.get((module, dependency.version)).flatMap {
               case (_, project) =>
-                val maybeScmUrl = project.info.scm.flatMap(i => Option(i.url)).filter(_.nonEmpty)
+                val maybeScmUrl = project.info.scm.flatMap(_.url).filter(_.nonEmpty)
                 val maybeHomepage = Option(project.info.homePage).filter(_.nonEmpty)
                 maybeScmUrl.orElse(maybeHomepage)
             }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Versions {
   val circe = "0.11.1"
   val http4s = "0.20.10"
   val refined = "0.9.9"
+  val coursier = "2.0.0-RC3-3"
 }
 
 object Dependencies {
@@ -19,8 +20,8 @@ object Dependencies {
   val circeRefined = "io.circe" %% "circe-refined" % Versions.circe
   val circeExtras = "io.circe" %% "circe-generic-extras" % Versions.circe
   val commonsIo = "commons-io" % "commons-io" % "2.6"
-  val coursierCore = "io.get-coursier" %% "coursier" % "2.0.0-RC3-2"
-  val coursierCatsInterop = "io.get-coursier" %% "coursier-cats-interop" % "2.0.0-RC3-2"
+  val coursierCore = "io.get-coursier" %% "coursier" % Versions.coursier
+  val coursierCatsInterop = "io.get-coursier" %% "coursier-cats-interop" % Versions.coursier
   val fs2Core = "co.fs2" %% "fs2-core" % "1.0.5"
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
   val http4sCirce = "org.http4s" %% "http4s-circe" % Versions.http4s


### PR DESCRIPTION
Follow-up of #762 and #814 

Improves handling incomplete `<scm>` reporeted in https://github.com/coursier/coursier/pull/1291#issuecomment-521518104
>  I've noticed that scm is None when developerConnection is missing in the POM. But not setting developerConnection seems to be common:
>```
><scm>
>   <url>https://github.com/typelevel/cats-effect</url>
>   <connection>git@github.com:typelevel/cats-effect.git</connection>
></scm>
>```
