### PR TITLE
Add "release-$version" as possible tag for diffs and release notes

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/package.scala
@@ -46,20 +46,21 @@ package object vcs {
         git.branchFor(update).name
     }
 
+  def possibleTags(version: String): List[String] =
+    List(s"v$version", version, s"release-$version")
+
   def possibleCompareUrls(repoUrl: String, update: Update): List[String] = {
     val from = update.currentVersion
     val to = update.nextVersion
     val canonicalized = repoUrl.replaceAll("/$", "")
     if (repoUrl.startsWith("https://github.com/") || repoUrl.startsWith("https://gitlab.com/"))
-      List(
-        s"${canonicalized}/compare/v${from}...v${to}",
-        s"${canonicalized}/compare/${from}...${to}"
-      )
+      possibleTags(from).zip(possibleTags(to)).map {
+        case (from1, to1) => s"${canonicalized}/compare/$from1...$to1"
+      }
     else if (repoUrl.startsWith("https://bitbucket.org/"))
-      List(
-        s"${canonicalized}/compare/v${to}..v${from}#diff",
-        s"${canonicalized}/compare/${to}..${from}#diff"
-      )
+      possibleTags(from).zip(possibleTags(to)).map {
+        case (from1, to1) => s"${canonicalized}/compare/${to1}..${from1}#diff"
+      }
     else
       List.empty
   }
@@ -68,10 +69,7 @@ package object vcs {
     val canonicalized = repoUrl.replaceAll("/$", "")
     val vcsSpecific =
       if (repoUrl.startsWith("https://github.com/"))
-        List(
-          s"${canonicalized}/releases/tag/${update.nextVersion}",
-          s"${canonicalized}/releases/tag/v${update.nextVersion}"
-        )
+        possibleTags(update.nextVersion).map(tag => s"${canonicalized}/releases/tag/$tag")
       else
         List.empty
     val files = {

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -24,21 +24,25 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
   test("possibleCompareUrls") {
     possibleCompareUrls("https://github.com/foo/bar", update) shouldBe List(
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
-      "https://github.com/foo/bar/compare/1.2.0...1.2.3"
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
+      "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
     // should canonicalize (drop last slash)
     possibleCompareUrls("https://github.com/foo/bar/", update) shouldBe List(
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
-      "https://github.com/foo/bar/compare/1.2.0...1.2.3"
+      "https://github.com/foo/bar/compare/1.2.0...1.2.3",
+      "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
 
     possibleCompareUrls("https://gitlab.com/foo/bar", update) shouldBe List(
       "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
-      "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3"
+      "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
+      "https://gitlab.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
     possibleCompareUrls("https://bitbucket.org/foo/bar", update) shouldBe List(
       "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
-      "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff"
+      "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff",
+      "https://bitbucket.org/foo/bar/compare/release-1.2.3..release-1.2.0#diff"
     )
 
     possibleCompareUrls("https://scalacenter.github.io/scalafix/", update) shouldBe List()
@@ -68,8 +72,9 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
       "https://github.com/foo/bar/blob/master/ReleaseNotes.md",
       "https://github.com/foo/bar/blob/master/ReleaseNotes.markdown",
       "https://github.com/foo/bar/blob/master/ReleaseNotes.rst",
+      "https://github.com/foo/bar/releases/tag/v1.2.3",
       "https://github.com/foo/bar/releases/tag/1.2.3",
-      "https://github.com/foo/bar/releases/tag/v1.2.3"
+      "https://github.com/foo/bar/releases/tag/release-1.2.3"
     )
 
     // blob/<branch>


### PR DESCRIPTION
When looking for version diffs and release notes we now also check URLs
that contain tags like `release-$version`.

ScalaTest uses this scheme for their tags. Here is an example PR that
now includes links to the version diff and release notes because of this
change: https://github.com/fthomas/refined-sjs-example/pull/67