### PR TITLE
Mark Scala.js 0.6.30 as bad

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -134,6 +134,17 @@ object FilterAlg {
           // https://github.com/http4s/http4s/pull/2153
           "0.19.0"
         )
+
+      case (
+          "org.scala-js",
+          "sbt-scalajs" | "scalajs-compiler" | "scalajs-test-bridge" | "scalajs-test-interface",
+          _
+          ) =>
+        List(
+          //https://github.com/scala-js/scala-js/issues/3865
+          "0.6.30"
+        )
+
       case _ => List.empty
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -137,7 +137,8 @@ object FilterAlg {
 
       case (
           "org.scala-js",
-          "sbt-scalajs" | "scalajs-compiler" | "scalajs-test-bridge" | "scalajs-test-interface",
+          "sbt-scalajs" | "scalajs-compiler" | "scalajs-library" | "scalajs-test-bridge" |
+          "scalajs-test-interface",
           _
           ) =>
         List(


### PR DESCRIPTION
See https://github.com/scala-js/scala-js/issues/3865.