### PR TITLE
Add Rewards Network to companies using Scala Steward

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Consider creating PR to add your company to the list and join the community.
 * [Firstbird](https://firstbird.com)
 * [HolidayCheck](https://github.com/holidaycheck)
 * [iAdvize](https://www.iadvize.com/en/)
+* [Rewards Network](https://www.rewardsnetwork.com/)
 * [Septeni Original](https://www.septeni-original.co.jp)
 * [SlamData](https://slamdata.com/)
 * [Snowplow Analytics](https://snowplowanalytics.com/)


### PR DESCRIPTION
I'm working for Rewards Network and, as I mentioned on Gitter earlier this week, we started using it in a gradual capacity. Hopefully within the next couple of months it becomes standard for all new projects. Right now we're using it on about ~5-6 or so on our internal repositories.