### PR TITLE
Make HttpExistenceClient fail-safe

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
@@ -17,18 +17,22 @@
 package org.scalasteward.core.util
 
 import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
 import org.http4s.{Method, Request, Uri}
 
 final class HttpExistenceClient[F[_]](
     implicit
     client: Client[F],
+    logger: Logger[F],
     F: MonadThrowable[F]
 ) {
   def exists(uri: String): F[Boolean] = F.fromEither(Uri.fromString(uri)).flatMap(exists)
 
   def exists(uri: Uri): F[Boolean] = {
-    val req: Request[F] = Request(method = Method.HEAD, uri = uri)
-    client.status(req).map(_.isSuccess)
+    val req = Request[F](method = Method.HEAD, uri = uri)
+    client.status(req).map(_.isSuccess).handleErrorWith { throwable =>
+      logger.debug(throwable)(s"Failed to check if $uri exists").as(false)
+    }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -5,6 +5,7 @@ import org.http4s.HttpRoutes
 import org.http4s.client.Client
 import org.http4s.dsl.io.{->, /, HEAD, NotFound, Ok, Root, _}
 import org.http4s.implicits._
+import org.scalasteward.core.TestInstances.ioLogger
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.{HttpExistenceClient, Nel}
 import org.scalatest.{FunSuite, Matchers}


### PR DESCRIPTION
For the same reason as given in https://github.com/fthomas/scala-steward/pull/882.

It is also a workaround for https://github.com/fthomas/scala-steward/issues/888.