### PR TITLE
Set TTL of Coursier's FileCache to 1 hour

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -25,6 +25,7 @@ import coursier.{Info, Module, ModuleName, Organization}
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.data.{Dependency, Version}
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 trait CoursierAlg[F[_]] {
   def getArtifactUrl(dependency: Dependency): F[Option[String]]
@@ -43,7 +44,7 @@ object CoursierAlg {
       override def shift: F[Unit] = F.unit
       override def evalOn[A](ec: ExecutionContext)(fa: F[A]): F[A] = fa
     }
-    val cache = coursier.cache.FileCache[F]()
+    val cache = coursier.cache.FileCache[F]().withTtl(1.hour)
     val sbtPluginReleases =
       ivy"https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/[defaultPattern]"
     val fetch = coursier.Fetch[F](cache).addRepositories(sbtPluginReleases)


### PR DESCRIPTION
The default TTL of Coursier's FileCache is 24 hours. Now that we're
using Coursier to find new versions, 24 hours is too long since the
runtime of my public instance is about 5-6 hours. If the TTL is greater
than that, Scala Steward could prune repos that have updates available.

This PR sets the TTL to 1 hour. This is fine for my public instance and
I assume that nobody runs Scala Steward more frequent than once per hour.