### PR TITLE
Resolve POMs of sbt plugins

### DIFF
--- a/modules/core/src/main/resources/StewardPlugin.scala
+++ b/modules/core/src/main/resources/StewardPlugin.scala
@@ -48,6 +48,7 @@ object StewardPlugin extends AutoPlugin {
             "version" -> moduleId.revision
           ) ++
             moduleId.extraAttributes.get("e:sbtVersion").map("sbtVersion" -> _).toList ++
+            moduleId.extraAttributes.get("e:scalaVersion").map("scalaVersion" -> _).toList ++
             moduleId.configurations.map("configurations" -> _).toList
 
           entries.map { case (k, v) => s""""$k": "$v"""" }.mkString("{ ", ", ", " }")

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.data
 
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
-import org.scalasteward.core.sbt.data.SbtVersion
+import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.util.Nel
 
 final case class Dependency(
@@ -27,6 +27,7 @@ final case class Dependency(
     artifactIdCross: String,
     version: String,
     sbtVersion: Option[SbtVersion] = None,
+    scalaVersion: Option[ScalaVersion] = None,
     configurations: Option[String] = None
 ) {
   def formatAsModuleId: String =

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -3,23 +3,36 @@ package org.scalasteward.core.coursier
 import org.scalasteward.core.data.{Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class CoursierAlgTest extends AnyFunSuite with Matchers {
-
-  test("getArtifactUrl") {
+  test("getArtifactUrl: library") {
     val dep = Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0")
     val (state, result) = coursierAlg
       .getArtifactUrl(dep)
       .run(MockState.empty)
       .unsafeRunSync()
-    state shouldBe MockState.empty.copy(
-      commands = Vector(),
-      logs = Vector(),
-      files = Map()
-    )
+    state shouldBe MockState.empty
     result shouldBe Some("https://github.com/typelevel/cats-effect")
+  }
+
+  test("getArtifactUrl: sbt plugin") {
+    val dep = Dependency(
+      GroupId("org.xerial.sbt"),
+      "sbt-sonatype",
+      "sbt-sonatype",
+      "3.8",
+      Some(SbtVersion("1.0")),
+      Some(ScalaVersion("2.12"))
+    )
+    val (state, result) = coursierAlg
+      .getArtifactUrl(dep)
+      .run(MockState.empty)
+      .unsafeRunSync()
+    state shouldBe MockState.empty
+    result shouldBe Some("https://github.com/xerial/sbt-sonatype")
   }
 
   test("getArtifactIdUrlMapping") {
@@ -31,15 +44,10 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       .getArtifactIdUrlMapping(dependencies)
       .run(MockState.empty)
       .unsafeRunSync()
-    state shouldBe MockState.empty.copy(
-      commands = Vector(),
-      logs = Vector(),
-      files = Map()
-    )
+    state shouldBe MockState.empty
     result shouldBe Map(
       "cats-core" -> "https://github.com/typelevel/cats",
       "cats-effect" -> "https://github.com/typelevel/cats-effect"
     )
   }
-
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -180,6 +180,7 @@ class parserTest extends AnyFunSuite with Matchers {
         "sbt-assembly",
         "0.14.8",
         Some(SbtVersion("1.0")),
+        None,
         Some("foo")
       ),
       Dependency(


### PR DESCRIPTION
This adds `sbtVersion` and `scalaVersion` attributes to
`coursier.Dependency` to correctly resolve POMs of sbt plugins. With
this change, Scala Steward shows the SCM URL or homepage in the PR body
of sbt plugins that are on Maven Central.

Here is a PR of sbt-sonatype before this change:
https://github.com/fthomas/refined-sjs-example/pull/57

and here with this change:
https://github.com/fthomas/refined-sjs-example/pull/63