### PR TITLE
Don't use Update.Group.artifactId for sorting updates

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Update.scala
@@ -96,7 +96,7 @@ object Update {
           head
       }
       .toList
-      .sortBy(update => (update.groupId, update.artifactId))
+      .sortBy(update => (update.groupId, update.artifactIds))
 
   val commonSuffixes: List[String] =
     List("config", "contrib", "core", "extra", "server")


### PR DESCRIPTION
Update.Group.artifactId tries to find the "main" artifactId and should
only be used if really necessary. This is definitely not the case for
sorting updates.