### PR TITLE
artifactIdCross does not need minor version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -20,15 +20,19 @@ import org.scalasteward.core.data.{Dependency, Version}
 import org.scalasteward.core.sbt.data.ScalaVersion
 
 package object scalafmt {
-  def scalafmtDependency(scalaVersion: ScalaVersion)(scalafmtVersion: Version): Option[Dependency] =
+  def scalafmtDependency(
+      scalaVersion: ScalaVersion
+  )(scalafmtVersion: Version): Option[Dependency] = {
+    val scalaMajor = scalaVersion.value.split("\\.").take(2).mkString(".")
     Some(
       Dependency(
         "org.scalameta",
         "scalafmt-core",
-        s"scalafmt-core_${scalaVersion.value}",
+        s"scalafmt-core_${scalaMajor}",
         scalafmtVersion.value
       )
     )
+  }
 
   def parseScalafmtConf(s: String): Option[Version] =
     """version\s*=\s*(.+)""".r

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafmt/UtilTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafmt/UtilTest.scala
@@ -1,0 +1,13 @@
+package org.scalasteward.core.scalafmt
+
+import org.scalasteward.core.data.{Dependency, Version}
+import org.scalasteward.core.sbt.data.ScalaVersion
+import org.scalatest.{FunSuite, Matchers}
+
+class UtilTest extends FunSuite with Matchers {
+  test("should not include minor version") {
+    scalafmtDependency(ScalaVersion("2.12.9"))(Version("1.0")) shouldBe Some(
+      Dependency("org.scalameta", "scalafmt-core", "scalafmt-core_2.12", "1.0")
+    )
+  }
+}


### PR DESCRIPTION
Follow-up of #842 