### PR TITLE
Introduce GroupId wrapper

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -45,7 +45,7 @@ object CoursierAlg {
     new CoursierAlg[F] {
       override def getArtifactUrl(dependency: Dependency): F[Option[String]] = {
         val module = coursier.Module(
-          coursier.Organization(dependency.groupId),
+          coursier.Organization(dependency.groupId.value),
           coursier.ModuleName(dependency.artifactIdCross)
         )
         val coursierDependency =

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -22,7 +22,7 @@ import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.util.Nel
 
 final case class Dependency(
-    groupId: String,
+    groupId: GroupId,
     artifactId: String,
     artifactIdCross: String,
     version: String,

--- a/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.data
+
+import cats.Order
+import cats.implicits._
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder}
+
+final case class GroupId(value: String) extends AnyVal {
+  override def toString: String = value
+}
+
+object GroupId {
+  implicit val groupIdDecoder: Decoder[GroupId] = deriveDecoder
+  implicit val groupIdEncoder: Encoder[GroupId] = deriveEncoder
+  implicit val groupIdOrder: Order[GroupId] = Order[String].contramap(_.value)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/GroupId.scala
@@ -18,7 +18,6 @@ package org.scalasteward.core.data
 
 import cats.Order
 import cats.implicits._
-import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 
 final case class GroupId(value: String) extends AnyVal {
@@ -26,7 +25,7 @@ final case class GroupId(value: String) extends AnyVal {
 }
 
 object GroupId {
-  implicit val groupIdDecoder: Decoder[GroupId] = deriveDecoder
-  implicit val groupIdEncoder: Encoder[GroupId] = deriveEncoder
+  implicit val groupIdDecoder: Decoder[GroupId] = Decoder[String].map(GroupId.apply)
+  implicit val groupIdEncoder: Encoder[GroupId] = Encoder[String].contramap(_.value)
   implicit val groupIdOrder: Order[GroupId] = Order[String].contramap(_.value)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -63,7 +63,7 @@ object Update {
       currentVersion: String,
       newerVersions: Nel[String],
       configurations: Option[String] = None,
-      newerGroupId: Option[String] = None
+      newerGroupId: Option[GroupId] = None
   ) extends Update {
     override def artifactIds: Nel[String] =
       Nel.one(artifactId)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -26,7 +26,7 @@ import org.scalasteward.core.util.Nel
 import org.scalasteward.core.util.string.MinLengthString
 
 sealed trait Update extends Product with Serializable {
-  def groupId: String
+  def groupId: GroupId
   def artifactId: String
   def artifactIds: Nel[String]
   def currentVersion: String
@@ -58,7 +58,7 @@ sealed trait Update extends Product with Serializable {
 
 object Update {
   final case class Single(
-      groupId: String,
+      groupId: GroupId,
       artifactId: String,
       currentVersion: String,
       newerVersions: Nel[String],
@@ -75,7 +75,7 @@ object Update {
   }
 
   final case class Group(
-      groupId: String,
+      groupId: GroupId,
       artifactIds: Nel[String],
       currentVersion: String,
       newerVersions: Nel[String]
@@ -118,9 +118,9 @@ object Update {
   def removeCommonSuffix(str: String): String =
     util.string.removeSuffix(str, commonSuffixes)
 
-  def nameOf(groupId: String, artifactId: String): String =
+  def nameOf(groupId: GroupId, artifactId: String): String =
     if (commonSuffixes.contains(artifactId))
-      util.string.rightmostLabel(groupId)
+      util.string.rightmostLabel(groupId.value)
     else
       artifactId
 

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -17,7 +17,7 @@
 package org.scalasteward.core.edit
 
 import cats.implicits._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex
@@ -89,7 +89,7 @@ object UpdateHeuristic {
     def replaceGroupF(update: Update): String => Option[String] = { target =>
       update match {
         case Update.Single(groupId, artifactId, _, _, _, Some(newerGroupId)) =>
-          val currentGroupId = Regex.quote(groupId)
+          val currentGroupId = Regex.quote(groupId.value)
           val currentArtifactId = Regex.quote(artifactId)
           val regex = s"""(?i)(.*)${currentGroupId}(.*${currentArtifactId})""".r
           replaceSomeInAllowedParts(regex, target, match0 => {
@@ -129,15 +129,20 @@ object UpdateHeuristic {
   val groupId = UpdateHeuristic(
     name = "groupId",
     replaceVersion = defaultReplaceVersion(
-      _.groupId.split('.').toList.drop(1).flatMap(util.string.extractWords).filter(_.length > 3)
+      _.groupId.value
+        .split('.')
+        .toList
+        .drop(1)
+        .flatMap(util.string.extractWords)
+        .filter(_.length > 3)
     )
   )
 
   val specific = UpdateHeuristic(
     name = "specific",
     replaceVersion = defaultReplaceVersion {
-      case Update.Single("org.scalameta", "scalafmt-core", _, _, _, _) => List("version")
-      case _                                                           => List.empty
+      case Update.Single(GroupId("org.scalameta"), "scalafmt-core", _, _, _, _) => List("version")
+      case _                                                                    => List.empty
     }
   )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import better.files.File
 import cats.implicits._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 
 package object io {
   def isSourceFile(file: File): Boolean = {
@@ -32,8 +32,9 @@ package object io {
 
   def isFileSpecificTo(update: Update)(f: File): Boolean =
     update match {
-      case Update.Single("org.scala-sbt", "sbt", _, _, _, _) => f.name === "build.properties"
-      case Update.Single("org.scalameta", "scalafmt-core", _, _, _, _) =>
+      case Update.Single(GroupId("org.scala-sbt"), "sbt", _, _, _, _) =>
+        f.name === "build.properties"
+      case Update.Single(GroupId("org.scalameta"), "scalafmt-core", _, _, _, _) =>
         f.name === ".scalafmt.conf"
       case _ => true
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -19,10 +19,10 @@ package org.scalasteward.core.repoconfig
 import cats.implicits._
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 
 final case class UpdatePattern(
-    groupId: String,
+    groupId: GroupId,
     artifactId: Option[String],
     version: Option[String]
 )

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import cats.implicits._
 import cats.effect.{IO, Resource}
-import org.scalasteward.core.data.{Dependency, Version}
+import org.scalasteward.core.data.{Dependency, GroupId, Version}
 import org.scalasteward.core.io.FileData
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import scala.io.Source
@@ -46,7 +46,7 @@ package object sbt {
 
   def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
     if (sbtVersion.toVersion >= Version("1.0.0"))
-      Some(Dependency("org.scala-sbt", "sbt", "sbt", sbtVersion.value))
+      Some(Dependency(GroupId("org.scala-sbt"), "sbt", "sbt", sbtVersion.value))
     else
       None
 

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.sbt
 
 import cats.implicits._
 import io.circe.parser.decode
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, GroupId, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.util.Nel
 
@@ -35,7 +35,9 @@ object parser {
         def msg(part: String) = s"failed to parse $part in '$line'"
 
         for {
-          groupId <- Either.fromOption(moduleId.headOption.filter(_.nonEmpty), msg("groupId"))
+          groupId <- Either
+            .fromOption(moduleId.headOption.filter(_.nonEmpty), msg("groupId"))
+            .map(GroupId.apply)
           artifactId <- Either.fromOption(moduleId.lift(1), msg("artifactId"))
           configurations = moduleId.lift(2)
           currentVersion <- Either.fromOption(

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/Migration.scala
@@ -16,12 +16,12 @@
 
 package org.scalasteward.core.scalafix
 
-import org.scalasteward.core.data.Version
+import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex
 
 final case class Migration(
-    groupId: String,
+    groupId: GroupId,
     artifactIds: Nel[Regex],
     newVersion: Version,
     rewriteRules: Nel[String]

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -17,20 +17,20 @@
 package org.scalasteward.core
 
 import cats.implicits._
-import org.scalasteward.core.data.{Update, Version}
+import org.scalasteward.core.data.{GroupId, Update, Version}
 import org.scalasteward.core.util.Nel
 
 package object scalafix {
   val migrations: List[Migration] =
     List(
       Migration(
-        "co.fs2",
+        GroupId("co.fs2"),
         Nel.of("fs2-.*".r),
         Version("1.0.0"),
         Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")
       ),
       Migration(
-        "com.spotify",
+        GroupId("com.spotify"),
         Nel.of("scio-.*".r),
         Version("0.7.0"),
         Nel.of(
@@ -41,13 +41,13 @@ package object scalafix {
         )
       ),
       Migration(
-        "org.http4s",
+        GroupId("org.http4s"),
         Nel.of("http4s-.*".r),
         Version("0.20.0"),
         Nel.of("github:http4s/http4s/v0_20?sha=v0.20.11")
       ),
       Migration(
-        "org.typelevel",
+        GroupId("org.typelevel"),
         Nel.of("cats-core".r),
         Version("1.0.0"),
         Nel.of(
@@ -55,7 +55,7 @@ package object scalafix {
         )
       ),
       Migration(
-        "org.scalatest",
+        GroupId("org.scalatest"),
         Nel.of("scalatest".r),
         Version("3.1.0"),
         Nel.of(
@@ -64,7 +64,7 @@ package object scalafix {
         )
       ),
       Migration(
-        "org.scalacheck",
+        GroupId("org.scalacheck"),
         Nel.of("scalacheck".r),
         Version("1.14.1"),
         Nel.of("github:typelevel/scalacheck/v1_14_1?sha=3fc537dde9d8fdf951503a8d8b027a568d52d055")

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -17,12 +17,12 @@
 package org.scalasteward.core
 
 import cats.implicits._
-import org.scalasteward.core.data.{Dependency, Version}
+import org.scalasteward.core.data.{Dependency, GroupId, Version}
 
 package object scalafmt {
   def scalafmtDependency(scalaBinaryVersion: String)(scalafmtVersion: Version): Dependency =
     Dependency(
-      if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson",
+      GroupId(if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson"),
       "scalafmt-core",
       s"scalafmt-core_${scalaBinaryVersion}",
       scalafmtVersion.value

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -76,7 +76,7 @@ object FilterAlg {
     globalFilter(update).flatMap(repoConfig.updates.keep)
 
   def isIgnoredGlobally(update: Update.Single): FilterResult = {
-    val keep = ((update.groupId, update.artifactId) match {
+    val keep = ((update.groupId.value, update.artifactId) match {
       case ("org.scala-lang", "scala-compiler") => false
       case ("org.scala-lang", "scala-library")  => false
       case ("org.scala-lang", "scala-reflect")  => false
@@ -109,7 +109,7 @@ object FilterAlg {
       .fold[FilterResult](Left(BadVersions(update)))(Right.apply)
 
   private def badVersions(update: Update.Single): List[String] =
-    (update.groupId, update.artifactId, update.currentVersion, update.nextVersion) match {
+    (update.groupId.value, update.artifactId, update.currentVersion, update.nextVersion) match {
       // https://github.com/vlovgr/ciris/pull/182#issuecomment-420599759
       case ("com.jsuereth", "sbt-pgp", "1.1.2-1", "1.1.2") => List("1.1.2")
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, GroupId, Update}
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
 import org.scalasteward.core.sbt._
@@ -163,9 +163,9 @@ object UpdateAlg {
       update.artifactIds.contains_(dependency.artifactId) &&
       update.currentVersion === dependency.version
 
-  def getNewerGroupId(currentGroupId: String, artifactId: String): Option[(String, String)] =
-    Option((currentGroupId, artifactId) match {
-      case ("org.spire-math", "kind-projector")   => ("org.typelevel", "0.10.0")
+  def getNewerGroupId(currentGroupId: GroupId, artifactId: String): Option[(GroupId, String)] =
+    Option((currentGroupId.value, artifactId) match {
+      case ("org.spire-math", "kind-projector")   => (GroupId("org.typelevel"), "0.10.0")
       case ("com.github.mpilquist", "simulacrum") => ("org.typelevel", "1.0.0")
       case ("com.geirsson", "sbt-scalafmt")       => ("org.scalameta", "2.0.0")
       case ("net.ceedubs", "ficus")               => ("com.iheart", "1.3.4")

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -163,12 +163,12 @@ object UpdateAlg {
       update.artifactIds.contains_(dependency.artifactId) &&
       update.currentVersion === dependency.version
 
-  def getNewerGroupId(currentGroupId: String, artifactId: String): Option[(String, String)] =
-    Some((currentGroupId, artifactId)).collect {
-      case ("org.spire-math", "kind-projector")   => ("org.typelevel", "0.10.0")
-      case ("com.github.mpilquist", "simulacrum") => ("org.typelevel", "1.0.0")
-      case ("com.geirsson", "sbt-scalafmt")       => ("org.scalameta", "2.0.0")
-      case ("net.ceedubs", "ficus")               => ("com.iheart", "1.3.4")
+  def getNewerGroupId(currentGroupId: GroupId, artifactId: String): Option[(GroupId, String)] =
+    Some((currentGroupId.value, artifactId)).collect {
+      case ("org.spire-math", "kind-projector")   => (GroupId("org.typelevel"), "0.10.0")
+      case ("com.github.mpilquist", "simulacrum") => (GroupId("org.typelevel"), "1.0.0")
+      case ("com.geirsson", "sbt-scalafmt")       => (GroupId("org.scalameta"), "2.0.0")
+      case ("net.ceedubs", "ficus")               => (GroupId("com.iheart"), "1.3.4")
     }
 
   def findUpdateUnderNewGroup(dep: Dependency): Option[Update.Single] =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.Traverse
 import cats.implicits._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 
@@ -26,7 +26,7 @@ object show {
   def oneLiner(update: Update): String =
     commaSeparated(update.groupId, update.artifactIds)
 
-  private def commaSeparated(groupId: String, artifactIds: Nel[String]): String = {
+  private def commaSeparated(groupId: GroupId, artifactIds: Nel[String]): String = {
     val artifacts = showArtifacts(groupId, artifactIds).toList
     val count = maxArtifacts(artifacts)
     val items = if (count < artifacts.size) artifacts.take(count) :+ "..." else artifacts
@@ -39,13 +39,17 @@ object show {
     math.max(1, accumulatedLengths.takeWhile(_ <= maxLength).size)
   }
 
-  private def showArtifacts[F[_]: Traverse](groupId: String, artifactIds: F[String]): F[String] = {
+  private def showArtifacts[F[_]: Traverse](groupId: GroupId, artifactIds: F[String]): F[String] = {
     val includeGroupId = util.intersects(artifactIds, Update.commonSuffixes)
     artifactIds.map(showArtifact(groupId, _, includeGroupId))
   }
 
-  private def showArtifact(groupId: String, artifactId: String, includeGroupId: Boolean): String = {
-    val groupName = util.string.rightmostLabel(groupId)
+  private def showArtifact(
+      groupId: GroupId,
+      artifactId: String,
+      includeGroupId: Boolean
+  ): String = {
+    val groupName = util.string.rightmostLabel(groupId.value)
     if (!includeGroupId || artifactId.contains(groupName)) artifactId
     else groupName + ":" + artifactId
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.vcs.data
 import cats.implicits._
 import io.circe.Encoder
 import io.circe.generic.semiauto._
-import org.scalasteward.core.data.{SemVer, Update}
+import org.scalasteward.core.data.{GroupId, SemVer, Update}
 import org.scalasteward.core.git.Branch
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfigAlg
@@ -94,7 +94,7 @@ object NewPullRequestData {
     }
 
   def artifactWithOptionalUrl(
-      groupId: String,
+      groupId: GroupId,
       artifactId: String,
       artifactId2Url: Map[String, String]
   ): String =

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.coursier
 
-import org.scalasteward.core.data.Dependency
+import org.scalasteward.core.data.{Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalatest.funsuite.AnyFunSuite
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class CoursierAlgTest extends AnyFunSuite with Matchers {
 
   test("getArtifactUrl") {
-    val dep = Dependency("org.typelevel", "cats-effect", "cats-effect_2.12", "1.0.0")
+    val dep = Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0")
     val (state, result) = coursierAlg
       .getArtifactUrl(dep)
       .run(MockState.empty)
@@ -24,8 +24,8 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
 
   test("getArtifactIdUrlMapping") {
     val dependencies = List(
-      Dependency("org.typelevel", "cats-core", "cats-core_2.12", "1.6.0"),
-      Dependency("org.typelevel", "cats-effect", "cats-effect_2.12", "1.0.0")
+      Dependency(GroupId("org.typelevel"), "cats-core", "cats-core_2.12", "1.6.0"),
+      Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0")
     )
     val (state, result) = coursierAlg
       .getArtifactIdUrlMapping(dependencies)

--- a/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
@@ -13,7 +13,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample1 = """val scalajsJqueryVersion = "0.9.3""""
       s"$goodExample1" in {
         val expectedResult = Some("""val scalajsJqueryVersion = "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample1)
           ._1 shouldBe expectedResult
       }
@@ -21,7 +21,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample2 = """val SCALAJSJQUERYVERSION = "0.9.3""""
       s"$goodExample2" in {
         val expectedResult = Some("""val SCALAJSJQUERYVERSION = "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample2)
           ._1 shouldBe expectedResult
       }
@@ -29,7 +29,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample3 = """val scalajsjquery = "0.9.3""""
       s"$goodExample3" in {
         val expectedResult = Some("""val scalajsjquery = "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample3)
           ._1 shouldBe expectedResult
       }
@@ -37,7 +37,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample4 = """addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")"""
       s"$goodExample4" in {
         val expectedResult = Some("""addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")""")
-        Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+        Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
           .replaceVersionIn(goodExample4)
           ._1 shouldBe expectedResult
       }
@@ -45,7 +45,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample5 = """"be.doeraene" %% "scalajs-jquery"  % "0.9.3""""
       s"$goodExample5" in {
         val expectedResult = Some(""""be.doeraene" %% "scalajs-jquery"  % "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample5)
           ._1 shouldBe expectedResult
       }
@@ -53,7 +53,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample6 = """val `scalajs-jquery-version` = "0.9.3""""
       s"$goodExample6" in {
         val expectedResult = Some("""val `scalajs-jquery-version` = "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample6)
           ._1 shouldBe expectedResult
       }
@@ -67,7 +67,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
           |  "0.9.3"""".stripMargin
       s"$badExample1" in {
         val expectedResult = None
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(badExample1)
           ._1 shouldBe expectedResult
       }
@@ -77,7 +77,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       s"$badExample2" in {
         val expectedResult =
           Some("""val scalajsJqueryVersion = "0.9.3" // val scalajsJqueryVersion = "0.9.4"""")
-        Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(badExample2)
           ._1 shouldBe expectedResult
       }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -9,7 +9,7 @@ class UpdateTest extends AnyFunSuite with Matchers {
 
   test("Group.artifactId") {
     Group(
-      "org.http4s",
+      GroupId("org.http4s"),
       Nel.of("http4s-blaze-server", "http4s-circe", "http4s-core", "http4s-dsl"),
       "0.18.16",
       Nel.of("0.18.18")
@@ -17,43 +17,59 @@ class UpdateTest extends AnyFunSuite with Matchers {
   }
 
   test("group: 1 update") {
-    val updates = List(Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5")))
+    val updates = List(Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5")))
     Update.group(updates) shouldBe updates
   }
 
   test("group: 2 updates") {
-    val update0 = Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(artifactId = "specs2-scalacheck")
     Update.group(List(update0, update1)) shouldBe List(
-      Group("org.specs2", Nel.of("specs2-core", "specs2-scalacheck"), "3.9.4", Nel.of("3.9.5"))
+      Group(
+        GroupId("org.specs2"),
+        Nel.of("specs2-core", "specs2-scalacheck"),
+        "3.9.4",
+        Nel.of("3.9.5")
+      )
     )
   }
 
   test("group: 2 updates with different configurations") {
-    val update0 = Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(configurations = Some("test"))
     Update.group(List(update0, update1)) shouldBe List(
-      Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+      Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
     )
   }
 
   test("group: 3 updates with different configurations") {
-    val update0 = Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(configurations = Some("test"))
     val update2 = update0.copy(artifactId = "specs2-scalacheck")
     Update.group(List(update0, update1, update2)) shouldBe List(
-      Group("org.specs2", Nel.of("specs2-core", "specs2-scalacheck"), "3.9.4", Nel.of("3.9.5"))
+      Group(
+        GroupId("org.specs2"),
+        Nel.of("specs2-core", "specs2-scalacheck"),
+        "3.9.4",
+        Nel.of("3.9.5")
+      )
     )
   }
 
   test("Single.show") {
-    val update = Single("org.specs2", "specs2-core", "3.9.4", Nel.of("3.9.5"), Some("test"))
+    val update =
+      Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"), Some("test"))
     update.show shouldBe "org.specs2:specs2-core:test : 3.9.4 -> 3.9.5"
   }
 
   test("Group.show") {
     val update =
-      Group("org.scala-sbt", Nel.of("sbt-launch", "scripted-plugin"), "1.2.1", Nel.of("1.2.4"))
+      Group(
+        GroupId("org.scala-sbt"),
+        Nel.of("sbt-launch", "scripted-plugin"),
+        "1.2.1",
+        Nel.of("1.2.4")
+      )
     update.show shouldBe "org.scala-sbt:{sbt-launch, scripted-plugin} : 1.2.1 -> 1.2.4"
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit
 
 import better.files.File
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.editAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
@@ -13,7 +13,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
 
   test("applyUpdate") {
     val repo = Repo("fthomas", "scala-steward")
-    val update = Update.Single("org.typelevel", "cats-core", "1.2.0", Nel.of("1.3.0"))
+    val update = Update.Single(GroupId("org.typelevel"), "cats-core", "1.2.0", Nel.of("1.3.0"))
     val file1 = File.temp / "ws/fthomas/scala-steward/build.sbt"
     val file2 = File.temp / "ws/fthomas/scala-steward/project/Dependencies.scala"
 
@@ -40,7 +40,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
 
   test("applyUpdate with scalafmt update") {
     val repo = Repo("fthomas", "scala-steward")
-    val update = Update.Single("org.scalameta", "scalafmt-core", "2.0.0", Nel.of("2.1.0"))
+    val update = Update.Single(GroupId("org.scalameta"), "scalafmt-core", "2.0.0", Nel.of("2.1.0"))
     val scalafmtFile = File.temp / "ws/fthomas/scala-steward/.scalafmt.conf"
     val file1 = File.temp / "ws/fthomas/scala-steward/build.sbt"
 
@@ -101,7 +101,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("reproduce https://github.com/circe/circe-config/pull/40") {
-    val update = Update.Single("com.typesafe", "config", "1.3.3", Nel.of("1.3.4"))
+    val update = Update.Single(GroupId("com.typesafe"), "config", "1.3.3", Nel.of("1.3.4"))
     val original = Map(
       "build.sbt" -> """val config = "1.3.3"""",
       "project/plugins.sbt" -> """addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.3")"""
@@ -114,7 +114,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("file restriction when sbt update") {
-    val update = Update.Single("org.scala-sbt", "sbt", "1.1.2", Nel.of("1.2.8"))
+    val update = Update.Single(GroupId("org.scala-sbt"), "sbt", "1.1.2", Nel.of("1.2.8"))
     val original = Map(
       "build.properties" -> """sbt.version=1.1.2""",
       "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit
 
-import org.scalasteward.core.data.Update
 import org.scalasteward.core.data.Update.{Group, Single}
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.edit.UpdateHeuristicTest.UpdateOps
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
@@ -12,7 +12,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("sbt: build.properties") {
     val original = """sbt.version=1.3.0-RC1"""
     val expected = """sbt.version=1.3.0"""
-    Single("org.scala-sbt", "sbt", "1.3.0-RC1", Nel.of("1.3.0"))
+    Single(GroupId("org.scala-sbt"), "sbt", "1.3.0-RC1", Nel.of("1.3.0"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -27,7 +27,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -37,14 +37,14 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore hyphen in artifactId") {
     val original = """val scalajsJqueryVersion = "0.9.3""""
     val expected = """val scalajsJqueryVersion = "0.9.4""""
-    Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -57,7 +57,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """// val scalajsJqueryVersion = "0.9.3
         |val scalajsJqueryVersion = "0.9.4" //bla
         |"""".stripMargin.trim
-    Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -74,28 +74,28 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |   addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.4")
         |   //addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
         |"""".stripMargin.trim
-    Single("be.doeraene", "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
   test("ignore '-core' suffix") {
     val original = """val specs2Version = "4.2.0""""
     val expected = """val specs2Version = "4.3.4""""
-    Single("org.specs2", "specs2-core", "4.2.0", Nel.of("4.3.4"))
+    Single(GroupId("org.specs2"), "specs2-core", "4.2.0", Nel.of("4.3.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("use groupId if artifactId is 'core'") {
     val original = """lazy val sttpVersion = "1.3.2""""
     val expected = """lazy val sttpVersion = "1.3.3""""
-    Single("com.softwaremill.sttp", "core", "1.3.2", Nel.of("1.3.3"))
+    Single(GroupId("com.softwaremill.sttp"), "core", "1.3.2", Nel.of("1.3.3"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""
-    Single("org.specs2", "specs2-core", "3.+", Nel.of("4.3.4"))
+    Single(GroupId("org.specs2"), "specs2-core", "3.+", Nel.of("4.3.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -103,7 +103,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val original = """ val circe = "0.10.0-M1" """
     val expected = """ val circe = "0.10.0-M2" """
     Group(
-      "io.circe",
+      GroupId("io.circe"),
       Nel.of("circe-generic", "circe-literal", "circe-parser", "circe-testing"),
       "0.10.0-M1",
       Nel.of("0.10.0-M2")
@@ -114,11 +114,11 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val original = """ "org.spire-math" %% "kind-projector" % "0.9.0""""
     val expected = """ "org.typelevel" %% "kind-projector" % "0.10.0""""
     Single(
-      "org.spire-math",
+      GroupId("org.spire-math"),
       "kind-projector",
       "0.9.0",
       Nel.of("0.10.0"),
-      newerGroupId = Some("org.typelevel")
+      newerGroupId = Some(GroupId("org.typelevel"))
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -131,7 +131,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """ "com.pepegar" %% "hammock-core"  % "0.8.5",
         | "com.pepegar" %% "hammock-circe" % "0.8.5"
       """.stripMargin.trim
-    Group("com.pepegar", Nel.of("hammock-core", "hammock-circe"), "0.8.1", Nel.of("0.8.5"))
+    Group(GroupId("com.pepegar"), Nel.of("hammock-core", "hammock-circe"), "0.8.1", Nel.of("0.8.5"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -146,7 +146,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         | "org.typelevel" %% "jawn-json4s"  % "0.14.1",
         | "org.typelevel" %% "jawn-play" % "0.14.1"
       """.stripMargin.trim
-    Group("org.typelevel", Nel.of("jawn-json4s", "jawn-play"), "0.14.0", Nel.of("0.14.1"))
+    Group(GroupId("org.typelevel"), Nel.of("jawn-json4s", "jawn-play"), "0.14.0", Nel.of("0.14.1"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -159,8 +159,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """lazy val scalajsReactVersion = "1.3.1"
         |lazy val logbackVersion = "1.2.3"
       """.stripMargin
-    Group("com.github.japgolly.scalajs-react", Nel.of("core", "extra"), "1.2.3", Nel.of("1.3.1"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
+    Group(
+      GroupId("com.github.japgolly.scalajs-react"),
+      Nel.of("core", "extra"),
+      "1.2.3",
+      Nel.of("1.3.1")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("ignore 'previous' prefix") {
@@ -173,7 +177,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |val previousCirceIterateeVersion = "0.10.0"
       """.stripMargin
     Group(
-      "io.circe",
+      GroupId("io.circe"),
       Nel.of("circe-jawn", "circe-testing"),
       "0.10.0",
       Nel.of("0.10.1")
@@ -190,7 +194,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |mimaPreviousArtifacts := Set("nl.grons" %% "metrics4-scala" % "4.0.1")
       """.stripMargin
     Group(
-      "io.dropwizard.metrics",
+      GroupId("io.dropwizard.metrics"),
       Nel.of("metrics-core", "metrics-healthchecks"),
       "4.0.1",
       Nel.of("4.0.3")
@@ -200,35 +204,39 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("artifactId with dot") {
     val original = """ def plotlyJs = "1.41.3" """
     val expected = """ def plotlyJs = "1.43.2" """
-    Single("org.webjars.bower", "plotly.js", "1.41.3", Nel.of("1.43.2"))
+    Single(GroupId("org.webjars.bower"), "plotly.js", "1.41.3", Nel.of("1.43.2"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("val with backticks") {
     val original = """ val `plotly.js` = "1.41.3" """
     val expected = """ val `plotly.js` = "1.43.2" """
-    Single("org.webjars.bower", "plotly.js", "1.41.3", Nel.of("1.43.2"))
+    Single(GroupId("org.webjars.bower"), "plotly.js", "1.41.3", Nel.of("1.43.2"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("word from artifactId") {
     val original = """lazy val circeVersion = "0.9.3""""
     val expected = """lazy val circeVersion = "0.11.1""""
-    Single("io.circe", "circe-generic", "0.9.3", Nel.of("0.11.1"))
+    Single(GroupId("io.circe"), "circe-generic", "0.9.3", Nel.of("0.11.1"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("artifactId with underscore") {
     val original = """val scShapelessV = "1.1.6""""
     val expected = """val scShapelessV = "1.1.8""""
-    Single("com.github.alexarchambault", "scalacheck-shapeless_1.13", "1.1.6", Nel.of("1.1.8"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
+    Single(
+      GroupId("com.github.alexarchambault"),
+      "scalacheck-shapeless_1.13",
+      "1.1.6",
+      Nel.of("1.1.8")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("camel case artifactId") {
     val original = """val hikariVersion = "3.3.0" """
     val expected = """val hikariVersion = "3.4.0" """
-    Single("com.zaxxer", "HikariCP", "3.3.0", Nel.of("3.4.0"))
+    Single(GroupId("com.zaxxer"), "HikariCP", "3.3.0", Nel.of("3.4.0"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
@@ -236,7 +244,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val original = """val mongoVersion = "3.7.0" """
     val expected = """val mongoVersion = "3.7.1" """
     Group(
-      "org.mongodb",
+      GroupId("org.mongodb"),
       Nel.of("mongodb-driver", "mongodb-driver-async", "mongodb-driver-core"),
       "3.7.0",
       Nel.of("3.7.1")
@@ -245,14 +253,14 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
 
   test("artifactId with common suffix") {
     val original = """case _ => "1.0.2" """
-    Single("co.fs2", "fs2-core", "1.0.2", Nel.of("1.0.4"))
+    Single(GroupId("co.fs2"), "fs2-core", "1.0.2", Nel.of("1.0.4"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("word from groupId") {
     val original = """val acolyteVersion = "1.0.49" """
     val expected = """val acolyteVersion = "1.0.51" """
-    Single("org.eu.acolyte", "jdbc-driver", "1.0.49", Nel.of("1.0.51"))
+    Single(GroupId("org.eu.acolyte"), "jdbc-driver", "1.0.49", Nel.of("1.0.51"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.groupId.name)
   }
 
@@ -264,33 +272,33 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       ("""version=2.0.0 """, """version=2.0.1 """)
     ).foreach {
       case (original, expected) =>
-        Single("org.scalameta", "scalafmt-core", "2.0.0", Nel.of("2.0.1"))
+        Single(GroupId("org.scalameta"), "scalafmt-core", "2.0.0", Nel.of("2.0.1"))
           .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.specific.name)
         // Should not edit if artifactId ontains scalaBinaryVersion
-        Single("org.scalameta", "scalafmt-core_2.12", "2.0.0", Nel.of("2.0.1"))
+        Single(GroupId("org.scalameta"), "scalafmt-core_2.12", "2.0.0", Nel.of("2.0.1"))
           .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.specific.name)
     }
 
     val original = """version=2.0.0"""
-    Single("org.scalameta", "other-artifact", "2.0.0", Nel.of("2.0.1"))
+    Single(GroupId("org.scalameta"), "other-artifact", "2.0.0", Nel.of("2.0.1"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore TLD") {
     val original = """ "com.propensive" %% "contextual" % "1.0.1" """
-    Single("com.slamdata", "fs2-gzip", "1.0.1", Nel.of("1.1.1"))
+    Single(GroupId("com.slamdata"), "fs2-gzip", "1.0.1", Nel.of("1.1.1"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore short words") {
     val original = "SBT_VERSION=1.2.7"
-    Single("org.scala-sbt", "scripted-plugin", "1.2.7", Nel.of("1.2.8"))
+    Single(GroupId("org.scala-sbt"), "scripted-plugin", "1.2.7", Nel.of("1.2.8"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore 'scala' substring") {
     val original = """ val scalaTestVersion = "3.0.7" """
-    Single("org.scalactic", "scalactic", "3.0.7", Nel.of("3.0.8"))
+    Single(GroupId("org.scalactic"), "scalactic", "3.0.7", Nel.of("3.0.8"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
@@ -306,7 +314,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       libraryDependencies += "com.thoughtworks.dsl" %%% "keywords-each"  % "1.2.0+14-7a373cbd" % Optional
       """
     Group(
-      "com.thoughtworks.dsl",
+      GroupId("com.thoughtworks.dsl"),
       Nel.of("keywords-each", "keywords-using"),
       "1.2.0",
       Nel.of("1.3.0")
@@ -316,7 +324,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("prevent exception: named capturing group is missing trailing '}'") {
     val original = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.8.0""""
     val expected = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.9.1""""
-    Group("org.nd4j", Nel.of("nd4j-api", "nd4j-native-platform"), "0.8.0", Nel.of("0.9.1"))
+    Group(GroupId("org.nd4j"), Nel.of("nd4j-api", "nd4j-native-platform"), "0.8.0", Nel.of("0.9.1"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
@@ -324,7 +332,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val original = """ "com.geirsson" % "sbt-ci-release" % "1.2.1" """
     val expected = """ "com.geirsson" % "sbt-ci-release" % "1.2.4" """
     Group(
-      "org.scala-sbt",
+      GroupId("org.scala-sbt"),
       Nel.of("sbt-launch", "scripted-plugin", "scripted-sbt"),
       "1.2.1",
       Nel.of("1.2.4")
@@ -340,8 +348,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """  "com.typesafe.akka" %% "akka-actor" % "2.4.0", // scala-steward:off
         |  "com.typesafe.akka" %% "akka-testkit" % "2.5.0",
         |  """.stripMargin.trim
-    Group("com.typesafe.akka", Nel.of("akka-actor", "akka-testkit"), "2.4.0", Nel.of("2.5.0"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
+    Group(
+      GroupId("com.typesafe.akka"),
+      Nel.of("akka-actor", "akka-testkit"),
+      "2.4.0",
+      Nel.of("2.5.0")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
   test("disable updates on multiple lines after `off` (no `on`)") {
@@ -350,8 +362,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
         |  "com.typesafe.akka" %% "akka-testkit" % "2.4.0",
         |  """.stripMargin.trim
-    Group("com.typesafe.akka", Nel.of("akka-actor", "akka-testkit"), "2.4.0", Nel.of("2.5.0"))
-      .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
+    Group(
+      GroupId("com.typesafe.akka"),
+      Nel.of("akka-actor", "akka-testkit"),
+      "2.4.0",
+      Nel.of("2.5.0")
+    ).replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("update multiple lines between `on` and `off`") {
@@ -372,7 +388,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |  "com.typesafe.akka" %% "akka-testkit" % "2.4.20" % "test"
         |  """.stripMargin.trim
     Group(
-      "com.typesafe.akka",
+      GroupId("com.typesafe.akka"),
       Nel.of("akka-actor", "akka-testkit", "akka-slf4j"),
       "2.4.20",
       Nel.of("2.5.0")

--- a/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
@@ -8,7 +8,7 @@ import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.http4s.{Http4sLiteralSyntax, HttpRoutes}
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockContext.{config, user}
 import org.scalasteward.core.nurture.UpdateData
@@ -50,7 +50,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
     Repo("foo", "bar"),
     Repo("scala-steward", "bar"),
     RepoConfig(),
-    Update.Single("ch.qos.logback", "logback-classic", "1.2.0", Nel.of("1.2.3")),
+    Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3")),
     Branch("master"),
     Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
     Branch("update/logback-classic-1.2.3")

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.repoConfigAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
@@ -22,8 +22,8 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
 
     config shouldBe RepoConfig(
       updates = UpdatesConfig(
-        allow = List(UpdatePattern("eu.timepit", Some("refined"), Some("0.8."))),
-        ignore = List(UpdatePattern("org.acme", None, Some("1.0")))
+        allow = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), Some("0.8."))),
+        ignore = List(UpdatePattern(GroupId("org.acme"), None, Some("1.0")))
       )
     )
   }
@@ -51,26 +51,26 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("configToIgnoreFurtherUpdates with single update") {
-    val update = Update.Single("a", "b", "c", Nel.of("d"))
+    val update = Update.Single(GroupId("a"), "b", "c", Nel.of("d"))
     val repoConfig = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
 
     repoConfig shouldBe RepoConfig(
       updates = UpdatesConfig(
-        ignore = List(UpdatePattern("a", Some("b"), None))
+        ignore = List(UpdatePattern(GroupId("a"), Some("b"), None))
       )
     )
   }
 
   test("configToIgnoreFurtherUpdates with group update") {
-    val update = Update.Group("a", Nel.of("b", "e"), "c", Nel.of("d"))
+    val update = Update.Group(GroupId("a"), Nel.of("b", "e"), "c", Nel.of("d"))
     val repoConfig = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
 
     repoConfig shouldBe RepoConfig(
-      updates = UpdatesConfig(ignore = List(UpdatePattern("a", None, None)))
+      updates = UpdatesConfig(ignore = List(UpdatePattern(GroupId("a"), None, None)))
     )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.sbt
 
 import better.files.File
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.data.Version
+import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.{MockContext, MockState}
 import org.scalasteward.core.sbt.command._
@@ -133,7 +133,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
     val repoDir = config.workspace / repo.owner / repo.repo
     val migrations = Nel.of(
       Migration(
-        "co.fs2",
+        GroupId("co.fs2"),
         Nel.of("fs2-core".r),
         Version("1.0.0"),
         Nel.of("github:functional-streams-for-scala/fs2/v1?sha=v1.0.5")

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/data/ArtificialProjectTest.scala
@@ -1,18 +1,30 @@
 package org.scalasteward.core.sbt.data
 
-import org.scalasteward.core.data.Dependency
+import org.scalasteward.core.data.{Dependency, GroupId}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class ArtificialProjectTest extends AnyFunSuite with Matchers {
   val catsEffect =
-    Dependency("org.typelevel", "cats-effect", "cats-effect_2.12", "1.0.0", None)
+    Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0", None)
   val scalaLibrary =
-    Dependency("org.scala-lang", "scala-library", "scala-library", "2.12.6", None)
+    Dependency(GroupId("org.scala-lang"), "scala-library", "scala-library", "2.12.6", None)
   val sbtTravisci =
-    Dependency("com.dwijnand", "sbt-travisci", "sbt-travisci", "1.1.3", Some(SbtVersion("1.0")))
+    Dependency(
+      GroupId("com.dwijnand"),
+      "sbt-travisci",
+      "sbt-travisci",
+      "1.1.3",
+      Some(SbtVersion("1.0"))
+    )
   val sbtScalafmt =
-    Dependency("com.geirsson", "sbt-scalafmt", "sbt-scalafmt", "1.6.0-RC4", Some(SbtVersion("1.0")))
+    Dependency(
+      GroupId("com.geirsson"),
+      "sbt-scalafmt",
+      "sbt-scalafmt",
+      "1.6.0-RC4",
+      Some(SbtVersion("1.0"))
+    )
   val project = ArtificialProject(
     ScalaVersion("2.12.7"),
     SbtVersion("1.2.3"),

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.sbt
 
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, GroupId, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.sbt.parser._
 import org.scalasteward.core.util.Nel
@@ -15,21 +15,28 @@ class parserTest extends AnyFunSuite with Matchers {
   test("parseSingleUpdate: 1 new version") {
     val str = "org.scala-js:sbt-scalajs : 0.6.24 -> 0.6.25"
     parseSingleUpdate(str) shouldBe
-      Right(Update.Single("org.scala-js", "sbt-scalajs", "0.6.24", Nel.of("0.6.25")))
+      Right(Update.Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25")))
   }
 
   test("parseSingleUpdate: 2 new versions") {
     val str = "org.scala-lang:scala-library   : 2.9.1 -> 2.9.3 -> 2.10.3"
     parseSingleUpdate(str) shouldBe
-      Right(Update.Single("org.scala-lang", "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3")))
+      Right(
+        Update
+          .Single(GroupId("org.scala-lang"), "scala-library", "2.9.1", Nel.of("2.9.3", "2.10.3"))
+      )
   }
 
   test("parseSingleUpdate: 3 new versions") {
     val str = "ch.qos.logback:logback-classic : 0.8   -> 0.8.1 -> 0.9.30 -> 1.0.13"
     parseSingleUpdate(str) shouldBe
       Right(
-        Update
-          .Single("ch.qos.logback", "logback-classic", "0.8", Nel.of("0.8.1", "0.9.30", "1.0.13"))
+        Update.Single(
+          GroupId("ch.qos.logback"),
+          "logback-classic",
+          "0.8",
+          Nel.of("0.8.1", "0.9.30", "1.0.13")
+        )
       )
   }
 
@@ -39,7 +46,7 @@ class parserTest extends AnyFunSuite with Matchers {
       Right(
         Update
           .Single(
-            "org.scalacheck",
+            GroupId("org.scalacheck"),
             "scalacheck",
             "1.12.5",
             Nel.of("1.12.6", "1.14.0"),
@@ -73,7 +80,8 @@ class parserTest extends AnyFunSuite with Matchers {
     val str =
       "bigdataoss:gcs-connector : hadoop2-1.9.16 -> InvalidVersion(hadoop3-2.0.0-SNAPSHOT) -> 1.9.4-hadoop3"
     parseSingleUpdate(str) shouldBe Right(
-      Update.Single("bigdataoss", "gcs-connector", "hadoop2-1.9.16", Nel.of("1.9.4-hadoop3"))
+      Update
+        .Single(GroupId("bigdataoss"), "gcs-connector", "hadoop2-1.9.16", Nel.of("1.9.4-hadoop3"))
     )
   }
 
@@ -91,16 +99,16 @@ class parserTest extends AnyFunSuite with Matchers {
       """.stripMargin.trim
     parseSingleUpdates(str.linesIterator.toList) shouldBe
       List(
-        Update.Single("ai.x", "diff", "1.2.0", Nel.of("1.2.1"), Some("test")),
+        Update.Single(GroupId("ai.x"), "diff", "1.2.0", Nel.of("1.2.1"), Some("test")),
         Update
           .Single(
-            "com.geirsson",
+            GroupId("com.geirsson"),
             "scalafmt-cli_2.11",
             "0.3.0",
             Nel.of("0.3.1", "0.6.8", "1.5.1"),
             Some("scalafmt")
           ),
-        Update.Single("eu.timepit", "refined", "0.7.0", Nel.of("0.9.3"))
+        Update.Single(GroupId("eu.timepit"), "refined", "0.7.0", Nel.of("0.9.3"))
       )
   }
 
@@ -117,9 +125,9 @@ class parserTest extends AnyFunSuite with Matchers {
     )
     parseSingleUpdates(lines) shouldBe
       List(
-        Update.Single("com.github.pureconfig", "pureconfig", "0.8.0", Nel.of("0.9.2")),
-        Update.Single("org.scala-lang", "scala-library", "2.12.3", Nel.of("2.12.6")),
-        Update.Single("org.scalacheck", "scalacheck", "1.13.5", Nel.of("1.14.0"))
+        Update.Single(GroupId("com.github.pureconfig"), "pureconfig", "0.8.0", Nel.of("0.9.2")),
+        Update.Single(GroupId("org.scala-lang"), "scala-library", "2.12.3", Nel.of("2.12.6")),
+        Update.Single(GroupId("org.scalacheck"), "scalacheck", "1.13.5", Nel.of("1.14.0"))
       )
   }
 
@@ -132,42 +140,42 @@ class parserTest extends AnyFunSuite with Matchers {
          |""".stripMargin.linesIterator.toList
     parseDependencies(lines) shouldBe List(
       Dependency(
-        "org.scala-lang",
+        GroupId("org.scala-lang"),
         "scala-library",
         "scala-library",
         "2.12.7",
         None
       ),
       Dependency(
-        "com.github.pathikrit",
+        GroupId("com.github.pathikrit"),
         "better-files",
         "better-files_2.12",
         "3.6.0",
         None
       ),
       Dependency(
-        "org.typelevel",
+        GroupId("org.typelevel"),
         "cats-effect",
         "cats-effect_2.12",
         "1.0.0",
         None
       ),
       Dependency(
-        "org.scala-lang",
+        GroupId("org.scala-lang"),
         "scala-library",
         "scala-library",
         "2.12.6",
         None
       ),
       Dependency(
-        "com.dwijnand",
+        GroupId("com.dwijnand"),
         "sbt-travisci",
         "sbt-travisci",
         "1.1.3",
         Some(SbtVersion("1.0"))
       ),
       Dependency(
-        "com.eed3si9n",
+        GroupId("com.eed3si9n"),
         "sbt-assembly",
         "sbt-assembly",
         "0.14.8",
@@ -175,7 +183,7 @@ class parserTest extends AnyFunSuite with Matchers {
         Some("foo")
       ),
       Dependency(
-        "com.geirsson",
+        GroupId("com.geirsson"),
         "sbt-scalafmt",
         "sbt-scalafmt",
         "1.6.0-RC4",

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.update
 
 import cats.implicits._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
@@ -12,40 +12,46 @@ import org.scalatest.matchers.should.Matchers
 
 class FilterAlgTest extends AnyFunSuite with Matchers {
   test("globalFilter: SNAP -> SNAP") {
-    val update = Update.Single("org.scalatest", "scalatest", "3.0.8-SNAP2", Nel.of("3.0.8-SNAP10"))
+    val update =
+      Update.Single(GroupId("org.scalatest"), "scalatest", "3.0.8-SNAP2", Nel.of("3.0.8-SNAP10"))
     FilterAlg.globalFilter(update) shouldBe Right(update)
   }
 
   test("globalFilter: RC -> SNAP") {
-    val update = Update.Single("org.scalatest", "scalatest", "3.0.8-RC2", Nel.of("3.1.0-SNAP10"))
+    val update =
+      Update.Single(GroupId("org.scalatest"), "scalatest", "3.0.8-RC2", Nel.of("3.1.0-SNAP10"))
     FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("globalFilter: update without bad version") {
-    val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
+    val update =
+      Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
     FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("1.1.2")))
   }
 
   test("globalFilter: update with bad version") {
-    val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.2-1", Nel.of("1.1.2", "2.0.0"))
+    val update =
+      Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.2-1", Nel.of("1.1.2", "2.0.0"))
     FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("2.0.0")))
   }
 
   test("globalFilter: update with only bad versions") {
-    val update = Update.Single("org.http4s", "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
+    val update = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
     FilterAlg.globalFilter(update) shouldBe Left(BadVersions(update))
   }
 
   test("globalFilter: update to pre-release of a different series") {
-    val update = Update.Single("com.jsuereth", "sbt-pgp", "1.1.2-1", Nel.of("2.0.1-M3"))
+    val update = Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.2-1", Nel.of("2.0.1-M3"))
     FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("ignore update via config updates.ignore") {
-    val update1 = Update.Single("org.http4s", "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
-    val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
+    val update1 = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
+    val update2 = Update.Single(GroupId("eu.timepit"), "refined", "0.8.0", Nel.of("0.8.1"))
     val config =
-      RepoConfig(UpdatesConfig(ignore = List(UpdatePattern("eu.timepit", Some("refined"), None))))
+      RepoConfig(
+        UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None)))
+      )
 
     val initialState = MockState.empty
     val (state, filtered) =
@@ -60,14 +66,14 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("ignore update via config updates.allow") {
-    val update1 = Update.Single("org.http4s", "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
-    val update2 = Update.Single("eu.timepit", "refined", "0.8.0", Nel.of("0.8.1"))
+    val update1 = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
+    val update2 = Update.Single(GroupId("eu.timepit"), "refined", "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
       updates = UpdatesConfig(
         allow = List(
-          UpdatePattern("org.http4s", None, Some("0.17")),
-          UpdatePattern("eu.timepit", Some("refined"), Some("0.8"))
+          UpdatePattern(update1.groupId, None, Some("0.17")),
+          UpdatePattern(update2.groupId, Some("refined"), Some("0.8"))
         )
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.update
 
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{Dependency, GroupId, Update}
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -8,19 +8,19 @@ import org.scalatest.matchers.should.Matchers
 class UpdateAlgTest extends AnyFunSuite with Matchers {
 
   test("findUpdateUnderNewGroup: returns empty if dep is not listed") {
-    val original = new Dependency("org.spire-math", "UNKNOWN", "_2.12", "1.0.0")
+    val original = Dependency(GroupId("org.spire-math"), "UNKNOWN", "_2.12", "1.0.0")
     UpdateAlg.findUpdateUnderNewGroup(original) shouldBe None
   }
 
   test("findUpdateUnderNewGroup: returns Update.Single for updateing groupId") {
-    val original = new Dependency("org.spire-math", "kind-projector", "_2.12", "0.9.0")
+    val original = Dependency(GroupId("org.spire-math"), "kind-projector", "_2.12", "0.9.0")
     UpdateAlg.findUpdateUnderNewGroup(original) shouldBe Some(
       Update.Single(
-        "org.spire-math",
+        GroupId("org.spire-math"),
         "kind-projector",
         "0.9.0",
         Nel.of("0.10.0"),
-        newerGroupId = Some("org.typelevel")
+        newerGroupId = Some(GroupId("org.typelevel"))
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.update
 
+import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.data.Update.{Group, Single}
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
@@ -8,45 +9,46 @@ import org.scalatest.matchers.should.Matchers
 class showTest extends AnyFunSuite with Matchers {
 
   test("oneLiner: cats-core") {
-    val update = Single("org.typelevel", "cats-core", "0.9.0", Nel.one("1.0.0"))
+    val update = Single(GroupId("org.typelevel"), "cats-core", "0.9.0", Nel.one("1.0.0"))
     show.oneLiner(update) shouldBe "cats-core"
   }
 
   test("oneLiner: fs2-core") {
-    val update = Single("co.fs2", "fs2-core", "0.9.7", Nel.one("1.0.0"))
+    val update = Single(GroupId("co.fs2"), "fs2-core", "0.9.7", Nel.one("1.0.0"))
     show.oneLiner(update) shouldBe "fs2-core"
   }
 
   test("oneLiner: monix") {
-    val update = Single("io.monix", "monix", "2.3.3", Nel.one("3.0.0"))
+    val update = Single(GroupId("io.monix"), "monix", "2.3.3", Nel.one("3.0.0"))
     show.oneLiner(update) shouldBe "monix"
   }
 
   test("oneLiner: sttp:core") {
-    val update = Single("com.softwaremill.sttp", "core", "1.3.3", Nel.one("1.3.5"))
+    val update = Single(GroupId("com.softwaremill.sttp"), "core", "1.3.3", Nel.one("1.3.5"))
     show.oneLiner(update) shouldBe "sttp:core"
   }
 
   test("oneLiner: typesafe:config") {
-    val update = Single("com.typesafe", "config", "1.3.0", Nel.one("1.3.3"))
+    val update = Single(GroupId("com.typesafe"), "config", "1.3.0", Nel.one("1.3.3"))
     show.oneLiner(update) shouldBe "typesafe:config"
   }
 
   test("oneLiner: single update with very long artifactId") {
     val artifactId = "1234567890" * 5
-    val update = Single("org.example", artifactId, "1.0.0", Nel.one("2.0.0"))
+    val update = Single(GroupId("org.example"), artifactId, "1.0.0", Nel.one("2.0.0"))
     show.oneLiner(update) shouldBe artifactId
   }
 
   test("oneLiner: group update with two artifacts") {
-    val update = Group("org.typelevel", Nel.of("cats-core", "cats-free"), "0.9.0", Nel.one("1.0.0"))
+    val update =
+      Group(GroupId("org.typelevel"), Nel.of("cats-core", "cats-free"), "0.9.0", Nel.one("1.0.0"))
     val expected = "cats-core, cats-free"
     show.oneLiner(update) shouldBe expected
   }
 
   test("oneLiner: group update with four artifacts") {
     val update = Group(
-      "org.typelevel",
+      GroupId("org.typelevel"),
       Nel.of("cats-core", "cats-free", "cats-laws", "cats-macros"),
       "0.9.0",
       Nel.one("1.0.0")
@@ -56,14 +58,15 @@ class showTest extends AnyFunSuite with Matchers {
   }
 
   test("oneLiner: group update with four short artifacts") {
-    val update = Group("group", Nel.of("data", "free", "laws", "macros"), "0.9.0", Nel.one("1.0.0"))
+    val update =
+      Group(GroupId("group"), Nel.of("data", "free", "laws", "macros"), "0.9.0", Nel.one("1.0.0"))
     val expected = "data, free, laws, macros"
     show.oneLiner(update) shouldBe expected
   }
 
   test("oneLiner: group update where one artifactId is a common suffix") {
     val update = Group(
-      "com.softwaremill.sttp",
+      GroupId("com.softwaremill.sttp"),
       Nel.of("circe", "core", "okhttp-backend-monix"),
       "1.3.3",
       Nel.one("1.3.5")

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -3,10 +3,10 @@ package org.scalasteward.core.vcs
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import org.http4s.client.Client
-import org.http4s.dsl.io.{->, /, HEAD, NotFound, Ok, Root, _}
+import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.ioLogger
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util.{HttpExistenceClient, Nel}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -23,9 +23,9 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
   implicit val httpExistenceClient = new HttpExistenceClient[IO]
 
   val vcsExtraAlg = VCSExtraAlg.create[IO]
-  val updateFoo = Update.Single("com.example", "foo", "0.1.0", Nel.of("0.2.0"))
-  val updateBar = Update.Single("com.example", "bar", "0.1.0", Nel.of("0.2.0"))
-  val updateBuz = Update.Single("com.example", "buz", "0.1.0", Nel.of("0.2.0"))
+  val updateFoo = Update.Single(GroupId("com.example"), "foo", "0.1.0", Nel.of("0.2.0"))
+  val updateBar = Update.Single(GroupId("com.example"), "bar", "0.1.0", Nel.of("0.2.0"))
+  val updateBuz = Update.Single(GroupId("com.example"), "buz", "0.1.0", Nel.of("0.2.0"))
 
   test("getBranchCompareUrl") {
     vcsExtraAlg.getBranchCompareUrl(None, updateBar).unsafeRunSync() shouldBe None

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.vcs
 
 import org.scalasteward.core.application.SupportedVCS.{GitHub, Gitlab}
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class VCSPackageTest extends AnyFunSuite with Matchers {
   val repo = Repo("foo", "bar")
-  val update = Update.Single("ch.qos.logback", "logback-classic", "1.2.0", Nel.of("1.2.3"))
+  val update = Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3"))
 
   test("listingBranch") {
     listingBranch(GitHub, repo, update) shouldBe "foo/bar:update/logback-classic-1.2.3"

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
-import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfig
@@ -15,7 +15,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       Repo("foo", "bar"),
       Repo("scala-steward", "bar"),
       RepoConfig(),
-      Update.Single("ch.qos.logback", "logback-classic", "1.2.0", Nel.of("1.2.3")),
+      Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3")),
       Branch("master"),
       Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
       Branch("update/logback-classic-1.2.3")
@@ -35,12 +35,12 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
 
   test("fromTo") {
     NewPullRequestData.fromTo(
-      Update.Single("com.example", "foo", "1.2.0", Nel.of("1.2.3")),
+      Update.Single(GroupId("com.example"), "foo", "1.2.0", Nel.of("1.2.3")),
       None
     ) shouldBe "from 1.2.0 to 1.2.3"
 
     NewPullRequestData.fromTo(
-      Update.Group("com.example", Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
+      Update.Group(GroupId("com.example"), Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
       Some("http://example.com/compare/v1.2.0...v1.2.3")
     ) shouldBe
       "[from 1.2.0 to 1.2.3](http://example.com/compare/v1.2.0...v1.2.3)"
@@ -56,12 +56,12 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
 
   test("showing artifacts with URL in Markdown format") {
     NewPullRequestData.artifactsWithOptionalUrl(
-      Update.Single("com.example", "foo", "1.2.0", Nel.of("1.2.3")),
+      Update.Single(GroupId("com.example"), "foo", "1.2.0", Nel.of("1.2.3")),
       Map("foo" -> "https://github.com/foo/foo")
     ) shouldBe "[com.example:foo](https://github.com/foo/foo)"
 
     NewPullRequestData.artifactsWithOptionalUrl(
-      Update.Group("com.example", Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
+      Update.Group(GroupId("com.example"), Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
       Map("foo" -> "https://github.com/foo/foo", "bar" -> "https://github.com/bar/bar")
     ) shouldBe
       """
@@ -72,7 +72,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
   }
 
   test("migrationNote: when no migrations") {
-    val update = Update.Single("com.example", "foo", "0.6.0", Nel.of("0.7.0"))
+    val update = Update.Single(GroupId("com.example"), "foo", "0.6.0", Nel.of("0.7.0"))
     val (label, appliedMigrations) = NewPullRequestData.migrationNote(update)
 
     label shouldBe None
@@ -80,7 +80,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
   }
 
   test("migrationNote: when artifact has migrations") {
-    val update = Update.Single("com.spotify", "scio-core", "0.6.0", Nel.of("0.7.0"))
+    val update = Update.Single(GroupId("com.spotify"), "scio-core", "0.6.0", Nel.of("0.7.0"))
     val (label, appliedMigrations) = NewPullRequestData.migrationNote(update)
 
     label shouldBe Some("scalafix-migrations")


### PR DESCRIPTION
Scala Steward is currently stringly typed in a lot of places and I'd like to slowly get away from that by introducing more wrapper types. This PR begins with a wrapper for groupIds.