### PR TITLE
Update scala-steward permissions in docker container

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val dockerSettings = Def.settings(
     ExecCmd("RUN", "apt-get", "install", "-y", "sbt"),
     Cmd("WORKDIR", "/opt/docker"),
     Cmd("ADD", "opt", "/opt"),
+    ExecCmd("RUN", "chmod", "0755", "/opt/docker/bin/scala-steward"),
     ExecCmd("ENTRYPOINT", "/opt/docker/bin/scala-steward"),
     ExecCmd("CMD", "")
   ),


### PR DESCRIPTION
java.lang.Throwable: Required option --workspace not specified
Required option --repos-file not specified
Required option --git-author-email not specified
Required option --vcs-login not specified
Required option --git-ask-pass not specified
    at org.scalasteward.core.application.Cli.$anonfun$parseArgs$7(Cli.scala:33)
    at cats.syntax.EitherOps$.bimap$extension(either.scala:128)
    at org.scalasteward.core.application.Cli.parseArgs(Cli.scala:33)
    at org.scalasteward.core.application.Context$.create(Context.scala:48)
    at org.scalasteward.core.Main$.run(Main.scala:24)
    at cats.effect.IOApp.$anonfun$main$3(IOApp.scala:67)
    at cats.effect.internals.IOAppPlatform$.mainFiber(IOAppPlatform.scala:36)
    at cats.effect.internals.IOAppPlatform$.main(IOAppPlatform.scala:24)
    at cats.effect.IOApp.main(IOApp.scala:67)
    at cats.effect.IOApp.main$(IOApp.scala:66)
    at org.scalasteward.core.Main$.main(Main.scala:22)
    at org.scalasteward.core.Main.main(Main.scala)
```

Setting permissions to `0755` allows it to work as non-root user,
which is a bit more secure and convenient for a non-root CI setup.