### PR TITLE
Ignore errors in memoizedGetDependencies

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -78,7 +78,9 @@ final class NurtureAlg[F[_]](
       grouped = Update.group(filtered)
       _ <- logger.info(util.logger.showUpdates(grouped))
       baseSha1 <- gitAlg.latestSha1(repo, baseBranch)
-      memoizedGetDependencies <- Async.memoize(sbtAlg.getDependencies(repo))
+      memoizedGetDependencies <- Async.memoize {
+        sbtAlg.getDependencies(repo).handleError(_ => List.empty)
+      }
       _ <- grouped.traverse_ { update =>
         val data =
           UpdateData(


### PR DESCRIPTION
Dependencies are required to find URLs. If getting dependecies fails, it
should not prevent Scala Steward from creating the PR.

This is another source of errors which will be eliminated with #851.