### PR TITLE
Bitbucket server pull request state should be case sensitive

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/PullRequestState.scala
@@ -30,9 +30,11 @@ object PullRequestState {
 
   implicit val pullRequestStateDecoder: Decoder[PullRequestState] =
     Decoder[String].emap {
-      case "open" | "opened"   => Right(Open)
-      case "closed" | "merged" => Right(Closed)
-      case unknown             => Left(s"Unexpected string '$unknown'")
+      _.toLowerCase match {
+        case "open" | "opened"                => Right(Open)
+        case "closed" | "merged" | "declined" => Right(Closed)
+        case unknown                          => Left(s"Unexpected string '$unknown'")
+      }
     }
 
   implicit val pullRequestStateEncoder: Encoder[PullRequestState] =


### PR DESCRIPTION
Hi,
according to this issue:
https://github.com/fthomas/scala-steward/issues/1100

In this PR I added a toLowerCase method inside the PullRequestState decoder to parse correctly the "OPEN" state of Bitbucket Server.

I added the declined state to match as a closed state

Regards,
Andrea