### PR TITLE
Do not refresh caches of failing repos

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -27,7 +27,7 @@ import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.{NurtureAlg, PullRequestRepository}
 import org.scalasteward.core.persistence.JsonKeyValueStore
-import org.scalasteward.core.repocache.{RepoCacheAlg, RepoCacheRepository}
+import org.scalasteward.core.repocache.{RefreshErrorAlg, RepoCacheAlg, RepoCacheRepository}
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
 import org.scalasteward.core.scalafmt.ScalafmtAlg
@@ -66,6 +66,8 @@ object Context {
         new PullRequestRepository[F](new JsonKeyValueStore("prs", "3"))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
+      implicit val refreshErrorAlg =
+        new RefreshErrorAlg[F](new JsonKeyValueStore("repos_refresh_errors", "1"))
       implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F]
       implicit val editAlg: EditAlg[F] = new EditAlg[F]
       implicit val updateRepository: UpdateRepository[F] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RefreshErrorAlg.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repocache
+
+import cats.Monad
+import cats.implicits._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import java.util.concurrent.TimeUnit
+import org.scalasteward.core.persistence.KeyValueStore
+import org.scalasteward.core.repocache.RefreshErrorAlg.Entry
+import org.scalasteward.core.util.DateTimeAlg
+import org.scalasteward.core.vcs.data.Repo
+import scala.concurrent.duration._
+
+final class RefreshErrorAlg[F[_]](kvStore: KeyValueStore[F, Repo, Entry])(
+    implicit
+    dateTimeAlg: DateTimeAlg[F],
+    F: Monad[F]
+) {
+  def failedRecently(repo: Repo): F[Boolean] =
+    dateTimeAlg.currentTimeMillis.flatMap { now =>
+      val maybeEntry = kvStore.modify(repo) {
+        case Some(entry) if entry.hasExpired(now) => None
+        case res                                  => res
+      }
+      maybeEntry.map(_.isDefined)
+    }
+
+  def persistError(repo: Repo, throwable: Throwable): F[Unit] =
+    dateTimeAlg.currentTimeMillis.flatMap { now =>
+      kvStore.put(repo, Entry(now, throwable.getMessage))
+    }
+}
+
+object RefreshErrorAlg {
+  final case class Entry(failedAt: Long, message: String) {
+    def hasExpired(now: Long): Boolean = {
+      val timeToLive = 7.days
+      FiniteDuration(now - failedAt, TimeUnit.MILLISECONDS) > timeToLive
+    }
+  }
+
+  object Entry {
+    implicit val entryDecoder: Decoder[Entry] =
+      deriveDecoder
+
+    implicit val entryEncoder: Encoder[Entry] =
+      deriveEncoder
+  }
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -33,6 +33,7 @@ final class RepoCacheAlg[F[_]](
     config: Config,
     gitAlg: GitAlg[F],
     logger: Logger[F],
+    refreshErrorAlg: RefreshErrorAlg[F],
     repoCacheRepository: RepoCacheRepository[F],
     repoConfigAlg: RepoConfigAlg[F],
     sbtAlg: SbtAlg[F],
@@ -44,13 +45,16 @@ final class RepoCacheAlg[F[_]](
 
   def checkCache(repo: Repo): F[Unit] =
     logger.attemptLog_(s"Check cache of ${repo.show}") {
-      for {
-        (repoOut, branchOut) <- vcsApiAlg.createForkOrGetRepoWithDefaultBranch(config, repo)
-        cachedSha1 <- repoCacheRepository.findSha1(repo)
-        latestSha1 = branchOut.commit.sha
-        refreshRequired = cachedSha1.forall(_ =!= latestSha1)
-        _ <- if (refreshRequired) cloneAndRefreshCache(repo, repoOut) else F.unit
-      } yield ()
+      F.ifM(refreshErrorAlg.failedRecently(repo))(
+        F.unit,
+        for {
+          (repoOut, branchOut) <- vcsApiAlg.createForkOrGetRepoWithDefaultBranch(config, repo)
+          cachedSha1 <- repoCacheRepository.findSha1(repo)
+          latestSha1 = branchOut.commit.sha
+          refreshRequired = cachedSha1.forall(_ =!= latestSha1)
+          _ <- if (refreshRequired) cloneAndRefreshCache(repo, repoOut) else F.unit
+        } yield ()
+      )
     }
 
   private def cloneAndRefreshCache(repo: Repo, repoOut: RepoOut): F[Unit] =
@@ -62,7 +66,15 @@ final class RepoCacheAlg[F[_]](
       _ <- gitAlg.removeClone(repo)
     } yield ()
 
-  private def refreshCache(repo: Repo): F[RepoCache] =
+  private def refreshCache(repo: Repo): F[Unit] =
+    computeCache(repo).attempt.flatMap {
+      case Right(cache) =>
+        repoCacheRepository.updateCache(repo, cache)
+      case Left(throwable) =>
+        refreshErrorAlg.persistError(repo, throwable) >> F.raiseError(throwable)
+    }
+
+  private def computeCache(repo: Repo): F[RepoCache] =
     for {
       branch <- gitAlg.currentBranch(repo)
       latestSha1 <- gitAlg.latestSha1(repo, branch)
@@ -70,13 +82,12 @@ final class RepoCacheAlg[F[_]](
       maybeSbtVersion <- sbtAlg.getSbtVersion(repo)
       maybeScalafmtVersion <- scalafmtAlg.getScalafmtVersion(repo)
       maybeRepoConfig <- repoConfigAlg.readRepoConfig(repo)
-      cache = RepoCache(
+    } yield
+      RepoCache(
         latestSha1,
         dependencies,
         maybeSbtVersion,
         maybeScalafmtVersion,
         maybeRepoConfig
       )
-      _ <- repoCacheRepository.updateCache(repo, cache)
-    } yield cache
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -82,12 +82,11 @@ final class RepoCacheAlg[F[_]](
       maybeSbtVersion <- sbtAlg.getSbtVersion(repo)
       maybeScalafmtVersion <- scalafmtAlg.getScalafmtVersion(repo)
       maybeRepoConfig <- repoConfigAlg.readRepoConfig(repo)
-    } yield
-      RepoCache(
-        latestSha1,
-        dependencies,
-        maybeSbtVersion,
-        maybeScalafmtVersion,
-        maybeRepoConfig
-      )
+    } yield RepoCache(
+      latestSha1,
+      dependencies,
+      maybeSbtVersion,
+      maybeScalafmtVersion,
+      maybeRepoConfig
+    )
 }


### PR DESCRIPTION
If `--prune-repos=true`, Scala Steward checks for every repository if
their `RepoCache` is still fresh and refreshes it if necessary. A cache
refresh calls sbt to get a list of all dependencies and is therefore a
costly operation. There are some repositories for which the refresh
fails because of a broken build. These broken repos slow down Steward
because it tries to refresh them on every run. With this change, the
caches of those repositores are not refreshed for 7 days. Note that the
caches are not invalidated if there is an error during the refresh.