### PR TITLE
Rename Update.artifactId to mainArtifactId

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -155,13 +155,15 @@ object UpdateHeuristic {
 
   val relaxed = UpdateHeuristic(
     name = "relaxed",
-    replaceVersion = defaultReplaceVersion(update => util.string.extractWords(update.artifactId))
+    replaceVersion = defaultReplaceVersion { update =>
+      util.string.extractWords(update.mainArtifactId)
+    }
   )
 
   val sliding = UpdateHeuristic(
     name = "sliding",
     replaceVersion =
-      defaultReplaceVersion(_.artifactId.sliding(5).take(5).filterNot(_ === "scala").toList)
+      defaultReplaceVersion(_.mainArtifactId.sliding(5).take(5).filterNot(_ === "scala").toList)
   )
 
   val completeGroupId = UpdateHeuristic(

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -139,10 +139,10 @@ final class NurtureAlg[F[_]](
       filteredDependencies = dependenciesInUpdates(dependencies, data.update)
       artifactIdToUrl <- coursierAlg.getArtifactIdUrlMapping(filteredDependencies)
       branchCompareUrl <- artifactIdToUrl
-        .get(data.update.artifactId)
+        .get(data.update.mainArtifactId)
         .flatTraverse(vcsExtraAlg.getBranchCompareUrl(_, data.update))
       releaseNoteUrl <- artifactIdToUrl
-        .get(data.update.artifactId)
+        .get(data.update.mainArtifactId)
         .flatTraverse(vcsExtraAlg.getReleaseNoteUrl(_, data.update))
       branchName = vcs.createBranch(config.vcsType, data.fork, data.update)
       migrations <- migrationAlg.findMigrations(data.update)

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -6,13 +6,22 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class UpdateTest extends AnyFunSuite with Matchers {
-  test("Group.artifactId") {
+  test("Group.mainArtifactId") {
     Group(
       GroupId("org.http4s"),
       Nel.of("http4s-blaze-server", "http4s-circe", "http4s-core", "http4s-dsl"),
       "0.18.16",
       Nel.of("0.18.18")
-    ).artifactId shouldBe "http4s-core"
+    ).mainArtifactId shouldBe "http4s-core"
+  }
+
+  test("Group.mainArtifactId: artifactIds contains a common suffix") {
+    Group(
+      GroupId("com.softwaremill.sttp"),
+      Nel.of("circe", "core", "monix"),
+      "1.3.2",
+      Nel.of("1.3.3")
+    ).mainArtifactId shouldBe "circe"
   }
 
   test("group: 1 update") {


### PR DESCRIPTION
... to better distinguish it from Update.Single.artifactId.