### PR TITLE
Introduce Version.Component to improve Order[Version]

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -117,7 +117,7 @@ object Version {
                 loop(t, h :: accN, List.empty, materialize(List.empty, accA, acc))
 
               case _ if h.isDigit && accA.isEmpty =>
-                loop(t, h :: accN, accA, acc)
+                loop(t, h :: accN, List.empty, acc)
 
               case _ if accN.nonEmpty =>
                 loop(t, List.empty, h :: accA, materialize(accN, List.empty, acc))

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -80,7 +80,7 @@ object Version {
     (l1.padTo(maxLength, elem), l2.padTo(maxLength, elem))
   }
 
-  sealed trait Component
+  sealed trait Component extends Product with Serializable
   object Component {
     final case class Numeric(value: String) extends Component
     final case class Alpha(value: String) extends Component {
@@ -93,10 +93,9 @@ object Version {
         case _                   => 0
       }
     }
-    sealed trait Separator extends Component
-    case object Dot extends Separator
-    case object Hyphen extends Separator
-    case object Plus extends Separator
+    case object Dot extends Component
+    case object Hyphen extends Component
+    case object Plus extends Component
     case object Empty extends Component
 
     def parse(str: String): List[Component] = {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -21,24 +21,11 @@ import cats.implicits._
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.util
-import scala.util.Try
+import scala.annotation.tailrec
 
 final case class Version(value: String) {
-  val numericComponents: List[BigInt] =
-    value
-      .split(Array('.', '-', '+'))
-      .flatMap(util.string.splitNumericAndNonNumeric)
-      .map(_.toUpperCase)
-      .map {
-        case "SNAP" | "SNAPSHOT" => BigInt(-5)
-        case "ALPHA"             => BigInt(-4)
-        case "BETA"              => BigInt(-3)
-        case "M"                 => BigInt(-2)
-        case "RC"                => BigInt(-1)
-        case s                   => Try(BigInt(s)).getOrElse(BigInt(0))
-      }
-      .toList
+  val components: List[Version.Component] =
+    Version.Component.parse(value)
 
   /** Selects the next version from a list of potentially newer versions.
     *
@@ -46,11 +33,11 @@ final case class Version(value: String) {
     * https://github.com/fthomas/scala-steward/blob/master/docs/faq.md#how-does-scala-steward-decide-what-version-it-is-updating-to
     */
   def selectNext(versions: List[Version]): Option[Version] = {
-    val cutoff = preReleaseIndex.fold(numericComponents.size)(_.value - 1)
-    val newerVersionsByCommonPrefix: Map[List[(BigInt, BigInt)], List[Version]] =
+    val cutoff = preReleaseIndex.fold(components.size)(_.value - 1)
+    val newerVersionsByCommonPrefix =
       versions
         .filter(_ > this)
-        .groupBy(_.numericComponents.zip(numericComponents).take(cutoff).takeWhile {
+        .groupBy(_.components.zip(components).take(cutoff).takeWhile {
           case (c1, c2) => c1 === c2
         })
 
@@ -68,13 +55,17 @@ final case class Version(value: String) {
     preReleaseIndex.isDefined
 
   private def preReleaseIndex: Option[NonNegInt] =
-    NonNegInt.unapply(numericComponents.indexWhere(_ < 0))
+    NonNegInt.unapply(components.indexWhere {
+      case Version.Component.Hyphen       => true
+      case a @ Version.Component.Alpha(_) => a.order < 0
+      case _                              => false
+    })
 }
 
 object Version {
   implicit val versionOrder: Order[Version] =
     Order.from[Version] { (v1, v2) =>
-      val (c1, c2) = padToSameLength(v1.numericComponents, v2.numericComponents, BigInt(0))
+      val (c1, c2) = padToSameLength(v1.components, v2.components, Component.Empty)
       c1.compare(c2)
     }
 
@@ -87,5 +78,103 @@ object Version {
   private def padToSameLength[A](l1: List[A], l2: List[A], elem: A): (List[A], List[A]) = {
     val maxLength = math.max(l1.length, l2.length)
     (l1.padTo(maxLength, elem), l2.padTo(maxLength, elem))
+  }
+
+  sealed trait Component
+  object Component {
+    final case class Numeric(value: String) extends Component
+    final case class Alpha(value: String) extends Component {
+      def order: Int = value.toUpperCase match {
+        case "SNAP" | "SNAPSHOT" => -5
+        case "ALPHA"             => -4
+        case "BETA"              => -3
+        case "M"                 => -2
+        case "RC"                => -1
+        case _                   => 0
+      }
+    }
+    sealed trait Separator extends Component
+    case object Dot extends Separator
+    case object Hyphen extends Separator
+    case object Plus extends Separator
+    case object Empty extends Component
+
+    def parse(str: String): List[Component] = {
+      @tailrec
+      def loop(
+          rest: List[Char],
+          accN: List[Char],
+          accA: List[Char],
+          acc: List[Component]
+      ): List[Component] =
+        rest match {
+          case h :: t =>
+            h match {
+              case '.' | '-' | '+' =>
+                val sep = if (h === '.') Dot else if (h === '-') Hyphen else Plus
+                loop(t, List.empty, List.empty, sep :: materialize(accN, accA, acc))
+
+              case _ if h.isDigit && accA.nonEmpty =>
+                loop(t, h :: accN, List.empty, materialize(List.empty, accA, acc))
+
+              case _ if h.isDigit && accA.isEmpty =>
+                loop(t, h :: accN, accA, acc)
+
+              case _ if accN.nonEmpty =>
+                loop(t, List.empty, h :: accA, materialize(accN, List.empty, acc))
+
+              case _ if accN.isEmpty =>
+                loop(t, List.empty, h :: accA, acc)
+            }
+          case Nil => materialize(accN, accA, acc)
+        }
+
+      def materialize(accN: List[Char], accA: List[Char], acc: List[Component]): List[Component] =
+        if (accN.nonEmpty) Numeric(accN.reverse.mkString) :: acc
+        else if (accA.nonEmpty) Alpha(accA.reverse.mkString) :: acc
+        else acc
+
+      loop(str.toList, List.empty, List.empty, List.empty).reverse
+    }
+
+    def render(components: List[Component]): String =
+      components.map {
+        case Numeric(value) => value
+        case Alpha(value)   => value
+        case Dot            => "."
+        case Hyphen         => "-"
+        case Plus           => "+"
+        case Empty          => ""
+      }.mkString
+
+    implicit val componentOrder: Order[Component] =
+      Order.from[Component] {
+        case (Numeric(v1), Numeric(v2)) => BigInt(v1).compare(BigInt(v2))
+        case (Numeric(_), Alpha(_))     => -1
+        case (Alpha(_), Numeric(_))     => 1
+        case (Numeric(_), _)            => 1
+        case (_, Numeric(_))            => -1
+
+        case (a1 @ Alpha(v1), a2 @ Alpha(v2)) =>
+          val (o1, o2) = (a1.order, a2.order)
+          if (o1 < 0 || o2 < 0) o1.compare(o2) else v1.compare(v2)
+
+        case (Alpha(_), _) => 1
+        case (_, Alpha(_)) => -1
+
+        case (Hyphen, Hyphen) => 0
+        case (Hyphen, _)      => -1
+        case (_, Hyphen)      => 1
+
+        case (Dot, Dot) => 0
+        case (Dot, _)   => 1
+        case (_, Dot)   => -1
+
+        case (Plus, Plus) => 0
+        case (Plus, _)    => 1
+        case (_, Plus)    => -1
+
+        case (Empty, Empty) => 0
+      }
   }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/string.scala
@@ -111,9 +111,6 @@ object string {
   def splitBetweenLowerAndUpperChars(s: String): List[String] =
     splitBetween2CharMatches("\\p{javaLowerCase}\\p{javaUpperCase}".r)(s)
 
-  def splitNumericAndNonNumeric(s: String): List[String] =
-    splitBetween2CharMatches("\\d\\D".r)(s).flatMap(splitBetween2CharMatches("\\D\\d".r))
-
   private def splitBetween2CharMatches(regex: Regex)(s: String): List[String] = {
     val bounds = regex.findAllIn(s).matchData.map(_.start + 1).toList
     val indices = 0 +: bounds :+ s.length

--- a/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/TestInstances.scala
@@ -33,5 +33,9 @@ object TestInstances {
   }
 
   implicit val versionCogen: Cogen[Version] =
-    Cogen(_.numericComponents.map(_.toLong).sum)
+    Cogen(_.components.map {
+      case Version.Component.Numeric(value) => BigInt(value).toLong
+      case a @ Version.Component.Alpha(_)   => a.order.toLong
+      case _                                => 0L
+    }.sum)
 }


### PR DESCRIPTION
This allows to make 1.0.0-20131213005945 (which is a pre-release version) less than 1.0.0. The `numericComponents` we hade before, couldn't accomplish that. 