### PR TITLE
Add migration rule for (not yet released) scalacheck 1.14.1

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -63,6 +63,12 @@ package object scalafix {
           "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala"
         ),
         Some("test")
+      ),
+      Migration(
+        "org.scalacheck",
+        Nel.of("scalacheck".r),
+        Version("1.14.1"),
+        Nel.of("github:typelevel/scalacheck/v1_14_1?sha=3fc537dde9d8fdf951503a8d8b027a568d52d055")
       )
     )
 


### PR DESCRIPTION
See https://github.com/typelevel/scalacheck/pull/498