### PR TITLE
Print banner at start of application

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val core = myCrossProject("core")
           defaultStrategy(otherwise)
       }
     },
-    buildInfoKeys := Seq[BuildInfoKey](scalaVersion, scalaBinaryVersion, sbtVersion),
+    buildInfoKeys := Seq[BuildInfoKey](version, scalaVersion, scalaBinaryVersion, sbtVersion),
     buildInfoPackage := moduleRootPkg.value,
     initialCommands += s"""
       import ${moduleRootPkg.value}._

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -43,6 +43,19 @@ final class StewardAlg[F[_]](
     workspaceAlg: WorkspaceAlg[F],
     F: Monad[F]
 ) {
+  def printBanner: F[Unit] = {
+    val banner =
+      """|  ____            _         ____  _                             _
+         | / ___|  ___ __ _| | __ _  / ___|| |_ _____      ____ _ _ __ __| |
+         | \___ \ / __/ _` | |/ _` | \___ \| __/ _ \ \ /\ / / _` | '__/ _` |
+         |  ___) | (_| (_| | | (_| |  ___) | ||  __/\ V  V / (_| | | | (_| |
+         | |____/ \___\__,_|_|\__,_| |____/ \__\___| \_/\_/ \__,_|_|  \__,_|
+         |""".stripMargin
+    val msg = List(" ", banner, s" v${org.scalasteward.core.BuildInfo.version}", " ")
+      .mkString(System.lineSeparator())
+    logger.info(msg)
+  }
+
   def prepareEnv: F[Unit] =
     for {
       _ <- sbtAlg.addGlobalPlugins
@@ -75,6 +88,7 @@ final class StewardAlg[F[_]](
   def runF: F[ExitCode] =
     logger.infoTotalTime("run") {
       for {
+        _ <- printBanner
         _ <- prepareEnv
         repos <- readRepos(config.reposFile)
         reposToNurture <- if (config.pruneRepos) pruneRepos(repos) else F.pure(repos)


### PR DESCRIPTION
This banner is now printed at the start of the application:
```
2019-09-15 20:32:54,029 INFO
  ____            _         ____  _                             _
 / ___|  ___ __ _| | __ _  / ___|| |_ _____      ____ _ _ __ __| |
 \___ \ / __/ _` | |/ _` | \___ \| __/ _ \ \ /\ / / _` | '__/ _` |
  ___) | (_| (_| | | (_| |  ___) | ||  __/\ V  V / (_| | | | (_| |
 |____/ \___\__,_|_|\__,_| |____/ \__\___| \_/\_/ \__,_|_|  \__,_|
 v0.4.0-1-5653f7f0-20190915-1731
```
This is obviously a very important enhancement! :-)

The banner was generated by http://patorjk.com/software/taag/#p=display&f=Standard&t=Scala%20Steward