### PR TITLE
Revert "do not force push as it might overwrite other changes"

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -153,7 +153,7 @@ object GitAlg {
       override def push(repo: Repo, branch: Branch): F[Unit] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)
-          _ <- exec(Nel.of("push", "--set-upstream", "origin", branch.name), repoDir)
+          _ <- exec(Nel.of("push", "--force", "--set-upstream", "origin", branch.name), repoDir)
         } yield ()
 
       override def remoteBranchExists(repo: Repo, branch: Branch): F[Boolean] =

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -91,7 +91,7 @@ class GitAlgTest extends FunSuite with Matchers {
         List(askPass, repoDir, "git", "fetch", "upstream"),
         List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
         List(askPass, repoDir, "git", "merge", "upstream/master"),
-        List(askPass, repoDir, "git", "push", "--set-upstream", "origin", "master")
+        List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
@@ -76,7 +76,7 @@ class GitHubRepoAlgTest extends FunSuite with Matchers {
         List(askPass, repoDir, "git", "fetch", "upstream"),
         List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
         List(askPass, repoDir, "git", "merge", "upstream/master"),
-        List(askPass, repoDir, "git", "push", "--set-upstream", "origin", "master")
+        List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")
       )
     )
     result shouldBe parentRepoOut


### PR DESCRIPTION
Reverts fthomas/scala-steward#878

That change caused quite a few errors that looked like this:
```
2019-09-09 15:14:58,601 INFO  ──────────── Nurture exoego/aws-sdk-scalajs-facade ────────────
2019-09-09 15:14:58,601 INFO  Clone and synchronize exoego/aws-sdk-scalajs-facade
2019-09-09 15:15:04,961 INFO  Find updates for exoego/aws-sdk-scalajs-facade
2019-09-09 15:17:07,322 INFO  Ignore org.scala-lang:scala-library:provided : 2.12.8 -> 2.12.9 -> 2.13.0 (reason: ignored globally)
2019-09-09 15:17:07,324 INFO  Found 3 updates:
  ch.epfl.scala:sbt-scalajs-bundler : 0.15.0-0.6 -> 0.15.0
  org.scalameta:scalafmt-core : 2.0.0 -> 2.0.1
  org.xerial.sbt:sbt-sonatype : 2.5 -> 2.6 -> 3.6
2019-09-09 15:17:07,363 INFO  Process update ch.epfl.scala:sbt-scalajs-bundler : 0.15.0-0.6 -> 0.15.0
2019-09-09 15:17:08,849 INFO  Trying heuristic 'strict'
2019-09-09 15:17:08,889 INFO  Create branch update/sbt-scalajs-bundler-0.15.0
2019-09-09 15:17:08,961 INFO  Commit and push changes
2019-09-09 15:17:10,920 ERROR ──────────── Nurture exoego/aws-sdk-scalajs-facade ──────────── failed
java.io.IOException: 'git push --set-upstream origin update/sbt-scalajs-bundler-0.15.0' exited with code 1
To https://github.com/scala-steward/aws-sdk-scalajs-facade.git
 ! [rejected]        update/sbt-scalajs-bundler-0.15.0 -> update/sbt-scalajs-bundler-0.15.0 (non-fast-forward)
error: failed to push some refs to 'https://scala-steward@github.com/scala-steward/aws-sdk-scalajs-facade.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

This needs further investigation, I've no idea why this happened. Until then, I'll revert to keep things running.