### PR TITLE
Add avast/scala-server-toolkit to repos.md

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -37,6 +37,7 @@
 - Atry/scalajs-all-in-one-template
 - augustjune/canoe
 - avast/datadog4s
+- avast/scala-server-toolkit
 - AVSystem/scala-commons
 - azhur/kafka-serde-scala
 - balhoff/arachne


### PR DESCRIPTION
We're starting a new project and we'd like to use Scala Steward for it. Thank you.