### PR TITLE
Do not use RepoCacheRepository in SbtAlg

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -17,7 +17,8 @@
 package org.scalasteward.core.sbt
 
 import cats.implicits._
-import io.circe.parser.decode
+import io.circe.Decoder
+import io.circe.parser._
 import org.scalasteward.core.data.{Dependency, RawUpdate, Update}
 import org.scalasteward.core.sbt.data.SbtVersion
 
@@ -35,6 +36,12 @@ object parser {
   /** Parses the output of our own `stewardDependencies` task. */
   def parseDependencies(lines: List[String]): List[Dependency] =
     lines.flatMap(line => decode[Dependency](removeSbtNoise(line)).toList)
+
+  def parseDependenciesAndUpdates(lines: List[String]): (List[Dependency], List[RawUpdate]) =
+    lines
+      .flatMap(line => parse(removeSbtNoise(line)).toList)
+      .flatMap(json => Decoder[Dependency].either(Decoder[RawUpdate]).decodeJson(json).toList)
+      .separate
 
   private def removeSbtNoise(s: String): String =
     s.replace("[info]", "").trim

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -38,10 +38,11 @@ object parser {
     lines.flatMap(line => decode[Dependency](removeSbtNoise(line)).toList)
 
   def parseDependenciesAndUpdates(lines: List[String]): (List[Dependency], List[RawUpdate]) =
-    lines
-      .flatMap(line => parse(removeSbtNoise(line)).toList)
-      .flatMap(json => Decoder[Dependency].either(Decoder[RawUpdate]).decodeJson(json).toList)
-      .separate
+    lines.flatMap { line =>
+      parse(removeSbtNoise(line)).flatMap { json =>
+        Decoder[Dependency].either(Decoder[RawUpdate]).decodeJson(json)
+      }.toList
+    }.separate
 
   private def removeSbtNoise(s: String): String =
     s.replace("[info]", "").trim

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -58,10 +58,9 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
               "sbt",
               "-batch",
               "-no-colors",
-              s";$stewardUpdates;$reloadPlugins;$stewardUpdates"
+              s";$stewardDependencies;$stewardUpdates;$reloadPlugins;$stewardDependencies;$stewardUpdates"
             ),
-            List("rm", s"$repoDir/project/tmp-sbt-dep.sbt"),
-            List("read", s"${config.workspace}/repos_v6.json")
+            List("rm", s"$repoDir/project/tmp-sbt-dep.sbt")
           )
         )
     }
@@ -90,11 +89,10 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "sbt",
           "-batch",
           "-no-colors",
-          s";$stewardUpdates;$reloadPlugins;$stewardUpdates"
+          s";$stewardDependencies;$stewardUpdates;$reloadPlugins;$stewardDependencies;$stewardUpdates"
         ),
         List("restore", (repoDir / ".sbtopts").toString),
-        List("restore", (repoDir / ".jvmopts").toString),
-        List("read", s"${config.workspace}/repos_v6.json")
+        List("restore", (repoDir / ".jvmopts").toString)
       )
     )
   }


### PR DESCRIPTION
This is another change inspired by #851 that removes
`RepoCacheRepository` from `SbtAlg`. In `getUpdatesForRepo` we also
need the dependencies of the repo to find updates that change the
groupId. Prior to this change, `RepoCacheRepository` was used to get the
dependencies. The disadvantage of this approach was, that it required a
fresh cache but the cache is only populated and fresh if
`--prune-repos=true`.

We now query sbt for dependencies and updates at the same time so there
is no more need for the `RepoCacheRepository` and updates with a new
groupId are now also reported if `--prune-repos=false`.