### PR TITLE
Do not include non-existent release note/changelog

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.util
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.http4s.client.Client
-import org.http4s.{Method, Request, Uri}
+import org.http4s.{Method, Request, Status, Uri}
 
 final class HttpExistenceClient[F[_]](
     implicit
@@ -31,7 +31,7 @@ final class HttpExistenceClient[F[_]](
 
   def exists(uri: Uri): F[Boolean] = {
     val req = Request[F](method = Method.HEAD, uri = uri)
-    client.status(req).map(_.isSuccess).handleErrorWith { throwable =>
+    client.status(req).map(_ === Status.Ok).handleErrorWith { throwable =>
       logger.debug(throwable)(s"Failed to check if $uri exists").as(false)
     }
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -14,6 +14,7 @@ class VCSExtraAlgTest extends FunSuite with Matchers {
   val routes: HttpRoutes[IO] =
     HttpRoutes.of[IO] {
       case HEAD -> Root / "foo" / "bar" / "compare" / "v0.1.0...v0.2.0" => Ok("exist")
+      case HEAD -> Root / "foo" / "buz" / "compare" / "v0.1.0...v0.2.0" => PermanentRedirect()
       case _                                                            => NotFound()
     }
 
@@ -23,6 +24,7 @@ class VCSExtraAlgTest extends FunSuite with Matchers {
   val vcsExtraAlg = VCSExtraAlg.create[IO]
   val updateFoo = Update.Single("com.example", "foo", "0.1.0", Nel.of("0.2.0"))
   val updateBar = Update.Single("com.example", "bar", "0.1.0", Nel.of("0.2.0"))
+  val updateBuz = Update.Single("com.example", "buz", "0.1.0", Nel.of("0.2.0"))
 
   test("getBranchCompareUrl") {
     vcsExtraAlg.getBranchCompareUrl(None, updateBar).unsafeRunSync() shouldBe None
@@ -32,5 +34,8 @@ class VCSExtraAlgTest extends FunSuite with Matchers {
     vcsExtraAlg
       .getBranchCompareUrl(Some("https://github.com/foo/bar"), updateBar)
       .unsafeRunSync() shouldBe Some("https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
+    vcsExtraAlg
+      .getBranchCompareUrl(Some("https://github.com/foo/buz"), updateBuz)
+      .unsafeRunSync() shouldBe None
   }
 }


### PR DESCRIPTION
Closes #915 

`HttpExistenceClient` should return `true` only if http response status is 200.
This is necessary since some servers return 302 and then 200 for 404.html.

Example PR:
* scalaz (404) have no link https://github.com/exoego/scala-steward-test-project/pull/98
* groovy (302->200) have no link https://github.com/exoego/scala-steward-test-project/pull/97
* minitest (200) have link to GitHub release https://github.com/exoego/scala-steward-test-project/pull/99
