### PR TITLE
Fix compile error with sbt 0.13

### DIFF
--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -64,8 +64,10 @@ object StewardPlugin extends AutoPlugin {
     sourcePositions.get(moduleId) match {
       case Some(fp: FilePosition) if fp.path.startsWith("(sbt.Classpaths") => true
       case Some(fp: FilePosition) if fp.path.startsWith("(")               => false
-      case Some(fp: FilePosition) if fp.path.startsWith("Defaults.scala")
-        && !moduleId.configurations.contains("plugin->default(compile)")   => false
-      case _                                                               => true
+      case Some(fp: FilePosition)
+          if fp.path.startsWith("Defaults.scala")
+            && !moduleId.configurations.exists(_ == "plugin->default(compile)") =>
+        false
+      case _ => true
     }
 }


### PR DESCRIPTION
This fixes the following compilation error with sbt 0.13:
```
[error] /home/frank/.sbt/0.13/plugins/StewardPlugin.scala:68: value contains is not a member of Option[String]
[error]         && !moduleId.configurations.contains("plugin->default(compile)")   => false
[error]                                     ^
[error] one error found
[error] (compile:compileIncremental) Compilation failed
```