### PR TITLE
Do not use Option for repoUrl parameters in VCSExtraAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -141,14 +141,12 @@ final class NurtureAlg[F[_]](
       dependencies <- getDependencies
       filteredDependencies = dependenciesInUpdates(dependencies, data.update)
       artifactIdToUrl <- coursierAlg.getArtifactIdUrlMapping(filteredDependencies)
-      branchCompareUrl <- vcsExtraAlg.getBranchCompareUrl(
-        artifactIdToUrl.get(data.update.artifactId),
-        data.update
-      )
-      releaseNoteUrl <- vcsExtraAlg.getReleaseNoteUrl(
-        artifactIdToUrl.get(data.update.artifactId),
-        data.update
-      )
+      branchCompareUrl <- artifactIdToUrl
+        .get(data.update.artifactId)
+        .flatTraverse(vcsExtraAlg.getBranchCompareUrl(_, data.update))
+      releaseNoteUrl <- artifactIdToUrl
+        .get(data.update.artifactId)
+        .flatTraverse(vcsExtraAlg.getReleaseNoteUrl(_, data.update))
       branchName = vcs.createBranch(config.vcsType, data.fork, data.update)
       requestData = NewPullRequestData.from(
         data,

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -23,8 +23,8 @@ import org.scalasteward.core.util.HttpExistenceClient
 import org.scalasteward.core.vcs
 
 trait VCSExtraAlg[F[_]] {
-  def getBranchCompareUrl(maybeRepoUrl: Option[String], update: Update): F[Option[String]]
-  def getReleaseNoteUrl(maybeRepoUrl: Option[String], update: Update): F[Option[String]]
+  def getBranchCompareUrl(repoUrl: String, update: Update): F[Option[String]]
+  def getReleaseNoteUrl(repoUrl: String, update: Update): F[Option[String]]
 }
 
 object VCSExtraAlg {
@@ -33,18 +33,10 @@ object VCSExtraAlg {
       existenceClient: HttpExistenceClient[F],
       F: Monad[F]
   ): VCSExtraAlg[F] = new VCSExtraAlg[F] {
-    override def getBranchCompareUrl(
-        maybeRepoUrl: Option[String],
-        update: Update
-    ): F[Option[String]] =
-      maybeRepoUrl.toList.flatMap(vcs.possibleCompareUrls(_, update)).findM(existenceClient.exists)
+    override def getBranchCompareUrl(repoUrl: String, update: Update): F[Option[String]] =
+      vcs.possibleCompareUrls(repoUrl, update).findM(existenceClient.exists)
 
-    override def getReleaseNoteUrl(
-        maybeRepoUrl: Option[String],
-        update: Update
-    ): F[Option[String]] =
-      maybeRepoUrl.toList
-        .flatMap(vcs.possibleReleaseNoteFiles(_, update))
-        .findM(existenceClient.exists)
+    override def getReleaseNoteUrl(repoUrl: String, update: Update): F[Option[String]] =
+      vcs.possibleReleaseNoteFiles(repoUrl, update).findM(existenceClient.exists)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -28,15 +28,14 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
   val updateBuz = Update.Single(GroupId("com.example"), "buz", "0.1.0", Nel.of("0.2.0"))
 
   test("getBranchCompareUrl") {
-    vcsExtraAlg.getBranchCompareUrl(None, updateBar).unsafeRunSync() shouldBe None
     vcsExtraAlg
-      .getBranchCompareUrl(Some("https://github.com/foo/foo"), updateFoo)
+      .getBranchCompareUrl("https://github.com/foo/foo", updateFoo)
       .unsafeRunSync() shouldBe None
     vcsExtraAlg
-      .getBranchCompareUrl(Some("https://github.com/foo/bar"), updateBar)
+      .getBranchCompareUrl("https://github.com/foo/bar", updateBar)
       .unsafeRunSync() shouldBe Some("https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
     vcsExtraAlg
-      .getBranchCompareUrl(Some("https://github.com/foo/buz"), updateBuz)
+      .getBranchCompareUrl("https://github.com/foo/buz", updateBuz)
       .unsafeRunSync() shouldBe None
   }
 }


### PR DESCRIPTION
The `Option` here  isn't necessary since a `None` always produced an
empty result without running any effects.