### PR TITLE
Automatically exclude dependencies from update check

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -31,7 +31,7 @@ import org.scalasteward.core.repocache.{RepoCacheAlg, RepoCacheRepository}
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.scalafmt.ScalafmtAlg
-import org.scalasteward.core.update.{FilterAlg, UpdateAlg, UpdateRepository}
+import org.scalasteward.core.update.{ExcludeAlg, FilterAlg, UpdateAlg, UpdateRepository}
 import org.scalasteward.core.util._
 import org.scalasteward.core.vcs.data.AuthenticatedUser
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg, VCSSelection}
@@ -72,6 +72,8 @@ object Context {
         new UpdateRepository[F](new JsonKeyValueStore("updates", "3"))
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create
       implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F]
+      implicit val excludeAlg: ExcludeAlg[F] =
+        new ExcludeAlg[F](new JsonKeyValueStore("excluded", "1"))
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
       new StewardAlg[F]
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/ExcludeAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/ExcludeAlg.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.update
+
+import cats.Monad
+import cats.implicits._
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
+import java.util.concurrent.TimeUnit
+import org.scalasteward.core.data.Dependency
+import org.scalasteward.core.persistence.KeyValueStore
+import org.scalasteward.core.update.ExcludeAlg._
+import org.scalasteward.core.util.DateTimeAlg
+import scala.concurrent.duration._
+
+final class ExcludeAlg[F[_]](
+    kvStore: KeyValueStore[F, String, List[Entry]]
+)(
+    implicit
+    dateTimeAlg: DateTimeAlg[F],
+    F: Monad[F]
+) {
+  private val key = "excluded"
+
+  def excludeTemporarily(dependencies: List[Dependency]): F[Unit] =
+    dateTimeAlg.currentTimeMillis.flatMap { now =>
+      kvStore.update(key) {
+        _.getOrElse(List.empty).filter(_.isExcluded(now)) ++ dependencies.map(Entry(_, now))
+      }
+    }
+
+  def removeExcluded(dependencies: List[Dependency]): F[List[Dependency]] =
+    for {
+      now <- dateTimeAlg.currentTimeMillis
+      maybeExcluded <- kvStore.get(key)
+      excluded = maybeExcluded.getOrElse(List.empty).filter(_.isExcluded(now))
+      _ <- kvStore.put(key, excluded)
+    } yield dependencies.diff(excluded.map(_.dependency))
+}
+
+object ExcludeAlg {
+  final case class Entry(dependency: Dependency, excludedAt: Long) {
+    def isExcluded(now: Long): Boolean =
+      FiniteDuration(now - excludedAt, TimeUnit.MILLISECONDS) <= 21.days
+  }
+
+  object Entry {
+    implicit val entryDecoder: Decoder[Entry] =
+      deriveDecoder
+
+    implicit val entryEncoder: Encoder[Entry] =
+      deriveEncoder
+  }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -32,6 +32,7 @@ import org.scalasteward.core.util
 
 final class UpdateAlg[F[_]](
     implicit
+    excludeAlg: ExcludeAlg[F],
     filterAlg: FilterAlg[F],
     logger: Logger[F],
     pullRequestRepo: PullRequestRepository[F],
@@ -42,12 +43,14 @@ final class UpdateAlg[F[_]](
 ) {
 
   // WIP
-  def checkForUpdates(repos: List[Repo]): F[List[Update.Single]] =
+  def checkForUpdates(repos: List[Repo]): F[List[Update.Single]] = {
+    val getDependencies =
+      repoCacheRepository.getDependencies(repos).flatMap(excludeAlg.removeExcluded)
     updateRepository.deleteAll >>
-      repoCacheRepository.getDependencies(repos).flatMap { dependencies =>
+      getDependencies.flatMap { dependencies =>
         val (libraries, plugins) = dependencies
           .filter { d =>
-            FilterAlg.isIgnoredGlobally(d.toUpdate).isRight && UpdateAlg.includeInUpdateCheck(d)
+            FilterAlg.isIgnoredGlobally(d.toUpdate).isRight
           }
           .partition(_.sbtVersion.isEmpty)
         val libProjects = splitter
@@ -81,7 +84,10 @@ final class UpdateAlg[F[_]](
             util.divideOnError(prj)(sbtAlg.getUpdatesForProject)(_.halve.toList.flatMap {
               case (p1, p2) => List(p1, p2)
             }) { (failedP: ArtificialProject, t: Throwable) =>
-              logger.error(t)(s"failed finding updates for $failedP").as(List.empty[Update.Single])
+              for {
+                _ <- logger.error(t)(s"failed finding updates for $failedP")
+                _ <- excludeAlg.excludeTemporarily(failedP.libraries ++ failedP.plugins)
+              } yield List.empty[Update.Single]
             }
 
           fa.flatTap { updates =>
@@ -92,6 +98,7 @@ final class UpdateAlg[F[_]](
 
         x.flatMap(updates => filterAlg.globalFilterMany(updates))
       }
+  }
 
   def filterByApplicableUpdates(repos: List[Repo], updates: List[Update.Single]): F[List[Repo]] =
     repos.filterA(needsAttention(_, updates))
@@ -155,24 +162,6 @@ object UpdateAlg {
     update.groupId === dependency.groupId &&
       update.artifactIds.contains_(dependency.artifactId) &&
       update.currentVersion === dependency.version
-
-  def includeInUpdateCheck(dependency: Dependency): Boolean =
-    (dependency.groupId, dependency.artifactId) match {
-      case ("com.ccadllc.cedi", "build")                     => false
-      case ("com.codecommit", "sbt-spiewak-sonatype")        => false
-      case ("com.gilt.sbt", "sbt-newrelic")                  => false
-      case ("com.iheart", "sbt-play-swagger")                => false
-      case ("com.nrinaudo", "kantan.sbt-kantan")             => false
-      case ("com.slamdata", "sbt-quasar-datasource")         => false
-      case ("com.typesafe.play", "interplay")                => false
-      case ("org.foundweekends.giter8", "sbt-giter8")        => false
-      case ("org.scalablytyped", "sbt-scalablytyped")        => false
-      case ("org.scala-lang.modules", "sbt-scala-module")    => false
-      case ("org.scala-lang.modules", "scala-module-plugin") => false
-      case ("org.scodec", "scodec-build")                    => false
-      case ("org.xerial.sbt", "sbt-pack")                    => false
-      case _                                                 => true
-    }
 
   def getNewerGroupId(currentGroupId: String, artifactId: String): Option[(String, String)] =
     Option((currentGroupId, artifactId) match {


### PR DESCRIPTION
If `pruneRepos` is `true`, Scala Steward will check all dependencies of
all repos for newer versions to decide on which repos it needs to be
working on. If a dependency can't be checked for updates with
`SbtAlg.getUpdatesForProject`, the whole update check is slowed down
considerably because of the way `UpdateAlg.checkForUpdates` is currently
implemented. Before this change, there was a static list of dependencies
that should be excluded from the update check to speed it up. With this
change this list is now dynamic and it excludes dependencies that
can't be checked for updates for 21 days from the update check. After
that period they are checked again for updates and if that fails again,
they'll be exluded again for the next 21 days.