### PR TITLE
Update scalafix for scalatest

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -59,8 +59,8 @@ package object scalafix {
         Nel.of("scalatest".r),
         Version("3.1.0"),
         Nel.of(
-          "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala",
-          "https://raw.githubusercontent.com/scalatest/autofix/6168da0e2bd113872b7dcd22cad7688d97ef9381/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala"
+          "https://raw.githubusercontent.com/scalatest/autofix/e4de53fa40fac423bd64d165ff36bde38ce52388/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala",
+          "https://raw.githubusercontent.com/scalatest/autofix/e4de53fa40fac423bd64d165ff36bde38ce52388/3.1.x/rules/src/main/scala/org/scalatest/autofix/v3_1_x/RewriteDeprecatedNames.scala"
         )
       ),
       Migration(


### PR DESCRIPTION
Closes #790 
This PR should wait until [scalatest/autofix](https://github.com/scalatest/autofix) releases its stable version.
