### PR TITLE
Do not grow line buffer in slurp unbounded

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/process.scala
@@ -20,7 +20,7 @@ import cats.effect._
 import cats.implicits._
 import fs2.Stream
 import java.io.{File, IOException, InputStream}
-import org.scalasteward.core.util.Nel
+import org.scalasteward.core.util._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
@@ -38,7 +38,7 @@ object process {
       F.delay(new ListBuffer[String]).flatMap { buffer =>
         val readOut = {
           val out = readInputStream[F](process.getInputStream, blocker)
-          out.evalMap(line => F.delay(buffer.append(line)) >> log(line)).compile.drain
+          out.evalMap(line => F.delay(appendBounded(buffer, line, 4096)) >> log(line)).compile.drain
         }
 
         val result = readOut >> F.delay(process.waitFor()) >>= { exitValue =>

--- a/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/package.scala
@@ -35,6 +35,12 @@ package object util {
 
   type BracketThrowable[F[_]] = Bracket[F, Throwable]
 
+  /** Appends `elem` to `buffer` such that its size does not exceed `maxSize`. */
+  def appendBounded[A](buffer: ListBuffer[A], elem: A, maxSize: Int): Unit = {
+    if (buffer.size >= maxSize) buffer.remove(0, maxSize / 2)
+    buffer.append(elem)
+  }
+
   /** Binds the elements of `gfb` until the first `F[Boolean]` that
     * evaluates to `true`.
     *

--- a/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/util/utilTest.scala
@@ -6,8 +6,32 @@ import eu.timepit.refined.types.numeric.PosInt
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import scala.collection.mutable.ListBuffer
 
 class utilTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks {
+  test("appendBounded") {
+    val lb = new ListBuffer[Int]
+    lb.append(1, 2, 3)
+
+    appendBounded(lb, 4, 4)
+    lb.toList shouldBe List(1, 2, 3, 4)
+
+    appendBounded(lb, 5, 4)
+    lb.toList shouldBe List(3, 4, 5)
+
+    appendBounded(lb, 6, 4)
+    lb.toList shouldBe List(3, 4, 5, 6)
+
+    appendBounded(lb, 7, 6)
+    lb.toList shouldBe List(3, 4, 5, 6, 7)
+
+    appendBounded(lb, 8, 6)
+    lb.toList shouldBe List(3, 4, 5, 6, 7, 8)
+
+    appendBounded(lb, 9, 6)
+    lb.toList shouldBe List(6, 7, 8, 9)
+  }
+
   test("bindUntilTrue: empty list") {
     bindUntilTrue(List.empty[Option[Boolean]]) shouldBe Some(false)
   }


### PR DESCRIPTION
If a program created by `process.slurp` outputs a lot of lines, the
internal line buffer can grow until there is no more available heap
space and an OOME occurs. I've observed this with a Scalafix migration
that printed a lot of stack traces.

To prevent OOMEs we put an upper bound on the number of lines we're
storing by using the new `appendBounded`.