### PR TITLE
Encapsulate moduleId for Scala binary version

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -30,10 +30,10 @@ final case class Dependency(
     configurations: Option[String] = None
 ) {
   def formatAsModuleId: String =
-    s""""$groupId" % "$artifactIdCross" % "$version""""
-
-  def formatAsModuleIdScalaVersionAgnostic: String =
-    s""""$groupId" %% "$artifactId" % "$version""""
+    artifactId match {
+      case `artifactIdCross` => s""""$groupId" % "$artifactIdCross" % "$version""""
+      case _                 => s""""$groupId" %% "$artifactId" % "$version""""
+    }
 
   def toUpdate: Update.Single =
     Update.Single(groupId, artifactId, version, Nel.of(version), configurations)

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
@@ -31,7 +31,7 @@ class ArtificialProjectTest extends FunSuite with Matchers {
     project.mkBuildSbt.content shouldBe
       """|scalaVersion := "2.12.7"
          |libraryDependencies ++= Seq(
-         |"org.typelevel" % "cats-effect_2.12" % "1.0.0",
+         |"org.typelevel" %% "cats-effect" % "1.0.0",
          |"org.scala-lang" % "scala-library" % "2.12.6"
          |)
          |""".stripMargin.trim


### PR DESCRIPTION
By this refactoring, we can simply use just `formatAsModuleId` for any new dependencies in `withTemporarySbtDependency`.