### PR TITLE
Enhance possibleReleaseNoteFiles

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -75,10 +75,22 @@ package object vcs {
         )
       else
         List.empty
-    val files = for {
-      name <- List("CHANGELOG", "Changelog", "changelog", "RELEASES", "Releases", "releases")
-      ext <- List("md", "markdown", "rst")
-    } yield s"${canonicalized}/${name}.${ext}"
+    val files = {
+      val pathToFile =
+        if (repoUrl.startsWith("https://github.com/") || repoUrl.startsWith("https://gitlab.com/")) {
+          Some("blob/master")
+        } else if (repoUrl.startsWith("https://bitbucket.org/")) {
+          Some("master")
+        } else {
+          None
+        }
+      pathToFile.toList.flatMap { path =>
+        for {
+          name <- List("CHANGELOG", "Changelog", "changelog", "RELEASES", "Releases", "releases")
+          ext <- List("md", "markdown", "rst")
+        } yield s"${canonicalized}/${path}/${name}.${ext}"
+      }
+    }
     files ++ vcsSpecific
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -43,4 +43,77 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
 
     possibleCompareUrls("https://scalacenter.github.io/scalafix/", update) shouldBe List()
   }
+
+  test("possibleReleaseNoteFiles") {
+    // blob/<branch>
+    possibleReleaseNoteFiles("https://github.com/foo/bar", update) shouldBe List(
+      "https://github.com/foo/bar/blob/master/CHANGELOG.md",
+      "https://github.com/foo/bar/blob/master/CHANGELOG.markdown",
+      "https://github.com/foo/bar/blob/master/CHANGELOG.rst",
+      "https://github.com/foo/bar/blob/master/Changelog.md",
+      "https://github.com/foo/bar/blob/master/Changelog.markdown",
+      "https://github.com/foo/bar/blob/master/Changelog.rst",
+      "https://github.com/foo/bar/blob/master/changelog.md",
+      "https://github.com/foo/bar/blob/master/changelog.markdown",
+      "https://github.com/foo/bar/blob/master/changelog.rst",
+      "https://github.com/foo/bar/blob/master/RELEASES.md",
+      "https://github.com/foo/bar/blob/master/RELEASES.markdown",
+      "https://github.com/foo/bar/blob/master/RELEASES.rst",
+      "https://github.com/foo/bar/blob/master/Releases.md",
+      "https://github.com/foo/bar/blob/master/Releases.markdown",
+      "https://github.com/foo/bar/blob/master/Releases.rst",
+      "https://github.com/foo/bar/blob/master/releases.md",
+      "https://github.com/foo/bar/blob/master/releases.markdown",
+      "https://github.com/foo/bar/blob/master/releases.rst",
+      "https://github.com/foo/bar/releases/tag/1.2.3",
+      "https://github.com/foo/bar/releases/tag/v1.2.3"
+    )
+
+    // blob/<branch>
+    possibleReleaseNoteFiles("https://gitlab.com/foo/bar", update) shouldBe List(
+      "https://gitlab.com/foo/bar/blob/master/CHANGELOG.md",
+      "https://gitlab.com/foo/bar/blob/master/CHANGELOG.markdown",
+      "https://gitlab.com/foo/bar/blob/master/CHANGELOG.rst",
+      "https://gitlab.com/foo/bar/blob/master/Changelog.md",
+      "https://gitlab.com/foo/bar/blob/master/Changelog.markdown",
+      "https://gitlab.com/foo/bar/blob/master/Changelog.rst",
+      "https://gitlab.com/foo/bar/blob/master/changelog.md",
+      "https://gitlab.com/foo/bar/blob/master/changelog.markdown",
+      "https://gitlab.com/foo/bar/blob/master/changelog.rst",
+      "https://gitlab.com/foo/bar/blob/master/RELEASES.md",
+      "https://gitlab.com/foo/bar/blob/master/RELEASES.markdown",
+      "https://gitlab.com/foo/bar/blob/master/RELEASES.rst",
+      "https://gitlab.com/foo/bar/blob/master/Releases.md",
+      "https://gitlab.com/foo/bar/blob/master/Releases.markdown",
+      "https://gitlab.com/foo/bar/blob/master/Releases.rst",
+      "https://gitlab.com/foo/bar/blob/master/releases.md",
+      "https://gitlab.com/foo/bar/blob/master/releases.markdown",
+      "https://gitlab.com/foo/bar/blob/master/releases.rst"
+    )
+
+    // just <branch>
+    possibleReleaseNoteFiles("https://bitbucket.org/foo/bar", update) shouldBe List(
+      "https://bitbucket.org/foo/bar/master/CHANGELOG.md",
+      "https://bitbucket.org/foo/bar/master/CHANGELOG.markdown",
+      "https://bitbucket.org/foo/bar/master/CHANGELOG.rst",
+      "https://bitbucket.org/foo/bar/master/Changelog.md",
+      "https://bitbucket.org/foo/bar/master/Changelog.markdown",
+      "https://bitbucket.org/foo/bar/master/Changelog.rst",
+      "https://bitbucket.org/foo/bar/master/changelog.md",
+      "https://bitbucket.org/foo/bar/master/changelog.markdown",
+      "https://bitbucket.org/foo/bar/master/changelog.rst",
+      "https://bitbucket.org/foo/bar/master/RELEASES.md",
+      "https://bitbucket.org/foo/bar/master/RELEASES.markdown",
+      "https://bitbucket.org/foo/bar/master/RELEASES.rst",
+      "https://bitbucket.org/foo/bar/master/Releases.md",
+      "https://bitbucket.org/foo/bar/master/Releases.markdown",
+      "https://bitbucket.org/foo/bar/master/Releases.rst",
+      "https://bitbucket.org/foo/bar/master/releases.md",
+      "https://bitbucket.org/foo/bar/master/releases.markdown",
+      "https://bitbucket.org/foo/bar/master/releases.rst"
+    )
+
+    // Empty for homepage
+    possibleReleaseNoteFiles("https://scalacenter.github.io/scalafix/", update) shouldBe List()
+  }
 }


### PR DESCRIPTION
Direct link to file requires special path.

* GitHub & GitLab: `/owner/repo/blob/<branch>/path/to/file`
    * e.g. https://github.com/typelevel/discipline-specs2/blob/master/CHANGELOG.md
    * e.g. https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CHANGELOG.md
* BitBucket:       `/owner/repo/<branch>/path/to/file`
    * e.g. https://bitbucket.org/gluon-oss/ignite/src/default/LICENSE
* Other pages: Empty. This skips unnecessary fetching URLs.
