### PR TITLE
Treat 'AM' as pre-release identifier

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -90,12 +90,12 @@ object Version {
     final case class Alpha(value: String) extends Component {
       def isPreReleaseIdent: Boolean = order < 0
       def order: Int = value.toUpperCase match {
-        case "SNAP" | "SNAPSHOT" => -5
-        case "ALPHA"             => -4
-        case "BETA"              => -3
-        case "M" | "MILESTONE"   => -2
-        case "RC"                => -1
-        case _                   => 0
+        case "SNAP" | "SNAPSHOT"      => -5
+        case "ALPHA"                  => -4
+        case "BETA"                   => -3
+        case "M" | "MILESTONE" | "AM" => -2
+        case "RC"                     => -1
+        case _                        => 0
       }
     }
     final case class Separator(c: Char) extends Component

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -130,7 +130,8 @@ class VersionTest extends AnyFunSuite with Discipline with Matchers with ScalaCh
       ("8.0.192-R14", List("12.0.2-RC18"), None),
       ("2.0.0-RC4", List("2.0.0-RC4-1"), Some("2.0.0-RC4-1")),
       ("2.0.0-RC4", List("2.1.0-RC4-1"), None),
-      ("9.4.21.v20190926", List("10.0.0-alpha0"), None)
+      ("9.4.21.v20190926", List("10.0.0-alpha0"), None),
+      ("2.0.0.AM4", List("2.0.0"), Some("2.0.0"))
     )
 
     val rnd = new Random()


### PR DESCRIPTION
To allow updates from 2.0.0.AM4 to 2.0.0, for example.

This identifier is used by [org.apache.directory.api:api-all](https://mvnrepository.com/artifact/org.apache.directory.api/api-all) and I assume
it designates a milestone release. But I've no idea what the 'A' stands
for. If somebody has an idea, please let me know.