### PR TITLE
Inline SbtAlg.getOriginalDependencies

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -31,6 +31,29 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
     )
   }
 
+  test("getDependencies") {
+    val repo = Repo("typelevel", "cats")
+    val repoDir = config.workspace / repo.show
+    val state = sbtAlg.getDependencies(repo).runS(MockState.empty).unsafeRunSync()
+    state shouldBe MockState.empty.copy(
+      commands = Vector(
+        List(
+          "TEST_VAR=GREAT",
+          "ANOTHER_TEST_VAR=ALSO_GREAT",
+          repoDir.toString,
+          "firejail",
+          s"--whitelist=$repoDir",
+          "sbt",
+          "-batch",
+          "-no-colors",
+          s";$stewardDependencies;$reloadPlugins;$stewardDependencies"
+        ),
+        List("read", s"$repoDir/project/build.properties"),
+        List("read", s"$repoDir/.scalafmt.conf")
+      )
+    )
+  }
+
   test("getUpdatesForRepo") {
     val repo = Repo("fthomas", "refined")
     val repoDir = config.workspace / "fthomas/refined"

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -34,7 +34,12 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
   test("getDependencies") {
     val repo = Repo("typelevel", "cats")
     val repoDir = config.workspace / repo.show
-    val state = sbtAlg.getDependencies(repo).runS(MockState.empty).unsafeRunSync()
+    val files = Map(
+      repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
+      repoDir / ".scalafmt.conf" -> "version=2.0.0"
+    )
+    val state =
+      sbtAlg.getDependencies(repo).runS(MockState.empty.copy(files = files)).unsafeRunSync()
     state shouldBe MockState.empty.copy(
       commands = Vector(
         List(
@@ -50,7 +55,8 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
         ),
         List("read", s"$repoDir/project/build.properties"),
         List("read", s"$repoDir/.scalafmt.conf")
-      )
+      ),
+      files = files
     )
   }
 


### PR DESCRIPTION
This method was called in two places before but now it is only used
`getDependencies` so we can inline it there.