### PR TITLE
add heuristic taking into account org type for short group ids

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -126,6 +126,11 @@ object UpdateHeuristic {
       defaultReplaceVersion(_.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList)
   )
 
+  val completeGroupId = UpdateHeuristic(
+    name = "completeGroupId",
+    replaceVersion = defaultReplaceVersion(update => List(update.groupId.value))
+  )
+
   val groupId = UpdateHeuristic(
     name = "groupId",
     replaceVersion = defaultReplaceVersion(
@@ -147,5 +152,5 @@ object UpdateHeuristic {
   )
 
   val all: Nel[UpdateHeuristic] =
-    Nel.of(strict, original, relaxed, sliding, groupId, specific)
+    Nel.of(strict, original, relaxed, sliding, completeGroupId, groupId, specific)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -68,6 +68,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
         List("read", scalafmtFile.pathAsString),
         List("read", scalafmtFile.pathAsString),
         List("read", scalafmtFile.pathAsString),
+        List("read", scalafmtFile.pathAsString),
         List("write", scalafmtFile.pathAsString)
       ),
       logs = Vector(
@@ -75,6 +76,7 @@ class EditAlgTest extends AnyFunSuite with Matchers {
         (None, "Trying heuristic 'original'"),
         (None, "Trying heuristic 'relaxed'"),
         (None, "Trying heuristic 'sliding'"),
+        (None, "Trying heuristic 'completeGroupId'"),
         (None, "Trying heuristic 'groupId'"),
         (None, "Trying heuristic 'specific'")
       ),

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -92,6 +92,29 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
+  test("short groupIds") {
+    val original = """
+                     |private val mapCommonsDeps = Seq(
+                     |    "akka-streams",
+                     |    "akka-streams-kafka"
+                     |  ).map("com.sky" %% _ % "1.2.0")
+                     |""".stripMargin
+
+    val expected = """
+                     |private val mapCommonsDeps = Seq(
+                     |    "akka-streams",
+                     |    "akka-streams-kafka"
+                     |  ).map("com.sky" %% _ % "1.3.0")
+                     |""".stripMargin
+
+    Group(
+      GroupId("com.sky"),
+      Nel.of("akka-streams", "akka-streams-kafka"),
+      "1.2.0",
+      Nel.one("1.3.0")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.completeGroupId.name)
+  }
+
   test("version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""


### PR DESCRIPTION
As discussed in Gitter. 
because GroupId heuristic filters search terms containing 3 or less characters, organisations like Sky, BBc, etc. get dropped and not updated (unless using variables for their versions).