### PR TITLE
Do not select versions with a hyphen

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -53,13 +53,19 @@ final case class Version(value: String) {
         case (commonPrefix, vs) =>
           // Do not select pre-release versions of a different series.
           val vs1 = vs.filterNot(_.isPreRelease && cutoff =!= commonPrefix.length)
-          // Do not select dynamic versions if this is not a dynamic version.
-          // E.g. 1.2.0 -> 1.2.0+17-7ef98061.
-          val vs2 = vs1.filterNot(_.containsPlus && !containsPlus)
+          // Do not select versions with a '+' or '-' if this is version does not
+          // contain such separator.
+          // E.g. 1.2.0 -> 1.2.0+17-7ef98061 or 3.1.0 -> 3.1.0-2156c0e.
+          val vs2 = vs1.filterNot { v =>
+            (v.containsHyphen && !containsHyphen) || (v.containsPlus && !containsPlus)
+          }
           vs2.sorted
       }
       .lastOption
   }
+
+  private def containsHyphen: Boolean =
+    components.contains(Version.Component.Separator('-'))
 
   private def containsPlus: Boolean =
     components.contains(Version.Component.Separator('+'))

--- a/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/VersionTest.scala
@@ -137,7 +137,10 @@ class VersionTest extends AnyFunSuite with Discipline with Matchers with ScalaCh
       ("1.2.0", List("1.2.0+17-7ef98061"), None),
       ("1.2.0+17-7ef98061", List("1.3.0"), Some("1.3.0")),
       ("2.4.4", List("3.0.0-preview"), None),
-      ("2.3.2", List("2.3.3-b02"), None)
+      ("2.3.2", List("2.3.3-b02"), None),
+      ("3.1.0", List("3.1.0-2156c0e"), None),
+      ("3.1.0-2156c0e", List("3.2.0"), Some("3.2.0")),
+      ("1.6.7", List("1.6.7-2-c28002d"), None)
     )
 
     val rnd = new Random()


### PR DESCRIPTION
... if the current version does not contain one. This is similar to
https://github.com/fthomas/scala-steward/pull/1134.

`selectNext` currently allows these updates:
```
org.specs2:specs2-core:test : 4.5.1 -> 4.5.1-924020314
io.monix:monix-catnap : 3.1.0 -> 3.1.0-2156c0e
io.monix:monix : 3.0.0 -> 3.0.0-ec266e1
com.lihaoyi:ammonite : 1.6.7 -> 1.6.7-2-c28002d
com.lihaoyi:ammonite-ops : 1.6.6 -> 1.6.6-10-5fa74ab
com.lightbend.paradox:sbt-paradox-project-info : 1.1.3 -> 9-6845d95d
commons-httpclient:commons-httpclient : 2.0.2 -> 2.0-dev.20020705.071400
org.specs2:specs2-core : 4.2.0 -> 4.2.0-add90d25e-20180428143534
```
All of these look like a transition from a release version to a dynamic
version except that these version numbers don't use `+` but a `-` to
separate the dynamic part from the release version.