### PR TITLE
Remove scalaBinaryVersion from temporary scalafmt dependency.

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -32,6 +32,9 @@ final case class Dependency(
   def formatAsModuleId: String =
     s""""$groupId" % "$artifactIdCross" % "$version""""
 
+  def formatAsModuleIdScalaVersionAgnostic: String =
+    s""""$groupId" %% "$artifactId" % "$version""""
+
   def toUpdate: Update.Single =
     Update.Single(groupId, artifactId, version, Nel.of(version), configurations)
 }


### PR DESCRIPTION
Follow-up of #842 

https://github.com/fthomas/scala-steward/pull/842#issuecomment-522218941
>[info]   org.scalameta:scalafmt-core_2.12 : 2.0.0 -> 2.0.1

Temporary `scalafmt-core` dependency's artifact id is `scalafmt-core_2.12` (including scalaBinaryVersion) due to https://github.com/fthomas/scala-steward/blob/1718dc26c08df42caf8376bc761c92965218a25f/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala#L178-L180
Therefore `UpdateHeuristic` for `scalafmt-core` does not work.

This PR makes the artifact id scalaBinaryVersion-agnostic for `scalafmt-core`.
So future updates for any Scala binary version (2.13, 2.14 or 3.0) should work.

Example PR
https://github.com/exoego/scala-steward-test-project/pull/77
