### PR TITLE
Move StewardPlugin in new plugin subproject

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -67,7 +67,7 @@ package object sbt {
     // I don't consider reading a resource as side-effect,
     // so it is OK to call `unsafeRunSync` here.
     Resource
-      .fromAutoCloseable(IO(Source.fromResource(name)))
+      .fromAutoCloseable(IO(Source.fromResource(s"org/scalasteward/plugin/$name")))
       .use(src => IO(FileData(name, src.mkString)))
       .unsafeRunSync()
   }

--- a/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
+++ b/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core
+package org.scalasteward.plugin
 
 import sbt.Keys._
 import sbt._
 
 object StewardPlugin extends AutoPlugin {
-
   override def trigger: PluginTrigger = allRequirements
 
   object autoImport {


### PR DESCRIPTION
With this change StewardPlugin.scala is compiled as part of the sbt
build and IDEs recognize this file now as proper source file.