### PR TITLE
Fetch only default branch when syncing the fork

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/GitAlg.scala
@@ -171,7 +171,7 @@ object GitAlg {
           branch = defaultBranch.name
           remoteBranch = s"$remote/$branch"
           _ <- exec(Nel.of("remote", "add", remote, upstreamUrl.toString), repoDir)
-          _ <- exec(Nel.of("fetch", remote), repoDir)
+          _ <- exec(Nel.of("fetch", remote, branch), repoDir)
           _ <- exec(Nel.of("checkout", "-B", branch, "--track", remoteBranch), repoDir)
           _ <- exec(Nel.of("merge", remoteBranch), repoDir)
           _ <- push(repo, defaultBranch)

--- a/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/GitAlgTest.scala
@@ -89,7 +89,7 @@ class GitAlgTest extends AnyFunSuite with Matchers {
           "upstream",
           "http://github.com/fthomas/datapackage"
         ),
-        List(askPass, repoDir, "git", "fetch", "upstream"),
+        List(askPass, repoDir, "git", "fetch", "upstream", "master"),
         List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
         List(askPass, repoDir, "git", "merge", "upstream/master"),
         List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")

--- a/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/github/GitHubRepoAlgTest.scala
@@ -74,7 +74,7 @@ class GitHubRepoAlgTest extends AnyFunSuite with Matchers {
           "upstream",
           s"https://${config.vcsLogin}@github.com/fthomas/datapackage"
         ),
-        List(askPass, repoDir, "git", "fetch", "upstream"),
+        List(askPass, repoDir, "git", "fetch", "upstream", "master"),
         List(askPass, repoDir, "git", "checkout", "-B", "master", "--track", "upstream/master"),
         List(askPass, repoDir, "git", "merge", "upstream/master"),
         List(askPass, repoDir, "git", "push", "--force", "--set-upstream", "origin", "master")


### PR DESCRIPTION
The default branch is the only branch required from the upstream repo
for syncing Scala Steward's fork. Working on large repos with many
branches will be a lot faster with this change.