### PR TITLE
Prevent updates to commons-collections 20040102.233541

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -113,6 +113,12 @@ object FilterAlg {
       // https://github.com/vlovgr/ciris/pull/182#issuecomment-420599759
       case ("com.jsuereth", "sbt-pgp", "1.1.2-1", "1.1.2") => List("1.1.2")
 
+      case ("commons-collections", "commons-collections", _, _) =>
+        List(
+          // https://github.com/albuch/sbt-dependency-check/pull/85
+          "20040102.233541"
+        )
+
       case ("io.monix", _, _, _) =>
         List(
           // https://github.com/fthomas/scala-steward/issues/105


### PR DESCRIPTION
The latest version is 3.2.2 and was released in 2015.
See also https://search.maven.org/search?q=g:commons-collections%20AND%20a:commons-collections&core=gav