### PR TITLE
scalafmt-core prior to 2.0.0-RC2 used a different groupId

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -16,12 +16,13 @@
 
 package org.scalasteward.core
 
+import cats.implicits._
 import org.scalasteward.core.data.{Dependency, Version}
 
 package object scalafmt {
   def scalafmtDependency(scalaBinaryVersion: String)(scalafmtVersion: Version): Dependency =
     Dependency(
-      "org.scalameta",
+      if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson",
       "scalafmt-core",
       s"scalafmt-core_${scalaBinaryVersion}",
       scalafmtVersion.value


### PR DESCRIPTION
This should prevent errors like this:
```
[error] coursier.error.ResolutionError$CantDownloadModule:
Error downloading org.scalameta:scalafmt-core_2.12:1.5.1
```

Different groupIds means that Scala Steward won't propose updates
anymore if the scalafmt version is at 2.0.0-RC1.