### PR TITLE
 Prevent updates to a pre-release of another series

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -18,14 +18,14 @@ package org.scalasteward.core.data
 
 import cats.Order
 import cats.implicits._
-import io.circe.{Decoder, Encoder}
+import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.util
-
 import scala.util.Try
 
 final case class Version(value: String) {
-  def numericComponents: List[BigInt] =
+  val numericComponents: List[BigInt] =
     value
       .split(Array('.', '-', '+'))
       .flatMap(util.string.splitNumericAndNonNumeric)
@@ -36,6 +36,36 @@ final case class Version(value: String) {
         case s                   => Try(BigInt(s)).getOrElse(BigInt(0))
       }
       .toList
+
+  /** Selects the next version from a list of potentially newer versions.
+    *
+    * Implements the scheme described in this FAQ:
+    * https://github.com/fthomas/scala-steward/blob/master/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to
+    */
+  def selectNext(versions: List[Version]): Option[Version] = {
+    val cutoff = preReleaseIndex.fold(numericComponents.size)(_.value - 1)
+    val newerVersionsByCommonPrefix: Map[List[(BigInt, BigInt)], List[Version]] =
+      versions
+        .filter(_ > this)
+        .groupBy(_.numericComponents.zip(numericComponents).take(cutoff).takeWhile {
+          case (c1, c2) => c1 === c2
+        })
+
+    newerVersionsByCommonPrefix.toList
+      .sortBy { case (commonPrefix, _) => commonPrefix.length }
+      .flatMap {
+        case (commonPrefix, vs) =>
+          // Do not select pre-release versions of a different series.
+          vs.filterNot(_.isPreRelease && cutoff =!= commonPrefix.length).sorted
+      }
+      .lastOption
+  }
+
+  private def isPreRelease: Boolean =
+    preReleaseIndex.isDefined
+
+  private def preReleaseIndex: Option[NonNegInt] =
+    NonNegInt.unapply(numericComponents.indexWhere(_ < 0))
 }
 
 object Version {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -19,10 +19,11 @@ package org.scalasteward.core.update
 import cats.implicits._
 import cats.{Monad, TraverseFilter}
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{Update, Version}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.FilterAlg._
 import org.scalasteward.core.util
+import org.scalasteward.core.util.Nel
 
 final class FilterAlg[F[_]](
     implicit
@@ -52,11 +53,11 @@ object FilterAlg {
   sealed trait RejectionReason {
     def update: Update.Single
     def show: String = this match {
-      case IgnoredGlobally(_)             => "ignored globally"
-      case IgnoredByConfig(_)             => "ignored by config"
-      case NotAllowedByConfig(_)          => "not allowed by config"
-      case BadVersions(_)                 => "bad versions"
-      case NonSnapshotToSnapshotUpdate(_) => "non-snapshot to snapshot"
+      case IgnoredGlobally(_)       => "ignored globally"
+      case IgnoredByConfig(_)       => "ignored by config"
+      case NotAllowedByConfig(_)    => "not allowed by config"
+      case BadVersions(_)           => "bad versions"
+      case NoSuitableNextVersion(_) => "no suitable next version"
     }
   }
 
@@ -64,12 +65,12 @@ object FilterAlg {
   final case class IgnoredByConfig(update: Update.Single) extends RejectionReason
   final case class NotAllowedByConfig(update: Update.Single) extends RejectionReason
   final case class BadVersions(update: Update.Single) extends RejectionReason
-  final case class NonSnapshotToSnapshotUpdate(update: Update.Single) extends RejectionReason
+  final case class NoSuitableNextVersion(update: Update.Single) extends RejectionReason
 
   def globalFilter(update: Update.Single): FilterResult =
     removeBadVersions(update)
       .flatMap(isIgnoredGlobally)
-      .flatMap(ignoreNonSnapshotToSnapshotUpdate)
+      .flatMap(selectSuitableNextVersion)
 
   def localFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
     globalFilter(update).flatMap(repoConfig.updates.keep)
@@ -92,12 +93,13 @@ object FilterAlg {
     if (keep) Right(update) else Left(IgnoredGlobally(update))
   }
 
-  def ignoreNonSnapshotToSnapshotUpdate(update: Update.Single): FilterResult = {
-    val snap = "-SNAP"
-    if (update.newerVersions.head.contains(snap) && !update.currentVersion.contains(snap))
-      Left(NonSnapshotToSnapshotUpdate(update))
-    else
-      Right(update)
+  def selectSuitableNextVersion(update: Update.Single): FilterResult = {
+    val newerVersions = update.newerVersions.map(Version.apply).toList
+    val maybeNext = Version(update.currentVersion).selectNext(newerVersions)
+    maybeNext match {
+      case Some(next) => Right(update.copy(newerVersions = Nel.of(next.value)))
+      case None       => Left(NoSuitableNextVersion(update))
+    }
   }
 
   def removeBadVersions(update: Update.Single): FilterResult =

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.typelevel.discipline.scalatest.Discipline
+import scala.util.Random
 
 class VersionTest extends AnyFunSuite with Discipline with Matchers {
   checkAll("Order[Version]", OrderTests[Version].order)
@@ -31,6 +32,54 @@ class VersionTest extends AnyFunSuite with Discipline with Matchers {
 
     forAll(versions) { (x, y, result) =>
       Version(x).comparison(Version(y)) shouldBe result
+    }
+  }
+
+  test("selectNext, table 1") {
+    val allVersions =
+      List("1.0.0", "1.0.1", "1.0.2", "1.1.0", "1.2.0", "2.0.0", "3.0.0", "3.0.0.1", "3.1")
+        .map(Version.apply)
+
+    val nextVersions = Table(
+      ("current", "result"),
+      ("1.0.0", Some("1.0.2")),
+      ("1.0.1", Some("1.0.2")),
+      ("1.0.2", Some("1.2.0")),
+      ("1.1.0", Some("1.2.0")),
+      ("1.2.0", Some("3.1")),
+      ("2.0.0", Some("3.1")),
+      ("3.0.0", Some("3.0.0.1")),
+      ("3.0.0.1", Some("3.1")),
+      ("3.1", None),
+      ("4", None)
+    )
+
+    forAll(nextVersions) { (current, result) =>
+      Version(current).selectNext(allVersions) shouldBe result.map(Version.apply)
+    }
+  }
+
+  test("selectNext, table 2") {
+    val nextVersions = Table(
+      ("current", "versions", "result"),
+      ("1.3.0-RC3", List("1.3.0-RC4", "1.3.0-RC5"), Some("1.3.0-RC5")),
+      ("1.3.0-RC3", List("1.3.0-RC4", "1.3.0-RC5", "1.3.0", "1.3.2"), Some("1.3.2")),
+      ("3.0-RC3", List("3.0-RC4", "3.0-RC5", "3.0", "3.2"), Some("3.2")),
+      ("1.3.0-RC5", List("1.3.0", "1.3.1", "1.3.2"), Some("1.3.2")),
+      ("2.5", List("2.6", "3.6"), Some("2.6")),
+      ("1.3.0-RC5", List("1.3.0", "1.4.0"), Some("1.3.0")),
+      ("1.1.2-1", List("2.0.0", "2.0.1-M3"), Some("2.0.0")),
+      ("0.19.0-RC1", List("0.20.0-RC1", "0.20.0"), Some("0.20.0")),
+      ("0.19.0-RC1", List("0.20.0-RC1", "0.21.0-RC1"), None),
+      ("1.14.0", List("1.14.1-RC1", "1.14.1", "1.14.2"), Some("1.14.2")),
+      ("3.1.0-SNAP13", List("3.2.0-M1"), None),
+      ("3.1.0-SNAP13", List("3.2.0-M1", "3.2.0"), Some("3.2.0"))
+    )
+
+    val rnd = new Random()
+    forAll(nextVersions) { (current, versions, result) =>
+      Version(current).selectNext(rnd.shuffle(versions).map(Version.apply)) shouldBe
+        result.map(Version.apply)
     }
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -5,25 +5,25 @@ import org.scalasteward.core.data.Update
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
-import org.scalasteward.core.update.FilterAlg.{BadVersions, NonSnapshotToSnapshotUpdate}
+import org.scalasteward.core.update.FilterAlg.{BadVersions, NoSuitableNextVersion}
 import org.scalasteward.core.util.Nel
 import org.scalatest.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 
 class FilterAlgTest extends AnyFunSuite with Matchers {
   test("globalFilter: SNAP -> SNAP") {
-    val update = Update.Single("org.scalatest", "scalatest", "3.0.8-SNAP2", Nel.of("3.1.0-SNAP10"))
+    val update = Update.Single("org.scalatest", "scalatest", "3.0.8-SNAP2", Nel.of("3.0.8-SNAP10"))
     FilterAlg.globalFilter(update) shouldBe Right(update)
   }
 
   test("globalFilter: RC -> SNAP") {
     val update = Update.Single("org.scalatest", "scalatest", "3.0.8-RC2", Nel.of("3.1.0-SNAP10"))
-    FilterAlg.globalFilter(update) shouldBe Left(NonSnapshotToSnapshotUpdate(update))
+    FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("globalFilter: update without bad version") {
     val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
-    FilterAlg.globalFilter(update) shouldBe Right(update)
+    FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("1.1.2")))
   }
 
   test("globalFilter: update with bad version") {
@@ -34,6 +34,11 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   test("globalFilter: update with only bad versions") {
     val update = Update.Single("org.http4s", "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
     FilterAlg.globalFilter(update) shouldBe Left(BadVersions(update))
+  }
+
+  test("globalFilter: update to pre-release of a different series") {
+    val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.2-1", Nel.of("2.0.1-M3"))
+    FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("ignore update via config updates.ignore") {

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -11,30 +11,29 @@ import org.scalatest.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 
 class FilterAlgTest extends AnyFunSuite with Matchers {
-  test("ignoreNonSnapshotToSnapshotUpdate: SNAP -> SNAP") {
+  test("globalFilter: SNAP -> SNAP") {
     val update = Update.Single("org.scalatest", "scalatest", "3.0.8-SNAP2", Nel.of("3.1.0-SNAP10"))
-    FilterAlg.ignoreNonSnapshotToSnapshotUpdate(update) shouldBe Right(update)
+    FilterAlg.globalFilter(update) shouldBe Right(update)
   }
 
-  test("ignoreNonSnapshotToSnapshotUpdate: RC -> SNAP") {
+  test("globalFilter: RC -> SNAP") {
     val update = Update.Single("org.scalatest", "scalatest", "3.0.8-RC2", Nel.of("3.1.0-SNAP10"))
-    FilterAlg.ignoreNonSnapshotToSnapshotUpdate(update) shouldBe
-      Left(NonSnapshotToSnapshotUpdate(update))
+    FilterAlg.globalFilter(update) shouldBe Left(NonSnapshotToSnapshotUpdate(update))
   }
 
-  test("removeBadVersions: update without bad version") {
+  test("globalFilter: update without bad version") {
     val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
-    FilterAlg.removeBadVersions(update) shouldBe Right(update)
+    FilterAlg.globalFilter(update) shouldBe Right(update)
   }
 
-  test("removeBadVersions: update with bad version") {
+  test("globalFilter: update with bad version") {
     val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.2-1", Nel.of("1.1.2", "2.0.0"))
-    FilterAlg.removeBadVersions(update) shouldBe Right(update.copy(newerVersions = Nel.of("2.0.0")))
+    FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("2.0.0")))
   }
 
-  test("removeBadVersions: update with only bad versions") {
+  test("globalFilter: update with only bad versions") {
     val update = Update.Single("org.http4s", "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
-    FilterAlg.removeBadVersions(update) shouldBe Left(BadVersions(update))
+    FilterAlg.globalFilter(update) shouldBe Left(BadVersions(update))
   }
 
   test("ignore update via config updates.ignore") {


### PR DESCRIPTION
This contains code from #851 for preventing updates to a pre-release of
another version series. Version.selectNext is now responsible for
selecting the next version from a list of possible newer versions. This
functions implements the scheme described in
https://github.com/fthomas/scala-steward/blob/master/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to
and also filters out all bumps between pre-releases of different version
series. This code incidentally also makes the code to deal with updates
from non-snapshot to snapshot versions (#485) superfluous.

Closes #956.