### PR TITLE
Revert "Use 2.12 for Scalafix migrations"

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -156,7 +156,7 @@ object SbtAlg {
               rule <- migration.rewriteRules
               cmd <- Nel.of(scalafix, testScalafix)
             } yield s"$cmd $rule"
-            _ <- exec(sbtCmd("++2.12.10!" :: scalafixEnable :: scalafixCmds.toList), repoDir)
+            _ <- exec(sbtCmd(scalafixEnable :: scalafixCmds.toList), repoDir)
           } yield ()
         }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -125,7 +125,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "sbt",
           "-batch",
           "-no-colors",
-          ";++2.12.10!;scalafixEnable;scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5;test:scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
+          ";scalafixEnable;scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5;test:scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
         List("rm", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         List("rm", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt")


### PR DESCRIPTION
Reverts fthomas/scala-steward#985. That PR was meant as a temporary workaround and I hope this isn't necessary anymore since there have been a few new Scalafix and Scalameta versions since then.
