### PR TITLE
projectId in repo for gitlab

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ lazy val core = myCrossProject("core")
       Dependencies.http4sDsl % Test,
       Dependencies.refinedScalacheck % Test,
       Dependencies.scalacheck % Test,
-      Dependencies.scalaTest % Test
+      Dependencies.scalaTest % Test,
+      Dependencies.mockito % Test
     ),
     assembly / test := {},
     assemblyMergeStrategy in assembly := {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -51,7 +51,7 @@ final class StewardAlg[F[_]](
   def readRepos(reposFile: File): F[List[Repo]] =
     fileAlg.readFile(reposFile).map { maybeContent =>
       val regex = """-\s+(.+)/([^/]+)""".r
-      val regexWithProjectId = """-\s+(.+)/([^/]+)/pid:([0-9]+)""".r
+      val regexWithProjectId = """-\s+(.+)/([^/]+)/pid:([0-9]+)$""".r
       val content = maybeContent.getOrElse("")
       content.linesIterator.collect {
         case regexWithProjectId(owner, repo, pid) if config.vcsType === SupportedVCS.Gitlab =>

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -60,8 +60,12 @@ final class StewardAlg[F[_]](
           Repo(
             owner.trim,
             repo.trim,
-            Try(pid.toLong).toOption.orElse(throw new IllegalArgumentException(
-              s"illegal PID for ${owner.trim}/${repo.trim} : not a number")))
+            Try(pid.toLong).toOption.orElse(
+              throw new IllegalArgumentException(
+                s"illegal PID for ${owner.trim}/${repo.trim} : not a number"
+              )
+            )
+          )
         case regex(owner, repo) =>
           Repo(owner.trim, repo.trim)
       }.toList

--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/Url.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/Url.scala
@@ -40,6 +40,8 @@ class Url(apiHost: Uri) {
       .withQueryParam("source_branch", source)
       .withQueryParam("target_branch", target)
 
-  def repos(repo: Repo): Uri =
-    apiHost / "projects" / s"${repo.owner}/${repo.repo}"
+  def repos(repo: Repo): Uri = {
+    val baseUri = apiHost / "projects"
+    repo.pid.fold(baseUri / s"${repo.owner}/${repo.repo}")(baseUri / _.toString)
+  }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -32,7 +32,7 @@ import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg}
 import org.scalasteward.core.{git, util, vcs}
 
-final class NurtureAlg[F[_]](
+class NurtureAlg[F[_]](
     implicit
     config: Config,
     editAlg: EditAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -27,7 +27,7 @@ import org.scalasteward.core.util.{LogAlg, MonadThrowable}
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 
-final class RepoCacheAlg[F[_]](
+class RepoCacheAlg[F[_]](
     implicit
     config: Config,
     gitAlg: GitAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateService.scala
@@ -30,7 +30,7 @@ import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
 import org.scalasteward.core.util
 
-final class UpdateService[F[_]](
+class UpdateService[F[_]](
     implicit
     filterAlg: FilterAlg[F],
     logger: Logger[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -20,7 +20,8 @@ import io.circe.{KeyDecoder, KeyEncoder}
 
 final case class Repo(
     owner: String,
-    repo: String
+    repo: String,
+    pid : Option[Long] = None
 ) {
   def show: String = s"$owner/$repo"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/Repo.scala
@@ -21,7 +21,7 @@ import io.circe.{KeyDecoder, KeyEncoder}
 final case class Repo(
     owner: String,
     repo: String,
-    pid : Option[Long] = None
+    pid: Option[Long] = None
 ) {
   def show: String = s"$owner/$repo"
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/StewardAlgTest.scala
@@ -1,0 +1,47 @@
+package org.scalasteward.core.application
+
+import org.scalatest.{FunSuite, Matchers}
+import better.files.File
+import org.scalasteward.core.mock.{MockEff, MockState}
+import org.scalasteward.core.vcs.data.Repo
+import org.scalasteward.core.mock.MockContext._
+import org.mockito.Mockito._
+import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository}
+import org.scalasteward.core.repocache.RepoCacheAlg
+import org.scalasteward.core.update.UpdateService
+import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg}
+
+class StewardAlgTest extends FunSuite with Matchers {
+
+  implicit val vcsMock = mock(classOf[VCSApiAlg[MockEff]])
+  implicit val vcsExtraMock = mock(classOf[VCSExtraAlg[MockEff]])
+  implicit val pullrequestMock = mock(classOf[PullRequestRepository[MockEff]])
+  implicit val updateServiceMock = mock(classOf[UpdateService[MockEff]])
+  implicit val repocacheAlgMock = mock(classOf[RepoCacheAlg[MockEff]])
+  implicit val nurtureAlgMock = mock(classOf[NurtureAlg[MockEff]])
+
+  implicit val conf = config.copy(vcsType = SupportedVCS.Gitlab)
+  val algTest = new StewardAlg[MockEff]()(
+    conf,
+    fileAlg,
+    logAlg,
+    logger,
+    nurtureAlgMock,
+    repocacheAlgMock,
+    sbtAlg,
+    updateServiceMock,
+    workspaceAlg,
+    mockEffBracketThrowable
+  )
+
+  test("the StewardAlg read the repos.md file like ") {
+    val f = File.temp / "repos_test.md"
+    val repos = algTest
+      .readRepos(f)
+      .runA(MockState.empty.add(f, "- HCScorps/baton\n- HCScorps/SOA/pid:344"))
+      .unsafeRunSync()
+
+    repos shouldEqual List(Repo("HCScorps", "baton"), Repo("HCScorps", "SOA", Some(344)))
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,5 +35,5 @@ object Dependencies {
   val refinedScalacheck = "eu.timepit" %% "refined-scalacheck" % Versions.refined
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
-  val mockito = "org.mockito" % "mockito-core" % "2.9.0"
+  val mockito = "org.mockito" % "mockito-core" % "3.0.0"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,4 +35,5 @@ object Dependencies {
   val refinedScalacheck = "eu.timepit" %% "refined-scalacheck" % Versions.refined
   val scalacheck = "org.scalacheck" %% "scalacheck" % "1.14.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
+  val mockito = "org.mockito" % "mockito-core" % "2.9.0"
 }


### PR DESCRIPTION
## Description
gitlab community edition, for some version, can't recognise a project through the encoded path, there is a way only for gitlab stewarding  to use directly the project ID.

## Note
I also remove the 'final' mark of some classes because I cannot mock them with mockito so it's a ... @ VisibleForTesting stuff I guess. If it's too dangerous I can remove the test itself or work in a way to mock all the Alg of the project.

## behaviour
now for a gitlab steward : 
a little change on the model : 

```
final case class Repo(
    owner: String,
    repo: String,
    pid : Option[Long] = None
) 
```
and so the new parsing provide : 

```  test("the StewardAlg read the repos.md file like ") {
    val f = File.temp / "repos_test.md"
    val repos = algTest
      .readRepos(f)
      .runA(MockState.empty.add(f, "- HCScorps/baton\n- HCScorps/SOA/pid:344"))
      .unsafeRunSync()
   
    repos shouldEqual List(Repo("HCScorps", "baton"), Repo("HCScorps", "SOA", Some(344)))
  }
```


Thanks
