### PR TITLE
Run self checks at program start

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -59,6 +59,7 @@ object Context {
       implicit val httpExistenceClient: HttpExistenceClient[F] = new HttpExistenceClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
         new RepoCacheRepository[F](new JsonKeyValueStore("repos", "6"))
+      implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/SelfCheckAlg.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.application
+
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import org.http4s.Uri
+import org.scalasteward.core.util.{HttpExistenceClient, MonadThrowable}
+
+final class SelfCheckAlg[F[_]](
+    implicit
+    httpExistenceClient: HttpExistenceClient[F],
+    logger: Logger[F],
+    F: MonadThrowable[F]
+) {
+  def checkAll: F[Unit] =
+    for {
+      _ <- logger.info("Run self checks")
+      _ <- checkHttpExistenceClient
+    } yield ()
+
+  private def checkHttpExistenceClient: F[Unit] =
+    for {
+      url <- F.fromEither(Uri.fromString("https://github.com"))
+      res <- httpExistenceClient.exists(url)
+      msg = s"Self check of HttpExistenceClient failed: checking that $url exists failed"
+      _ <- if (!res) logger.warn(msg) else F.unit
+    } yield ()
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -39,6 +39,7 @@ final class StewardAlg[F[_]](
     nurtureAlg: NurtureAlg[F],
     repoCacheAlg: RepoCacheAlg[F],
     sbtAlg: SbtAlg[F],
+    selfCheckAlg: SelfCheckAlg[F],
     updateAlg: UpdateAlg[F],
     workspaceAlg: WorkspaceAlg[F],
     F: Monad[F]
@@ -88,6 +89,7 @@ final class StewardAlg[F[_]](
     logger.infoTotalTime("run") {
       for {
         _ <- printBanner
+        _ <- selfCheckAlg.checkAll
         _ <- prepareEnv
         repos <- readRepos(config.reposFile)
         reposToNurture <- if (config.pruneRepos) pruneRepos(repos) else F.pure(repos)


### PR DESCRIPTION
This adds a `SelfCheckAlg` which is used to run self checks at program
start. The intention of these self checks is to check that components
work correctly before they are used later in the program. This should
help users tweaking the environment until all components work as
expected. For now it only includes a check of HttpExistenceClient which
might need additional JVM properties if Scala Steward is operated behind
a proxy server.