### PR TITLE
Add update state UpdateRejectedByConfig

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -29,7 +29,7 @@ object UpdateState {
 
   final case class DependencyOutdated(dependency: Dependency, update: Update) extends UpdateState
 
-  final case class UpdateRejectedByConfig(dependency: Dependency, reason: RejectionReason)
+  final case class UpdateRejectedByConfig(dependency: Dependency, rejectionReason: RejectionReason)
       extends UpdateState
 
   final case class PullRequestUpToDate(dependency: Dependency, update: Update, pullRequest: Uri)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/data/UpdateState.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.update.data
 
 import org.http4s.Uri
 import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.update.FilterAlg.RejectionReason
 
 sealed trait UpdateState extends Product with Serializable {
   def dependency: Dependency
@@ -27,6 +28,9 @@ object UpdateState {
   final case class DependencyUpToDate(dependency: Dependency) extends UpdateState
 
   final case class DependencyOutdated(dependency: Dependency, update: Update) extends UpdateState
+
+  final case class UpdateRejectedByConfig(dependency: Dependency, reason: RejectionReason)
+      extends UpdateState
 
   final case class PullRequestUpToDate(dependency: Dependency, update: Update, pullRequest: Uri)
       extends UpdateState


### PR DESCRIPTION
When pruning repos, Scala Steward now takes into account if updates are
rejected by repo configuration. This will prevent Scala Steward from
unnecessarily working on repos where it determined that a dependency is
outdated but it was actually ignored by the repo config.