### PR TITLE
Check updates for all crossScalaVersions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -59,14 +59,14 @@ object Context {
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
-        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "6"))
+        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "7"))
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
       implicit val vcsExtraAlg: VCSExtraAlg[F] = VCSExtraAlg.create[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
-        new PullRequestRepository[F](new JsonKeyValueStore("prs", "3"))
+        new PullRequestRepository[F](new JsonKeyValueStore("prs", "4"))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
@@ -77,7 +77,7 @@ object Context {
       implicit val migrationAlg: MigrationAlg[F] = MigrationAlg.create[F]
       implicit val editAlg: EditAlg[F] = new EditAlg[F]
       implicit val updateRepository: UpdateRepository[F] =
-        new UpdateRepository[F](new JsonKeyValueStore("updates", "3"))
+        new UpdateRepository[F](new JsonKeyValueStore("updates", "4"))
       implicit val nurtureAlg: NurtureAlg[F] = new NurtureAlg[F]
       implicit val pruningAlg: PruningAlg[F] = new PruningAlg[F]
       new StewardAlg[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -38,7 +38,7 @@ trait CoursierAlg[F[_]] {
       implicit F: Applicative[F]
   ): F[Map[String, String]] =
     dependencies
-      .traverseFilter(dep => getArtifactUrl(dep).map(_.map(dep.artifactId -> _)))
+      .traverseFilter(dep => getArtifactUrl(dep).map(_.map(dep.artifactId.name -> _)))
       .map(_.toMap)
 }
 
@@ -98,7 +98,7 @@ object CoursierAlg {
   private def toCoursierModule(dependency: Dependency): Module =
     Module(
       Organization(dependency.groupId.value),
-      ModuleName(dependency.artifactIdCross),
+      ModuleName(dependency.artifactId.firstCrossName),
       dependency.attributes
     )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/data/ArtifactId.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/ArtifactId.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.data
+
+import cats.Order
+import cats.implicits._
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import monocle.Lens
+
+/** A name of an artifact as used in build files and with potential
+  * cross version suffixes.
+  *
+  * @example {{{
+  * scala> ArtifactId(
+  *      |   name = "discipline-core",
+  *      |   crossNames = List(
+  *      |     "discipline-core_2.12",
+  *      |     "discipline-core_2.13",
+  *      |     "discipline-core_sjs0.6_2.12",
+  *      |     "discipline-core_sjs0.6_2.13"
+  *      | )).getClass.getSimpleName
+  * res1: String = ArtifactId
+  * }}}
+  */
+final case class ArtifactId(name: String, crossNames: List[String] = Nil) {
+  def firstCrossName: String =
+    crossNames.headOption.getOrElse(name)
+
+  def show: String =
+    if (crossNames.isEmpty) name else (name :: crossNames).mkString("(", ", ", ")")
+}
+
+object ArtifactId {
+  def apply(name: String, crossName: String): ArtifactId =
+    ArtifactId(name, List(crossName))
+
+  val crossName: Lens[ArtifactId, List[String]] =
+    Lens[ArtifactId, List[String]](_.crossNames)(crossNames => _.copy(crossNames = crossNames))
+
+  def combineCrossNames[A](lens: Lens[A, ArtifactId])(as: List[A]): List[A] = {
+    val l = crossName.compose(lens)
+    as.groupBy(l.set(Nil))
+      .map { case (a, grouped) => l.set(grouped.flatMap(l.get).distinct.sorted)(a) }
+      .toList
+  }
+
+  implicit val artifactIdCodec: Codec[ArtifactId] =
+    deriveCodec
+
+  implicit val artifactIdOrder: Order[ArtifactId] =
+    Order.by((a: ArtifactId) => (a.name, a.crossNames))
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -16,15 +16,15 @@
 
 package org.scalasteward.core.data
 
+import io.circe.Codec
 import io.circe.generic.semiauto._
-import io.circe.{Decoder, Encoder}
+import monocle.Lens
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.util.Nel
 
 final case class Dependency(
     groupId: GroupId,
-    artifactId: String,
-    artifactIdCross: String,
+    artifactId: ArtifactId,
     version: String,
     sbtVersion: Option[SbtVersion] = None,
     scalaVersion: Option[ScalaVersion] = None,
@@ -39,9 +39,9 @@ final case class Dependency(
 }
 
 object Dependency {
-  implicit val dependencyDecoder: Decoder[Dependency] =
-    deriveDecoder
+  val artifactId: Lens[Dependency, ArtifactId] =
+    Lens[Dependency, ArtifactId](_.artifactId)(artifactId => _.copy(artifactId = artifactId))
 
-  implicit val dependencyEncoder: Encoder[Dependency] =
-    deriveEncoder
+  implicit val dependencyCodec: Codec[Dependency] =
+    deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/RawUpdate.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/RawUpdate.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.data
 
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import monocle.Lens
 import org.scalasteward.core.util.Nel
 
 final case class RawUpdate(
@@ -29,6 +30,9 @@ final case class RawUpdate(
 }
 
 object RawUpdate {
+  val dependency: Lens[RawUpdate, Dependency] =
+    Lens[RawUpdate, Dependency](_.dependency)(dependency => _.copy(dependency = dependency))
+
   implicit val rawUpdateDecoder: Decoder[RawUpdate] =
     deriveDecoder
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -19,8 +19,7 @@ package org.scalasteward.core.data
 import cats.Order
 import cats.implicits._
 import eu.timepit.refined.types.numeric.NonNegInt
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.{Decoder, Encoder}
+import io.circe.{Codec, Decoder, Encoder}
 import scala.annotation.tailrec
 
 final case class Version(value: String) {
@@ -98,11 +97,8 @@ object Version {
       c1.compare(c2)
     }
 
-  implicit val versionDecoder: Decoder[Version] =
-    deriveDecoder
-
-  implicit val versionEncoder: Encoder[Version] =
-    deriveEncoder
+  implicit val versionCodec: Codec[Version] =
+    Codec.from(Decoder[String].map(Version.apply), Encoder[String].contramap(_.value))
 
   private def padToSameLength[A](l1: List[A], l2: List[A], elem: A): (List[A], List[A]) = {
     val maxLength = math.max(l1.length, l2.length)

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/UpdateHeuristic.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.edit
 
 import cats.Foldable
 import cats.implicits._
-import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
+import org.scalasteward.core.data.{GroupId, Update}
 import org.scalasteward.core.util
 import org.scalasteward.core.util.Nel
 import scala.util.matching.Regex
@@ -188,8 +188,8 @@ object UpdateHeuristic {
   val specific = UpdateHeuristic(
     name = "specific",
     replaceVersion = defaultReplaceVersion {
-      case Update
-            .Single(GroupId("org.scalameta"), ArtifactId("scalafmt-core", _), _, _, _, _) =>
+      case s: Update.Single
+          if s.groupId === GroupId("org.scalameta") && s.artifactId.name === "scalafmt-core" =>
         List("version")
       case _ => List.empty
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import better.files.File
 import cats.implicits._
-import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
+import org.scalasteward.core.data.{GroupId, Update}
 
 package object io {
   def isSourceFile(file: File): Boolean = {
@@ -33,16 +33,11 @@ package object io {
 
   def isFileSpecificTo(update: Update)(f: File): Boolean =
     update match {
-      case Update.Single(GroupId("org.scala-sbt"), ArtifactId("sbt", _), _, _, _, _) =>
+      case s: Update.Single
+          if s.groupId === GroupId("org.scala-sbt") && s.artifactId.name === "sbt" =>
         f.name === "build.properties"
-      case Update.Single(
-          GroupId("org.scalameta"),
-          ArtifactId("scalafmt-core", _),
-          _,
-          _,
-          _,
-          _
-          ) =>
+      case s: Update.Single
+          if s.groupId === GroupId("org.scalameta") && s.artifactId.name === "scalafmt-core" =>
         f.name === ".scalafmt.conf"
       case _ => true
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import better.files.File
 import cats.implicits._
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 
 package object io {
   def isSourceFile(file: File): Boolean = {
@@ -33,9 +33,16 @@ package object io {
 
   def isFileSpecificTo(update: Update)(f: File): Boolean =
     update match {
-      case Update.Single(GroupId("org.scala-sbt"), "sbt", _, _, _, _) =>
+      case Update.Single(GroupId("org.scala-sbt"), ArtifactId("sbt", _), _, _, _, _) =>
         f.name === "build.properties"
-      case Update.Single(GroupId("org.scalameta"), "scalafmt-core", _, _, _, _) =>
+      case Update.Single(
+          GroupId("org.scalameta"),
+          ArtifactId("scalafmt-core", _),
+          _,
+          _,
+          _,
+          _
+          ) =>
         f.name === ".scalafmt.conf"
       case _ => true
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -74,7 +74,7 @@ final class NurtureAlg[F[_]](
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
       repoConfig <- repoConfigAlg.readRepoConfigOrDefault(repo)
-      updates <- sbtAlg.getUpdatesForRepo(repo)
+      updates <- sbtAlg.getUpdates(repo)
       filtered <- filterAlg.localFilterMany(repoConfig, updates)
       grouped = Update.group(filtered)
       sorted <- NurtureAlg.sortUpdatesByMigration(grouped)
@@ -171,10 +171,13 @@ final class NurtureAlg[F[_]](
   ): List[Dependency] =
     update match {
       case Update.Single(groupId, artifactId, _, _, _, _) =>
-        dependencies.filter(dep => dep.groupId === groupId && dep.artifactId === artifactId)
+        dependencies.filter(dep =>
+          dep.groupId === groupId && dep.artifactId.name === artifactId.name
+        )
       case Update.Group(groupId, artifactIds, _, _) =>
-        val artifactIdSet = artifactIds.toList.toSet
-        dependencies.filter(dep => dep.groupId === groupId && artifactIdSet.contains(dep.artifactId)
+        val artifactIdSet = artifactIds.toList.map(_.name).toSet
+        dependencies.filter(dep =>
+          dep.groupId === groupId && artifactIdSet.contains(dep.artifactId.name)
         )
     }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -58,7 +58,7 @@ object RepoConfigAlg {
   def configToIgnoreFurtherUpdates(update: Update): String =
     update match {
       case s: Update.Single =>
-        s"""updates.ignore = [ { groupId = "${s.groupId}", artifactId = "${s.artifactId}" } ]"""
+        s"""updates.ignore = [ { groupId = "${s.groupId}", artifactId = "${s.artifactId.name}" } ]"""
       case g: Update.Group =>
         s"""updates.ignore = [ { groupId = "${g.groupId}" } ]"""
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatePattern.scala
@@ -35,7 +35,7 @@ object UpdatePattern {
 
   def findMatch(patterns: List[UpdatePattern], update: Update.Single): MatchResult = {
     val byGroupId = patterns.filter(_.groupId === update.groupId)
-    val byArtifactId = byGroupId.filter(_.artifactId.forall(_ === update.artifactId))
+    val byArtifactId = byGroupId.filter(_.artifactId.forall(_ === update.artifactId.name))
     val byVersion = byArtifactId.filter(_.version.forall(update.nextVersion.startsWith))
     MatchResult(byArtifactId, byVersion)
   }

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
@@ -19,6 +19,8 @@ package org.scalasteward.core.sbt
 object command {
   val stewardUpdates = "show stewardUpdates"
   val stewardDependencies = "show stewardDependencies"
+  val crossStewardUpdates = s"+ $stewardUpdates"
+  val crossStewardDependencies = s"+ $stewardDependencies"
   val reloadPlugins = "reload plugins"
   val scalafix = "scalafix"
   val testScalafix = "test:scalafix"

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/package.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core
 
 import cats.effect.{IO, Resource}
 import cats.implicits._
-import org.scalasteward.core.data.{Dependency, GroupId, Version}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 import org.scalasteward.core.io.FileData
 import org.scalasteward.core.sbt.data.SbtVersion
 import scala.io.Source
@@ -29,7 +29,7 @@ package object sbt {
 
   def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
     if (sbtVersion.toVersion >= Version("1.0.0"))
-      Some(Dependency(GroupId("org.scala-sbt"), "sbt", "sbt", sbtVersion.value))
+      Some(Dependency(GroupId("org.scala-sbt"), ArtifactId("sbt"), sbtVersion.value))
     else
       None
 

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafix/package.scala
@@ -73,7 +73,9 @@ package object scalafix {
   def findMigrations(givenMigrations: List[Migration], update: Update): List[Migration] =
     givenMigrations.filter { migration =>
       update.groupId === migration.groupId &&
-      migration.artifactIds.exists(re => update.artifactIds.exists(re.r.findFirstIn(_).isDefined)) &&
+      migration.artifactIds.exists(re =>
+        update.artifactIds.exists(artifactId => re.r.findFirstIn(artifactId.name).isDefined)
+      ) &&
       Version(update.currentVersion) < migration.newVersion &&
       Version(update.newerVersions.head) >= migration.newVersion
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -17,14 +17,13 @@
 package org.scalasteward.core
 
 import cats.implicits._
-import org.scalasteward.core.data.{Dependency, GroupId, Version}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 
 package object scalafmt {
   def scalafmtDependency(scalaBinaryVersion: String)(scalafmtVersion: Version): Dependency =
     Dependency(
       GroupId(if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson"),
-      "scalafmt-core",
-      s"scalafmt-core_${scalaBinaryVersion}",
+      ArtifactId("scalafmt-core", s"scalafmt-core_$scalaBinaryVersion"),
       scalafmtVersion.value
     )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.update
 import cats.implicits._
 import cats.{Monad, TraverseFilter}
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.data.{GroupId, Update, Version}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update, Version}
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.FilterAlg._
 import org.scalasteward.core.util.Nel
@@ -75,7 +75,7 @@ object FilterAlg {
     globalFilter(update).flatMap(repoConfig.updates.keep)
 
   def isIgnoredGlobally(update: Update.Single): FilterResult = {
-    val keep = ((update.groupId.value, update.artifactId) match {
+    val keep = ((update.groupId.value, update.artifactId.name) match {
       case ("org.scala-lang", "scala-compiler") => false
       case ("org.scala-lang", "scala-library")  => false
       case ("org.scala-lang", "scala-reflect")  => false
@@ -108,8 +108,8 @@ object FilterAlg {
       .map(versions => update.copy(newerVersions = versions))
       .fold[FilterResult](Left(BadVersions(update)))(Right.apply)
 
-  private def badVersions(groupId: GroupId, artifactId: String): String => Boolean =
-    (groupId.value, artifactId) match {
+  private def badVersions(groupId: GroupId, artifactId: ArtifactId): String => Boolean =
+    (groupId.value, artifactId.name) match {
       case ("commons-collections", "commons-collections") =>
         List(
           "20030418.083655",

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -20,7 +20,7 @@ import cats.Monad
 import cats.implicits._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.data.{Dependency, Update}
+import org.scalasteward.core.data.{ArtifactId, Dependency, Update}
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
 import org.scalasteward.core.update.data.UpdateState
@@ -43,14 +43,16 @@ final class PruningAlg[F[_]](
     val findUpdates = Stream
       .evals(repoCacheRepository.getDependencies(repos))
       .filter(dep => FilterAlg.isIgnoredGlobally(dep.toUpdate).isRight)
-      .evalMap(updateAlg.findUpdate)
+      .evalMap(dependency => updateAlg.findUpdate(dependency.copy(configurations = None)))
       .unNone
       .compile
       .toList
 
-    updateRepository.deleteAll >> findUpdates.flatTap { updates =>
-      updateRepository.saveMany(updates)
-    }
+    updateRepository.deleteAll >> findUpdates
+      .flatTap { updates =>
+        updateRepository.saveMany(updates)
+      }
+      .map(ArtifactId.combineCrossNames(Update.Single.artifactId))
   }
 
   def filterByApplicableUpdates(repos: List[Repo], updates: List[Update.Single]): F[List[Repo]] =
@@ -76,7 +78,8 @@ final class PruningAlg[F[_]](
   def findAllUpdateStates(repo: Repo, updates: List[Update.Single]): F[List[UpdateState]] =
     repoCacheRepository.findCache(repo).flatMap {
       case Some(repoCache) =>
-        val dependencies = repoCache.dependencies
+        val dependencies =
+          ArtifactId.combineCrossNames(Dependency.artifactId)(repoCache.dependencies)
         dependencies.traverse { dependency =>
           findUpdateState(repo, repoCache, dependency, updates)
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -49,9 +49,7 @@ final class PruningAlg[F[_]](
       .toList
 
     updateRepository.deleteAll >> findUpdates
-      .flatTap { updates =>
-        updateRepository.saveMany(updates)
-      }
+      .flatTap(updateRepository.saveMany)
       .map(ArtifactId.combineCrossNames(Update.Single.artifactId))
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/show.scala
@@ -24,7 +24,7 @@ import org.scalasteward.core.util.Nel
 
 object show {
   def oneLiner(update: Update): String =
-    commaSeparated(update.groupId, update.artifactIds)
+    commaSeparated(update.groupId, update.artifactIds.map(_.name))
 
   private def commaSeparated(groupId: GroupId, artifactIds: Nel[String]): String = {
     val artifacts = showArtifacts(groupId, artifactIds).toList

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -50,7 +50,7 @@ object NewPullRequestData {
     val details = ignoreFutureUpdates(update) :: appliedMigrations.toList
     val labels = Nel.fromList(semVerLabel(update).toList ++ migrationLabel.toList)
 
-    s"""|Updates ${artifacts} ${fromTo(update, branchCompareUrl)}.
+    s"""|Updates $artifacts ${fromTo(update, branchCompareUrl)}.
         |${releaseNote(releaseNoteUrl).getOrElse("")}
         |
         |I'll automatically update this PR to resolve conflicts as long as you don't change it yourself.
@@ -80,11 +80,12 @@ object NewPullRequestData {
 
   def artifactsWithOptionalUrl(update: Update, artifactIdToUrl: Map[String, String]): String =
     update match {
-      case s: Update.Single => artifactWithOptionalUrl(s.groupId, s.artifactId, artifactIdToUrl)
+      case s: Update.Single =>
+        artifactWithOptionalUrl(s.groupId, s.artifactId.name, artifactIdToUrl)
       case g: Update.Group =>
         g.artifactIds
           .map(artifactId =>
-            s"* ${artifactWithOptionalUrl(g.groupId, artifactId, artifactIdToUrl)}\n"
+            s"* ${artifactWithOptionalUrl(g.groupId, artifactId.name, artifactIdToUrl)}\n"
           )
           .mkString_("\n", "", "\n")
     }
@@ -95,8 +96,8 @@ object NewPullRequestData {
       artifactId2Url: Map[String, String]
   ): String =
     artifactId2Url.get(artifactId) match {
-      case Some(url) => s"[${groupId}:${artifactId}](${url})"
-      case None      => s"${groupId}:${artifactId}"
+      case Some(url) => s"[$groupId:$artifactId]($url)"
+      case None      => s"$groupId:$artifactId"
     }
 
   def ignoreFutureUpdates(update: Update): Details =

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.coursier
 
-import org.scalasteward.core.data.{Dependency, GroupId}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
@@ -9,7 +9,8 @@ import org.scalatest.matchers.should.Matchers
 
 class CoursierAlgTest extends AnyFunSuite with Matchers {
   test("getArtifactUrl: library") {
-    val dep = Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0")
+    val dep =
+      Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     val (state, result) = coursierAlg
       .getArtifactUrl(dep)
       .run(MockState.empty)
@@ -21,8 +22,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
   test("getArtifactUrl: defaults to homepage") {
     val dep = Dependency(
       GroupId("com.typesafe.play"),
-      "play-ws-standalone-json",
-      "play-ws-standalone-json_2.12",
+      ArtifactId("play-ws-standalone-json", "play-ws-standalone-json_2.12"),
       "2.1.0-M7"
     )
     val (state, result) = coursierAlg
@@ -36,8 +36,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
   test("getArtifactUrl: sbt plugin on Maven Central") {
     val dep = Dependency(
       GroupId("org.xerial.sbt"),
-      "sbt-sonatype",
-      "sbt-sonatype",
+      ArtifactId("sbt-sonatype"),
       "3.8",
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
@@ -53,8 +52,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
   test("getArtifactUrl: sbt plugin on sbt-plugin-releases") {
     val dep = Dependency(
       GroupId("com.github.gseitz"),
-      "sbt-release",
-      "sbt-release",
+      ArtifactId("sbt-release"),
       "1.0.12",
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
@@ -65,8 +63,8 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
 
   test("getArtifactIdUrlMapping") {
     val dependencies = List(
-      Dependency(GroupId("org.typelevel"), "cats-core", "cats-core_2.12", "1.6.0"),
-      Dependency(GroupId("org.typelevel"), "cats-effect", "cats-effect_2.12", "1.0.0")
+      Dependency(GroupId("org.typelevel"), ArtifactId("cats-core", "cats-core_2.12"), "1.6.0"),
+      Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     )
     val (state, result) = coursierAlg
       .getArtifactIdUrlMapping(dependencies)

--- a/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/ExampleTest.scala
@@ -12,7 +12,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample1 = """val scalajsJqueryVersion = "0.9.3""""
       s"$goodExample1" in {
         val expectedResult = Some("""val scalajsJqueryVersion = "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample1)
           ._1 shouldBe expectedResult
       }
@@ -20,7 +20,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample2 = """val SCALAJSJQUERYVERSION = "0.9.3""""
       s"$goodExample2" in {
         val expectedResult = Some("""val SCALAJSJQUERYVERSION = "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample2)
           ._1 shouldBe expectedResult
       }
@@ -28,7 +28,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample3 = """val scalajsjquery = "0.9.3""""
       s"$goodExample3" in {
         val expectedResult = Some("""val scalajsjquery = "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample3)
           ._1 shouldBe expectedResult
       }
@@ -36,7 +36,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample4 = """addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")"""
       s"$goodExample4" in {
         val expectedResult = Some("""addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")""")
-        Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+        Single(GroupId("org.scala-js"), ArtifactId("sbt-scalajs"), "0.6.24", Nel.of("0.6.25"))
           .replaceVersionIn(goodExample4)
           ._1 shouldBe expectedResult
       }
@@ -44,7 +44,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample5 = """"be.doeraene" %% "scalajs-jquery"  % "0.9.3""""
       s"$goodExample5" in {
         val expectedResult = Some(""""be.doeraene" %% "scalajs-jquery"  % "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample5)
           ._1 shouldBe expectedResult
       }
@@ -52,7 +52,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       val goodExample6 = """val `scalajs-jquery-version` = "0.9.3""""
       s"$goodExample6" in {
         val expectedResult = Some("""val `scalajs-jquery-version` = "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(goodExample6)
           ._1 shouldBe expectedResult
       }
@@ -66,7 +66,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
           |  "0.9.3"""".stripMargin
       s"$badExample1" in {
         val expectedResult = None
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(badExample1)
           ._1 shouldBe expectedResult
       }
@@ -76,7 +76,7 @@ class ExampleTest extends AnyWordSpec with Matchers {
       s"$badExample2" in {
         val expectedResult =
           Some("""val scalajsJqueryVersion = "0.9.3" // val scalajsJqueryVersion = "0.9.4"""")
-        Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+        Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
           .replaceVersionIn(badExample2)
           ._1 shouldBe expectedResult
       }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/UpdateTest.scala
@@ -9,7 +9,12 @@ class UpdateTest extends AnyFunSuite with Matchers {
   test("Group.mainArtifactId") {
     Group(
       GroupId("org.http4s"),
-      Nel.of("http4s-blaze-server", "http4s-circe", "http4s-core", "http4s-dsl"),
+      Nel.of(
+        ArtifactId("http4s-blaze-server"),
+        ArtifactId("http4s-circe"),
+        ArtifactId("http4s-core"),
+        ArtifactId("http4s-dsl")
+      ),
       "0.18.16",
       Nel.of("0.18.18")
     ).mainArtifactId shouldBe "http4s-core"
@@ -18,24 +23,26 @@ class UpdateTest extends AnyFunSuite with Matchers {
   test("Group.mainArtifactId: artifactIds contains a common suffix") {
     Group(
       GroupId("com.softwaremill.sttp"),
-      Nel.of("circe", "core", "monix"),
+      Nel.of(ArtifactId("circe"), ArtifactId("core"), ArtifactId("monix")),
       "1.3.2",
       Nel.of("1.3.3")
     ).mainArtifactId shouldBe "circe"
   }
 
   test("group: 1 update") {
-    val updates = List(Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5")))
+    val updates =
+      List(Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.9.4", Nel.of("3.9.5")))
     Update.group(updates) shouldBe updates
   }
 
   test("group: 2 updates") {
-    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
-    val update1 = update0.copy(artifactId = "specs2-scalacheck")
+    val update0 =
+      Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.9.4", Nel.of("3.9.5"))
+    val update1 = update0.copy(artifactId = ArtifactId("specs2-scalacheck"))
     Update.group(List(update0, update1)) shouldBe List(
       Group(
         GroupId("org.specs2"),
-        Nel.of("specs2-core", "specs2-scalacheck"),
+        Nel.of(ArtifactId("specs2-core"), ArtifactId("specs2-scalacheck")),
         "3.9.4",
         Nel.of("3.9.5")
       )
@@ -43,21 +50,22 @@ class UpdateTest extends AnyFunSuite with Matchers {
   }
 
   test("group: 2 updates with different configurations") {
-    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 = Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(configurations = Some("test"))
     Update.group(List(update0, update1)) shouldBe List(
-      Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
+      Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.9.4", Nel.of("3.9.5"))
     )
   }
 
   test("group: 3 updates with different configurations") {
-    val update0 = Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"))
+    val update0 =
+      Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.9.4", Nel.of("3.9.5"))
     val update1 = update0.copy(configurations = Some("test"))
-    val update2 = update0.copy(artifactId = "specs2-scalacheck")
+    val update2 = update0.copy(artifactId = ArtifactId("specs2-scalacheck"))
     Update.group(List(update0, update1, update2)) shouldBe List(
       Group(
         GroupId("org.specs2"),
-        Nel.of("specs2-core", "specs2-scalacheck"),
+        Nel.of(ArtifactId("specs2-core"), ArtifactId("specs2-scalacheck")),
         "3.9.4",
         Nel.of("3.9.5")
       )
@@ -66,7 +74,13 @@ class UpdateTest extends AnyFunSuite with Matchers {
 
   test("Single.show") {
     val update =
-      Single(GroupId("org.specs2"), "specs2-core", "3.9.4", Nel.of("3.9.5"), Some("test"))
+      Single(
+        GroupId("org.specs2"),
+        ArtifactId("specs2-core"),
+        "3.9.4",
+        Nel.of("3.9.5"),
+        Some("test")
+      )
     update.show shouldBe "org.specs2:specs2-core:test : 3.9.4 -> 3.9.5"
   }
 
@@ -74,7 +88,7 @@ class UpdateTest extends AnyFunSuite with Matchers {
     val update =
       Group(
         GroupId("org.scala-sbt"),
-        Nel.of("sbt-launch", "scripted-plugin"),
+        Nel.of(ArtifactId("sbt-launch"), ArtifactId("scripted-plugin")),
         "1.2.1",
         Nel.of("1.2.4")
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit
 
 import better.files.File
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.mock.MockContext.editAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
@@ -12,7 +12,8 @@ import org.scalatest.matchers.should.Matchers
 class EditAlgTest extends AnyFunSuite with Matchers {
   test("applyUpdate") {
     val repo = Repo("fthomas", "scala-steward")
-    val update = Update.Single(GroupId("org.typelevel"), "cats-core", "1.2.0", Nel.of("1.3.0"))
+    val update =
+      Update.Single(GroupId("org.typelevel"), ArtifactId("cats-core"), "1.2.0", Nel.of("1.3.0"))
     val file1 = File.temp / "ws/fthomas/scala-steward/build.sbt"
     val file2 = File.temp / "ws/fthomas/scala-steward/project/Dependencies.scala"
 
@@ -41,7 +42,8 @@ class EditAlgTest extends AnyFunSuite with Matchers {
 
   test("applyUpdate with scalafmt update") {
     val repo = Repo("fthomas", "scala-steward")
-    val update = Update.Single(GroupId("org.scalameta"), "scalafmt-core", "2.0.0", Nel.of("2.1.0"))
+    val update =
+      Update.Single(GroupId("org.scalameta"), ArtifactId("scalafmt-core"), "2.0.0", Nel.of("2.1.0"))
     val scalafmtFile = File.temp / "ws/fthomas/scala-steward/.scalafmt.conf"
     val file1 = File.temp / "ws/fthomas/scala-steward/build.sbt"
 
@@ -96,7 +98,8 @@ class EditAlgTest extends AnyFunSuite with Matchers {
 
   test("apply update to ammonite file") {
     val repo = Repo("fthomas", "scala-steward")
-    val update = Update.Single(GroupId("org.typelevel"), "cats-core", "1.2.0", Nel.of("1.3.0"))
+    val update =
+      Update.Single(GroupId("org.typelevel"), ArtifactId("cats-core"), "1.2.0", Nel.of("1.3.0"))
     val file1 = File.temp / "ws/fthomas/scala-steward/script.sc"
     val file2 = File.temp / "ws/fthomas/scala-steward/build.sbt"
 
@@ -140,7 +143,8 @@ class EditAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("reproduce https://github.com/circe/circe-config/pull/40") {
-    val update = Update.Single(GroupId("com.typesafe"), "config", "1.3.3", Nel.of("1.3.4"))
+    val update =
+      Update.Single(GroupId("com.typesafe"), ArtifactId("config"), "1.3.3", Nel.of("1.3.4"))
     val original = Map(
       "build.sbt" -> """val config = "1.3.3"""",
       "project/plugins.sbt" -> """addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.3")"""
@@ -153,13 +157,14 @@ class EditAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("file restriction when sbt update") {
-    val update = Update.Single(GroupId("org.scala-sbt"), "sbt", "1.1.2", Nel.of("1.2.8"))
+    val update =
+      Update.Single(GroupId("org.scala-sbt"), ArtifactId("sbt"), "1.1.2", Nel.of("1.2.8"))
     val original = Map(
       "build.properties" -> """sbt.version=1.1.2""",
       "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""
     )
     val expected = Map(
-      "build.properties" -> """sbt.version=1.2.8""", // the version should have been updated here
+      "build.properties" -> """sbt.version=1.2.8""",
       "project/plugins.sbt" -> """addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")"""
     )
     runApplyUpdate(update, original) shouldBe expected

--- a/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/UpdateHeuristicTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.edit
 
 import org.scalasteward.core.data.Update.{Group, Single}
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.edit.UpdateHeuristicTest.UpdateOps
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
@@ -11,7 +11,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("sbt: build.properties") {
     val original = """sbt.version=1.3.0-RC1"""
     val expected = """sbt.version=1.3.0"""
-    Single(GroupId("org.scala-sbt"), "sbt", "1.3.0-RC1", Nel.of("1.3.0"))
+    Single(GroupId("org.scala-sbt"), ArtifactId("sbt"), "1.3.0-RC1", Nel.of("1.3.0"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -26,7 +26,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Single(GroupId("org.scala-js"), ArtifactId("sbt-scalajs"), "0.6.24", Nel.of("0.6.25"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -36,14 +36,14 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
         |addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
       """.stripMargin.trim
-    Single(GroupId("org.scala-js"), "sbt-scalajs", "0.6.24", Nel.of("0.6.25"))
+    Single(GroupId("org.scala-js"), ArtifactId("sbt-scalajs"), "0.6.24", Nel.of("0.6.25"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore hyphen in artifactId") {
     val original = """val scalajsJqueryVersion = "0.9.3""""
     val expected = """val scalajsJqueryVersion = "0.9.4""""
-    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -56,7 +56,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """// val scalajsJqueryVersion = "0.9.3
         |val scalajsJqueryVersion = "0.9.4" //bla
         |"""".stripMargin.trim
-    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
@@ -73,42 +73,40 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |   addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.4")
         |   //addSbtPlugin("be.doeraene" %% "scalajs-jquery"  % "0.9.3")
         |"""".stripMargin.trim
-    Single(GroupId("be.doeraene"), "scalajs-jquery", "0.9.3", Nel.of("0.9.4"))
+    Single(GroupId("be.doeraene"), ArtifactId("scalajs-jquery"), "0.9.3", Nel.of("0.9.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("ignore '-core' suffix") {
     val original = """val specs2Version = "4.2.0""""
     val expected = """val specs2Version = "4.3.4""""
-    Single(GroupId("org.specs2"), "specs2-core", "4.2.0", Nel.of("4.3.4"))
+    Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "4.2.0", Nel.of("4.3.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("use groupId if artifactId is 'core'") {
     val original = """lazy val sttpVersion = "1.3.2""""
     val expected = """lazy val sttpVersion = "1.3.3""""
-    Single(GroupId("com.softwaremill.sttp"), "core", "1.3.2", Nel.of("1.3.3"))
+    Single(GroupId("com.softwaremill.sttp"), ArtifactId("core"), "1.3.2", Nel.of("1.3.3"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("short groupIds") {
-    val original = """
-                     |private val mapCommonsDeps = Seq(
-                     |    "akka-streams",
-                     |    "akka-streams-kafka"
-                     |  ).map("com.sky" %% _ % "1.2.0")
-                     |""".stripMargin
+    val original = """|private val mapCommonsDeps = Seq(
+                      |    "akka-streams",
+                      |    "akka-streams-kafka"
+                      |  ).map("com.sky" %% _ % "1.2.0")
+                      |""".stripMargin
 
-    val expected = """
-                     |private val mapCommonsDeps = Seq(
-                     |    "akka-streams",
-                     |    "akka-streams-kafka"
-                     |  ).map("com.sky" %% _ % "1.3.0")
-                     |""".stripMargin
+    val expected = """|private val mapCommonsDeps = Seq(
+                      |    "akka-streams",
+                      |    "akka-streams-kafka"
+                      |  ).map("com.sky" %% _ % "1.3.0")
+                      |""".stripMargin
 
     Group(
       GroupId("com.sky"),
-      Nel.of("akka-streams", "akka-streams-kafka"),
+      Nel.of(ArtifactId("akka-streams"), ArtifactId("akka-streams-kafka")),
       "1.2.0",
       Nel.one("1.3.0")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.completeGroupId.name)
@@ -117,7 +115,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("version range") {
     val original = """Seq("org.specs2" %% "specs2-core" % "3.+" % "test")"""
     val expected = """Seq("org.specs2" %% "specs2-core" % "4.3.4" % "test")"""
-    Single(GroupId("org.specs2"), "specs2-core", "3.+", Nel.of("4.3.4"))
+    Single(GroupId("org.specs2"), ArtifactId("specs2-core"), "3.+", Nel.of("4.3.4"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
@@ -126,7 +124,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val expected = """ val circe = "0.10.0-M2" """
     Group(
       GroupId("io.circe"),
-      Nel.of("circe-generic", "circe-literal", "circe-parser", "circe-testing"),
+      Nel.of(
+        ArtifactId("circe-generic"),
+        ArtifactId("circe-literal"),
+        ArtifactId("circe-parser"),
+        ArtifactId("circe-testing")
+      ),
       "0.10.0-M1",
       Nel.of("0.10.0-M2")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
@@ -137,7 +140,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val expected = """ "org.typelevel" %% "kind-projector" % "0.10.0""""
     Single(
       GroupId("org.spire-math"),
-      "kind-projector",
+      ArtifactId("kind-projector"),
       "0.9.0",
       Nel.of("0.10.0"),
       newerGroupId = Some(GroupId("org.typelevel"))
@@ -153,8 +156,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """ "com.pepegar" %% "hammock-core"  % "0.8.5",
         | "com.pepegar" %% "hammock-circe" % "0.8.5"
       """.stripMargin.trim
-    Group(GroupId("com.pepegar"), Nel.of("hammock-core", "hammock-circe"), "0.8.1", Nel.of("0.8.5"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
+    Group(
+      GroupId("com.pepegar"),
+      Nel.of(ArtifactId("hammock-core"), ArtifactId("hammock-circe")),
+      "0.8.1",
+      Nel.of("0.8.5")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("same version, same artifact prefix, different groupId") {
@@ -168,8 +175,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         | "org.typelevel" %% "jawn-json4s"  % "0.14.1",
         | "org.typelevel" %% "jawn-play" % "0.14.1"
       """.stripMargin.trim
-    Group(GroupId("org.typelevel"), Nel.of("jawn-json4s", "jawn-play"), "0.14.0", Nel.of("0.14.1"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
+    Group(
+      GroupId("org.typelevel"),
+      Nel.of(ArtifactId("jawn-json4s"), ArtifactId("jawn-play")),
+      "0.14.0",
+      Nel.of("0.14.1")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 
   test("artifactIds are common suffixes") {
@@ -183,7 +194,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """.stripMargin
     Group(
       GroupId("com.github.japgolly.scalajs-react"),
-      Nel.of("core", "extra"),
+      Nel.of(ArtifactId("core"), ArtifactId("extra")),
       "1.2.3",
       Nel.of("1.3.1")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
@@ -200,7 +211,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """.stripMargin
     Group(
       GroupId("io.circe"),
-      Nel.of("circe-jawn", "circe-testing"),
+      Nel.of(ArtifactId("circe-jawn"), ArtifactId("circe-testing")),
       "0.10.0",
       Nel.of("0.10.1")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
@@ -217,7 +228,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """.stripMargin
     Group(
       GroupId("io.dropwizard.metrics"),
-      Nel.of("metrics-core", "metrics-healthchecks"),
+      Nel.of(ArtifactId("metrics-core"), ArtifactId("metrics-healthchecks")),
       "4.0.1",
       Nel.of("4.0.3")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
@@ -226,22 +237,26 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("artifactId with dot") {
     val original = """ def plotlyJs = "1.41.3" """
     val expected = """ def plotlyJs = "1.43.2" """
-    Single(GroupId("org.webjars.bower"), "plotly.js", "1.41.3", Nel.of("1.43.2"))
+    Single(GroupId("org.webjars.bower"), ArtifactId("plotly.js"), "1.41.3", Nel.of("1.43.2"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("val with backticks") {
     val original = """ val `plotly.js` = "1.41.3" """
     val expected = """ val `plotly.js` = "1.43.2" """
-    Single(GroupId("org.webjars.bower"), "plotly.js", "1.41.3", Nel.of("1.43.2"))
+    Single(GroupId("org.webjars.bower"), ArtifactId("plotly.js"), "1.41.3", Nel.of("1.43.2"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.original.name)
   }
 
   test("word from artifactId") {
     val original = """lazy val circeVersion = "0.9.3""""
     val expected = """lazy val circeVersion = "0.11.1""""
-    Single(GroupId("io.circe"), "circe-generic", "0.9.3", Nel.of("0.11.1"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
+    Single(
+      GroupId("io.circe"),
+      ArtifactId("circe-generic", "circe-generic_2.12"),
+      "0.9.3",
+      Nel.of("0.11.1")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
   test("artifactId with underscore") {
@@ -249,7 +264,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val expected = """val scShapelessV = "1.1.8""""
     Single(
       GroupId("com.github.alexarchambault"),
-      "scalacheck-shapeless_1.13",
+      ArtifactId("scalacheck-shapeless_1.13"),
       "1.1.6",
       Nel.of("1.1.8")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
@@ -258,7 +273,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("camel case artifactId") {
     val original = """val hikariVersion = "3.3.0" """
     val expected = """val hikariVersion = "3.4.0" """
-    Single(GroupId("com.zaxxer"), "HikariCP", "3.3.0", Nel.of("3.4.0"))
+    Single(GroupId("com.zaxxer"), ArtifactId("HikariCP"), "3.3.0", Nel.of("3.4.0"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
   }
 
@@ -267,7 +282,11 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val expected = """val mongoVersion = "3.7.1" """
     Group(
       GroupId("org.mongodb"),
-      Nel.of("mongodb-driver", "mongodb-driver-async", "mongodb-driver-core"),
+      Nel.of(
+        ArtifactId("mongodb-driver"),
+        ArtifactId("mongodb-driver-async"),
+        ArtifactId("mongodb-driver-core")
+      ),
       "3.7.0",
       Nel.of("3.7.1")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.sliding.name)
@@ -275,14 +294,14 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
 
   test("artifactId with common suffix") {
     val original = """case _ => "1.0.2" """
-    Single(GroupId("co.fs2"), "fs2-core", "1.0.2", Nel.of("1.0.4"))
+    Single(GroupId("co.fs2"), ArtifactId("fs2-core"), "1.0.2", Nel.of("1.0.4"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("word from groupId") {
     val original = """val acolyteVersion = "1.0.49" """
     val expected = """val acolyteVersion = "1.0.51" """
-    Single(GroupId("org.eu.acolyte"), "jdbc-driver", "1.0.49", Nel.of("1.0.51"))
+    Single(GroupId("org.eu.acolyte"), ArtifactId("jdbc-driver"), "1.0.49", Nel.of("1.0.51"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.groupId.name)
   }
 
@@ -294,33 +313,34 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       ("""version=2.0.0 """, """version=2.0.1 """)
     ).foreach {
       case (original, expected) =>
-        Single(GroupId("org.scalameta"), "scalafmt-core", "2.0.0", Nel.of("2.0.1"))
-          .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.specific.name)
-        // Should not edit if artifactId ontains scalaBinaryVersion
-        Single(GroupId("org.scalameta"), "scalafmt-core_2.12", "2.0.0", Nel.of("2.0.1"))
-          .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.specific.name)
+        Single(
+          GroupId("org.scalameta"),
+          ArtifactId("scalafmt-core", "scalafmt-core_2.12"),
+          "2.0.0",
+          Nel.of("2.0.1")
+        ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.specific.name)
     }
 
     val original = """version=2.0.0"""
-    Single(GroupId("org.scalameta"), "other-artifact", "2.0.0", Nel.of("2.0.1"))
+    Single(GroupId("org.scalameta"), ArtifactId("other-artifact"), "2.0.0", Nel.of("2.0.1"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore TLD") {
     val original = """ "com.propensive" %% "contextual" % "1.0.1" """
-    Single(GroupId("com.slamdata"), "fs2-gzip", "1.0.1", Nel.of("1.1.1"))
+    Single(GroupId("com.slamdata"), ArtifactId("fs2-gzip"), "1.0.1", Nel.of("1.1.1"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore short words") {
     val original = "SBT_VERSION=1.2.7"
-    Single(GroupId("org.scala-sbt"), "scripted-plugin", "1.2.7", Nel.of("1.2.8"))
+    Single(GroupId("org.scala-sbt"), ArtifactId("scripted-plugin"), "1.2.7", Nel.of("1.2.8"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
   test("ignore 'scala' substring") {
     val original = """ val scalaTestVersion = "3.0.7" """
-    Single(GroupId("org.scalactic"), "scalactic", "3.0.7", Nel.of("3.0.8"))
+    Single(GroupId("org.scalactic"), ArtifactId("scalactic"), "3.0.7", Nel.of("3.0.8"))
       .replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
   }
 
@@ -337,7 +357,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
       """
     Group(
       GroupId("com.thoughtworks.dsl"),
-      Nel.of("keywords-each", "keywords-using"),
+      Nel.of(ArtifactId("keywords-each"), ArtifactId("keywords-using")),
       "1.2.0",
       Nel.of("1.3.0")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
@@ -346,8 +366,12 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
   test("prevent exception: named capturing group is missing trailing '}'") {
     val original = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.8.0""""
     val expected = """ "org.nd4j" % s"nd4j-""" + "$" + """{nd4jRuntime.value}-platform" % "0.9.1""""
-    Group(GroupId("org.nd4j"), Nel.of("nd4j-api", "nd4j-native-platform"), "0.8.0", Nel.of("0.9.1"))
-      .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
+    Group(
+      GroupId("org.nd4j"),
+      Nel.of(ArtifactId("nd4j-api"), ArtifactId("nd4j-native-platform")),
+      "0.8.0",
+      Nel.of("0.9.1")
+    ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.strict.name)
   }
 
   test("NOK: change of unrelated ModuleID") {
@@ -355,7 +379,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val expected = """ "com.geirsson" % "sbt-ci-release" % "1.2.4" """
     Group(
       GroupId("org.scala-sbt"),
-      Nel.of("sbt-launch", "scripted-plugin", "scripted-sbt"),
+      Nel.of(ArtifactId("sbt-launch"), ArtifactId("scripted-plugin"), ArtifactId("scripted-sbt")),
       "1.2.1",
       Nel.of("1.2.4")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.relaxed.name)
@@ -372,7 +396,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |  """.stripMargin.trim
     Group(
       GroupId("com.typesafe.akka"),
-      Nel.of("akka-actor", "akka-testkit"),
+      Nel.of(ArtifactId("akka-actor"), ArtifactId("akka-testkit")),
       "2.4.0",
       Nel.of("2.5.0")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
@@ -386,7 +410,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |  """.stripMargin.trim
     Group(
       GroupId("com.typesafe.akka"),
-      Nel.of("akka-actor", "akka-testkit"),
+      Nel.of(ArtifactId("akka-actor"), ArtifactId("akka-testkit")),
       "2.4.0",
       Nel.of("2.5.0")
     ).replaceVersionIn(original) shouldBe (None -> UpdateHeuristic.all.last.name)
@@ -411,7 +435,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |  """.stripMargin.trim
     Group(
       GroupId("com.typesafe.akka"),
-      Nel.of("akka-actor", "akka-testkit", "akka-slf4j"),
+      Nel.of(ArtifactId("akka-actor"), ArtifactId("akka-testkit"), ArtifactId("akka-slf4j")),
       "2.4.20",
       Nel.of("2.5.0")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
@@ -432,7 +456,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
         |""".stripMargin
     Group(
       GroupId("org.typelevel"),
-      Nel.of("cats-core", "cats-laws"),
+      Nel.of(ArtifactId("cats-core"), ArtifactId("cats-laws")),
       "2.0.0-M4",
       Nel.of("2.0.0-RC1")
     ).replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
@@ -442,7 +466,7 @@ class UpdateHeuristicTest extends AnyFunSuite with Matchers {
     val original = " import $ivy.`org.typelevel::cats-core:1.2.0` ".stripMargin
     val expected = " import $ivy.`org.typelevel::cats-core:1.3.0` ".stripMargin
 
-    Single(GroupId("org.typelevel"), "cats-core", "1.2.0", Nel.of("1.3.0"))
+    Single(GroupId("org.typelevel"), ArtifactId("cats-core"), "1.2.0", Nel.of("1.3.0"))
       .replaceVersionIn(original) shouldBe (Some(expected) -> UpdateHeuristic.moduleId.name)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
@@ -8,7 +8,7 @@ import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.implicits._
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.mock.MockContext.{config, user}
 import org.scalasteward.core.nurture.UpdateData
@@ -50,7 +50,8 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
     Repo("foo", "bar"),
     Repo("scala-steward", "bar"),
     RepoConfig(),
-    Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3")),
+    Update
+      .Single(GroupId("ch.qos.logback"), ArtifactId("logback-classic"), "1.2.0", Nel.of("1.2.3")),
     Branch("master"),
     Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
     Branch("update/logback-classic-1.2.3")

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.repoconfig
 
 import better.files.File
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.mock.MockContext.repoConfigAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
@@ -53,7 +53,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("configToIgnoreFurtherUpdates with single update") {
-    val update = Update.Single(GroupId("a"), "b", "c", Nel.of("d"))
+    val update = Update.Single(GroupId("a"), ArtifactId("b"), "c", Nel.of("d"))
     val repoConfig = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())
@@ -66,7 +66,8 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("configToIgnoreFurtherUpdates with group update") {
-    val update = Update.Group(GroupId("a"), Nel.of("b", "e"), "c", Nel.of("d"))
+    val update =
+      Update.Group(GroupId("a"), Nel.of(ArtifactId("b"), ArtifactId("e")), "c", Nel.of("d"))
     val repoConfig = RepoConfigAlg
       .parseRepoConfig(RepoConfigAlg.configToIgnoreFurtherUpdates(update))
       .getOrElse(RepoConfig())

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.sbt
 
-import org.scalasteward.core.data.{Dependency, GroupId, RawUpdate}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, RawUpdate}
 import org.scalasteward.core.sbt.data.SbtVersion
 import org.scalasteward.core.sbt.parser._
 import org.scalasteward.core.util.Nel
@@ -15,55 +15,49 @@ class parserTest extends AnyFunSuite with Matchers {
   test("parseDependencies") {
     val lines =
       """|[info] core / stewardDependencies
-         |[info]  { "groupId": "org.scala-lang", "artifactId": "scala-library", "artifactIdCross": "scala-library", "version": "2.12.7" }
-         |[info]  { "groupId": "com.github.pathikrit", "artifactId": "better-files", "artifactIdCross": "better-files_2.12", "version": "3.6.0" }
-         |[info]  { "groupId": "org.typelevel", "artifactId": "cats-effect", "artifactIdCross": "cats-effect_2.12", "version": "1.0.0" }
+         |[info]  { "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.7" }
+         |[info]  { "groupId": "com.github.pathikrit", "artifactId": { "name": "better-files", "crossNames": [ "better-files_2.12" ] }, "version": "3.6.0" }
+         |[info]  { "groupId": "org.typelevel", "artifactId": { "name": "cats-effect", "crossNames": [ "cats-effect_2.12" ] }, "version": "1.0.0" }
          |sbt:project> stewardDependencies
-         |[info]  { "groupId": "org.scala-lang", "artifactId": "scala-library", "artifactIdCross": "scala-library", "version": "2.12.6" }
-         |[info]  { "groupId": "com.dwijnand", "artifactId": "sbt-travisci", "artifactIdCross": "sbt-travisci", "version": "1.1.3",  "sbtVersion": "1.0" }
-         |[info]  { "groupId": "com.eed3si9n", "artifactId": "sbt-assembly", "artifactIdCross": "sbt-assembly", "version": "0.14.8", "sbtVersion": "1.0", "configurations": "foo" }
-         |[info]  { "groupId": "com.geirsson", "artifactId": "sbt-scalafmt", "artifactIdCross": "sbt-scalafmt", "version": "1.6.0-RC4", "sbtVersion": "1.0" }
+         |[info]  { "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.6" }
+         |[info]  { "groupId": "com.dwijnand", "artifactId": { "name": "sbt-travisci", "crossNames": [ ] }, "version": "1.1.3",  "sbtVersion": "1.0" }
+         |[info]  { "groupId": "com.eed3si9n", "artifactId": { "name": "sbt-assembly", "crossNames": [ ] }, "version": "0.14.8", "sbtVersion": "1.0", "configurations": "foo" }
+         |[info]  { "groupId": "com.geirsson", "artifactId": { "name": "sbt-scalafmt", "crossNames": [ ] }, "version": "1.6.0-RC4", "sbtVersion": "1.0" }
          |""".stripMargin.linesIterator.toList
-    parseDependencies(lines) shouldBe List(
+    parseDependencies(lines) should contain theSameElementsAs List(
       Dependency(
         GroupId("org.scala-lang"),
-        "scala-library",
-        "scala-library",
+        ArtifactId("scala-library"),
         "2.12.7",
         None
       ),
       Dependency(
         GroupId("com.github.pathikrit"),
-        "better-files",
-        "better-files_2.12",
+        ArtifactId("better-files", "better-files_2.12"),
         "3.6.0",
         None
       ),
       Dependency(
         GroupId("org.typelevel"),
-        "cats-effect",
-        "cats-effect_2.12",
+        ArtifactId("cats-effect", "cats-effect_2.12"),
         "1.0.0",
         None
       ),
       Dependency(
         GroupId("org.scala-lang"),
-        "scala-library",
-        "scala-library",
+        ArtifactId("scala-library"),
         "2.12.6",
         None
       ),
       Dependency(
         GroupId("com.dwijnand"),
-        "sbt-travisci",
-        "sbt-travisci",
+        ArtifactId("sbt-travisci"),
         "1.1.3",
         Some(SbtVersion("1.0"))
       ),
       Dependency(
         GroupId("com.eed3si9n"),
-        "sbt-assembly",
-        "sbt-assembly",
+        ArtifactId("sbt-assembly"),
         "0.14.8",
         Some(SbtVersion("1.0")),
         None,
@@ -71,8 +65,7 @@ class parserTest extends AnyFunSuite with Matchers {
       ),
       Dependency(
         GroupId("com.geirsson"),
-        "sbt-scalafmt",
-        "sbt-scalafmt",
+        ArtifactId("sbt-scalafmt"),
         "1.6.0-RC4",
         Some(SbtVersion("1.0"))
       )
@@ -82,25 +75,24 @@ class parserTest extends AnyFunSuite with Matchers {
   test("parseDependenciesAndUpdates") {
     val lines =
       """|[info] core / stewardDependencies
-         |[info] { "groupId": "io.get-coursier", "artifactId": "coursier", "artifactIdCross": "coursier_2.12", "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
-         |[info] { "groupId": "io.get-coursier", "artifactId": "coursier-cats-interop", "artifactIdCross": "coursier-cats-interop_2.12", "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
+         |[info] { "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
+         |[info] { "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
          |[info] core / stewardUpdates
-         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": "coursier", "artifactIdCross": "coursier_2.12", "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
-         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": "coursier-cats-interop", "artifactIdCross": "coursier-cats-interop_2.12", "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
+         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
+         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
          |""".stripMargin.linesIterator.toList
 
     val coursier =
-      Dependency(GroupId("io.get-coursier"), "coursier", "coursier_2.12", "2.0.0-RC5-2")
+      Dependency(GroupId("io.get-coursier"), ArtifactId("coursier", "coursier_2.12"), "2.0.0-RC5-2")
     val catsInterop =
       Dependency(
         GroupId("io.get-coursier"),
-        "coursier-cats-interop",
-        "coursier-cats-interop_2.12",
+        ArtifactId("coursier-cats-interop", "coursier-cats-interop_2.12"),
         "2.0.0-RC5-2"
       )
     val (dependencies, updates) = parser.parseDependenciesAndUpdates(lines)
-    dependencies shouldBe List(coursier, catsInterop)
-    updates shouldBe List(
+    dependencies should contain theSameElementsAs List(coursier, catsInterop)
+    updates should contain theSameElementsAs List(
       RawUpdate(coursier, Nel.of("2.0.0-RC5-3")),
       RawUpdate(catsInterop, Nel.of("2.0.0-RC5-3"))
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.update
 
 import cats.implicits._
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}
@@ -13,25 +13,45 @@ import org.scalatest.matchers.should.Matchers
 class FilterAlgTest extends AnyFunSuite with Matchers {
   test("globalFilter: SNAP -> SNAP") {
     val update =
-      Update.Single(GroupId("org.scalatest"), "scalatest", "3.0.8-SNAP2", Nel.of("3.0.8-SNAP10"))
+      Update.Single(
+        GroupId("org.scalatest"),
+        ArtifactId("scalatest"),
+        "3.0.8-SNAP2",
+        Nel.of("3.0.8-SNAP10")
+      )
     FilterAlg.globalFilter(update) shouldBe Right(update)
   }
 
   test("globalFilter: RC -> SNAP") {
     val update =
-      Update.Single(GroupId("org.scalatest"), "scalatest", "3.0.8-RC2", Nel.of("3.1.0-SNAP10"))
+      Update.Single(
+        GroupId("org.scalatest"),
+        ArtifactId("scalatest"),
+        "3.0.8-RC2",
+        Nel.of("3.1.0-SNAP10")
+      )
     FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("globalFilter: update without bad version") {
     val update =
-      Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.0", Nel.of("1.1.2", "2.0.0"))
+      Update.Single(
+        GroupId("com.jsuereth"),
+        ArtifactId("sbt-pgp"),
+        "1.1.0",
+        Nel.of("1.1.2", "2.0.0")
+      )
     FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("1.1.2")))
   }
 
   test("globalFilter: update with bad version") {
     val update =
-      Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.2-1", Nel.of("1.1.2", "2.0.0"))
+      Update.Single(
+        GroupId("com.jsuereth"),
+        ArtifactId("sbt-pgp"),
+        "1.1.2-1",
+        Nel.of("1.1.2", "2.0.0")
+      )
     FilterAlg.globalFilter(update) shouldBe Right(update.copy(newerVersions = Nel.of("2.0.0")))
   }
 
@@ -39,7 +59,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val update =
       Update.Single(
         GroupId("net.sourceforge.plantuml"),
-        "plantuml",
+        ArtifactId("plantuml"),
         "1.2019.11",
         Nel.of("7726", "8020", "2017.09", "1.2019.12")
       )
@@ -47,18 +67,22 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("globalFilter: update with only bad versions") {
-    val update = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.18.0", Nel.of("0.19.0"))
+    val update =
+      Update.Single(GroupId("org.http4s"), ArtifactId("http4s-dsl"), "0.18.0", Nel.of("0.19.0"))
     FilterAlg.globalFilter(update) shouldBe Left(BadVersions(update))
   }
 
   test("globalFilter: update to pre-release of a different series") {
-    val update = Update.Single(GroupId("com.jsuereth"), "sbt-pgp", "1.1.2-1", Nel.of("2.0.1-M3"))
+    val update =
+      Update.Single(GroupId("com.jsuereth"), ArtifactId("sbt-pgp"), "1.1.2-1", Nel.of("2.0.1-M3"))
     FilterAlg.globalFilter(update) shouldBe Left(NoSuitableNextVersion(update))
   }
 
   test("ignore update via config updates.ignore") {
-    val update1 = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
-    val update2 = Update.Single(GroupId("eu.timepit"), "refined", "0.8.0", Nel.of("0.8.1"))
+    val update1 =
+      Update.Single(GroupId("org.http4s"), ArtifactId("http4s-dsl"), "0.17.0", Nel.of("0.18.0"))
+    val update2 =
+      Update.Single(GroupId("eu.timepit"), ArtifactId("refined"), "0.8.0", Nel.of("0.8.1"))
     val config =
       RepoConfig(
         UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None)))
@@ -77,8 +101,10 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   }
 
   test("ignore update via config updates.allow") {
-    val update1 = Update.Single(GroupId("org.http4s"), "http4s-dsl", "0.17.0", Nel.of("0.18.0"))
-    val update2 = Update.Single(GroupId("eu.timepit"), "refined", "0.8.0", Nel.of("0.8.1"))
+    val update1 =
+      Update.Single(GroupId("org.http4s"), ArtifactId("http4s-dsl"), "0.17.0", Nel.of("0.18.0"))
+    val update2 =
+      Update.Single(GroupId("eu.timepit"), ArtifactId("refined"), "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
       updates = UpdatesConfig(

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.update
 
-import org.scalasteward.core.data.{Dependency, GroupId}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.git.Sha1.HexString
 import org.scalasteward.core.mock.MockContext._
@@ -14,14 +14,16 @@ import org.scalatest.matchers.should.Matchers
 class PruningAlgTest extends AnyFunSuite with Matchers {
   test("checkForUpdates: returns updates for artificialProject") {
     val repo = Repo("manuelcueto", "s3mock")
-    val dep = List(Dependency(GroupId("org.typelevel"), "cats-core", "cats-core_2.12", "1.6.0"))
-    val expectedUpdates = dep.map(_.toUpdate.copy(newerVersions = Nel.one("1.6.1")))
+    val dep =
+      Dependency(GroupId("org.typelevel"), ArtifactId("cats-core", "cats-core_2.12"), "1.6.0")
+
+    val expectedUpdate = dep.toUpdate.copy(newerVersions = Nel.one("1.6.1"))
     val result = for {
       _ <- cacheRepository.updateCache(
         repo,
         RepoCache(
           Sha1(HexString.unsafeFrom("12345678ff12345678ff12345678ff12345678ff")),
-          dep,
+          List(dep),
           None,
           None,
           None
@@ -30,6 +32,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
       updates <- pruningAlg.checkForUpdates(List(repo))
     } yield updates
 
-    result.runA(MockState.empty).unsafeRunSync() shouldBe expectedUpdates
+    result.runA(MockState.empty).unsafeRunSync() shouldBe List(expectedUpdate)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/UpdateAlgTest.scala
@@ -1,6 +1,6 @@
 package org.scalasteward.core.update
 
-import org.scalasteward.core.data.{Dependency, GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Update}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.util.Nel
@@ -9,16 +9,21 @@ import org.scalatest.matchers.should.Matchers
 
 class UpdateAlgTest extends AnyFunSuite with Matchers {
   test("findUpdateUnderNewGroup: returns empty if dep is not listed") {
-    val original = Dependency(GroupId("org.spire-math"), "UNKNOWN", "_2.12", "1.0.0")
+    val original =
+      Dependency(GroupId("org.spire-math"), ArtifactId("UNKNOWN", "UNKNOWN_2.12"), "1.0.0")
     UpdateAlg.findUpdateUnderNewGroup(original) shouldBe None
   }
 
-  test("findUpdateUnderNewGroup: returns Update.Single for updateing groupId") {
-    val original = Dependency(GroupId("org.spire-math"), "kind-projector", "_2.12", "0.9.0")
+  test("findUpdateUnderNewGroup: returns Update.Single for updating groupId") {
+    val original = Dependency(
+      GroupId("org.spire-math"),
+      ArtifactId("kind-projector", "kind-projector_2.12"),
+      "0.9.0"
+    )
     UpdateAlg.findUpdateUnderNewGroup(original) shouldBe Some(
       Update.Single(
         GroupId("org.spire-math"),
-        "kind-projector",
+        ArtifactId("kind-projector", "kind-projector_2.12"),
         "0.9.0",
         Nel.of("0.10.0"),
         newerGroupId = Some(GroupId("org.typelevel"))
@@ -28,10 +33,14 @@ class UpdateAlgTest extends AnyFunSuite with Matchers {
 
   test("findUpdate: newer groupId") {
     val dependency =
-      Dependency(GroupId("org.spire-math"), "kind-projector", "kind-projector_2.12", "0.9.10")
+      Dependency(
+        GroupId("org.spire-math"),
+        ArtifactId("kind-projector", "kind-projector_2.12"),
+        "0.9.10"
+      )
     val expected = Update.Single(
       GroupId("org.spire-math"),
-      "kind-projector",
+      ArtifactId("kind-projector", "kind-projector_2.12"),
       "0.9.10",
       Nel.of("0.10.0"),
       newerGroupId = Some(GroupId("org.typelevel"))

--- a/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/showTest.scala
@@ -1,46 +1,53 @@
 package org.scalasteward.core.update
 
-import org.scalasteward.core.data.GroupId
 import org.scalasteward.core.data.Update.{Group, Single}
+import org.scalasteward.core.data.{ArtifactId, GroupId}
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class showTest extends AnyFunSuite with Matchers {
   test("oneLiner: cats-core") {
-    val update = Single(GroupId("org.typelevel"), "cats-core", "0.9.0", Nel.one("1.0.0"))
+    val update =
+      Single(GroupId("org.typelevel"), ArtifactId("cats-core"), "0.9.0", Nel.one("1.0.0"))
     show.oneLiner(update) shouldBe "cats-core"
   }
 
   test("oneLiner: fs2-core") {
-    val update = Single(GroupId("co.fs2"), "fs2-core", "0.9.7", Nel.one("1.0.0"))
+    val update = Single(GroupId("co.fs2"), ArtifactId("fs2-core"), "0.9.7", Nel.one("1.0.0"))
     show.oneLiner(update) shouldBe "fs2-core"
   }
 
   test("oneLiner: monix") {
-    val update = Single(GroupId("io.monix"), "monix", "2.3.3", Nel.one("3.0.0"))
+    val update = Single(GroupId("io.monix"), ArtifactId("monix"), "2.3.3", Nel.one("3.0.0"))
     show.oneLiner(update) shouldBe "monix"
   }
 
   test("oneLiner: sttp:core") {
-    val update = Single(GroupId("com.softwaremill.sttp"), "core", "1.3.3", Nel.one("1.3.5"))
+    val update =
+      Single(GroupId("com.softwaremill.sttp"), ArtifactId("core"), "1.3.3", Nel.one("1.3.5"))
     show.oneLiner(update) shouldBe "sttp:core"
   }
 
   test("oneLiner: typesafe:config") {
-    val update = Single(GroupId("com.typesafe"), "config", "1.3.0", Nel.one("1.3.3"))
+    val update = Single(GroupId("com.typesafe"), ArtifactId("config"), "1.3.0", Nel.one("1.3.3"))
     show.oneLiner(update) shouldBe "typesafe:config"
   }
 
   test("oneLiner: single update with very long artifactId") {
-    val artifactId = "1234567890" * 5
+    val artifactId = ArtifactId("1234567890" * 5)
     val update = Single(GroupId("org.example"), artifactId, "1.0.0", Nel.one("2.0.0"))
-    show.oneLiner(update) shouldBe artifactId
+    show.oneLiner(update) shouldBe artifactId.name
   }
 
   test("oneLiner: group update with two artifacts") {
     val update =
-      Group(GroupId("org.typelevel"), Nel.of("cats-core", "cats-free"), "0.9.0", Nel.one("1.0.0"))
+      Group(
+        GroupId("org.typelevel"),
+        Nel.of(ArtifactId("cats-core"), ArtifactId("cats-free")),
+        "0.9.0",
+        Nel.one("1.0.0")
+      )
     val expected = "cats-core, cats-free"
     show.oneLiner(update) shouldBe expected
   }
@@ -48,7 +55,12 @@ class showTest extends AnyFunSuite with Matchers {
   test("oneLiner: group update with four artifacts") {
     val update = Group(
       GroupId("org.typelevel"),
-      Nel.of("cats-core", "cats-free", "cats-laws", "cats-macros"),
+      Nel.of(
+        ArtifactId("cats-core"),
+        ArtifactId("cats-free"),
+        ArtifactId("cats-laws"),
+        ArtifactId("cats-macros")
+      ),
       "0.9.0",
       Nel.one("1.0.0")
     )
@@ -58,7 +70,12 @@ class showTest extends AnyFunSuite with Matchers {
 
   test("oneLiner: group update with four short artifacts") {
     val update =
-      Group(GroupId("group"), Nel.of("data", "free", "laws", "macros"), "0.9.0", Nel.one("1.0.0"))
+      Group(
+        GroupId("group"),
+        Nel.of(ArtifactId("data"), ArtifactId("free"), ArtifactId("laws"), ArtifactId("macros")),
+        "0.9.0",
+        Nel.one("1.0.0")
+      )
     val expected = "data, free, laws, macros"
     show.oneLiner(update) shouldBe expected
   }
@@ -66,7 +83,7 @@ class showTest extends AnyFunSuite with Matchers {
   test("oneLiner: group update where one artifactId is a common suffix") {
     val update = Group(
       GroupId("com.softwaremill.sttp"),
-      Nel.of("circe", "core", "okhttp-backend-monix"),
+      Nel.of(ArtifactId("circe"), ArtifactId("core"), ArtifactId("okhttp-backend-monix")),
       "1.3.3",
       Nel.one("1.3.5")
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -6,7 +6,7 @@ import org.http4s.client.Client
 import org.http4s.dsl.io._
 import org.http4s.implicits._
 import org.scalasteward.core.TestInstances.ioLogger
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.util.{HttpExistenceClient, Nel}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -24,9 +24,9 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
     HttpExistenceClient.create[IO].allocated.map(_._1).unsafeRunSync()
 
   val vcsExtraAlg = VCSExtraAlg.create[IO]
-  val updateFoo = Update.Single(GroupId("com.example"), "foo", "0.1.0", Nel.of("0.2.0"))
-  val updateBar = Update.Single(GroupId("com.example"), "bar", "0.1.0", Nel.of("0.2.0"))
-  val updateBuz = Update.Single(GroupId("com.example"), "buz", "0.1.0", Nel.of("0.2.0"))
+  val updateFoo = Update.Single(GroupId("com.example"), ArtifactId("foo"), "0.1.0", Nel.of("0.2.0"))
+  val updateBar = Update.Single(GroupId("com.example"), ArtifactId("bar"), "0.1.0", Nel.of("0.2.0"))
+  val updateBuz = Update.Single(GroupId("com.example"), ArtifactId("buz"), "0.1.0", Nel.of("0.2.0"))
 
   test("getBranchCompareUrl") {
     vcsExtraAlg

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.vcs
 
 import org.scalasteward.core.application.SupportedVCS.{GitHub, Gitlab}
-import org.scalasteward.core.data.{GroupId, Update}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
@@ -9,7 +9,12 @@ import org.scalatest.matchers.should.Matchers
 
 class VCSPackageTest extends AnyFunSuite with Matchers {
   val repo = Repo("foo", "bar")
-  val update = Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3"))
+  val update = Update.Single(
+    GroupId("ch.qos.logback"),
+    ArtifactId("logback-classic"),
+    "1.2.0",
+    Nel.of("1.2.3")
+  )
 
   test("listingBranch") {
     listingBranch(GitHub, repo, update) shouldBe "foo/bar:update/logback-classic-1.2.3"

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -1,14 +1,14 @@
 package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
-import org.scalasteward.core.data.{GroupId, Update, Version}
+import org.scalasteward.core.data.{ArtifactId, GroupId, Update, Version}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.nurture.UpdateData
 import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.scalasteward.core.scalafix.Migration
 
 class NewPullRequestDataTest extends AnyFunSuite with Matchers {
   test("asJson") {
@@ -16,7 +16,8 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       Repo("foo", "bar"),
       Repo("scala-steward", "bar"),
       RepoConfig(),
-      Update.Single(GroupId("ch.qos.logback"), "logback-classic", "1.2.0", Nel.of("1.2.3")),
+      Update
+        .Single(GroupId("ch.qos.logback"), ArtifactId("logback-classic"), "1.2.0", Nel.of("1.2.3")),
       Branch("master"),
       Sha1(Sha1.HexString("d6b6791d2ea11df1d156fe70979ab8c3a5ba3433")),
       Branch("update/logback-classic-1.2.3")
@@ -36,15 +37,19 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
 
   test("fromTo") {
     NewPullRequestData.fromTo(
-      Update.Single(GroupId("com.example"), "foo", "1.2.0", Nel.of("1.2.3")),
+      Update.Single(GroupId("com.example"), ArtifactId("foo"), "1.2.0", Nel.of("1.2.3")),
       None
     ) shouldBe "from 1.2.0 to 1.2.3"
 
     NewPullRequestData.fromTo(
-      Update.Group(GroupId("com.example"), Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
+      Update.Group(
+        GroupId("com.example"),
+        Nel.of(ArtifactId("foo"), ArtifactId("bar")),
+        "1.2.0",
+        Nel.of("1.2.3")
+      ),
       Some("http://example.com/compare/v1.2.0...v1.2.3")
-    ) shouldBe
-      "[from 1.2.0 to 1.2.3](http://example.com/compare/v1.2.0...v1.2.3)"
+    ) shouldBe "[from 1.2.0 to 1.2.3](http://example.com/compare/v1.2.0...v1.2.3)"
   }
 
   test("links to release notes/changelog") {
@@ -57,12 +62,17 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
 
   test("showing artifacts with URL in Markdown format") {
     NewPullRequestData.artifactsWithOptionalUrl(
-      Update.Single(GroupId("com.example"), "foo", "1.2.0", Nel.of("1.2.3")),
+      Update.Single(GroupId("com.example"), ArtifactId("foo"), "1.2.0", Nel.of("1.2.3")),
       Map("foo" -> "https://github.com/foo/foo")
     ) shouldBe "[com.example:foo](https://github.com/foo/foo)"
 
     NewPullRequestData.artifactsWithOptionalUrl(
-      Update.Group(GroupId("com.example"), Nel.of("foo", "bar"), "1.2.0", Nel.of("1.2.3")),
+      Update.Group(
+        GroupId("com.example"),
+        Nel.of(ArtifactId("foo"), ArtifactId("bar")),
+        "1.2.0",
+        Nel.of("1.2.3")
+      ),
       Map("foo" -> "https://github.com/foo/foo", "bar" -> "https://github.com/bar/bar")
     ) shouldBe
       """
@@ -80,10 +90,11 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
   }
 
   test("migrationNote: when artifact has migrations") {
-    val update = Update.Single(GroupId("com.spotify"), "scio-core", "0.6.0", Nel.of("0.7.0"))
+    val update =
+      Update.Single(GroupId("com.spotify"), ArtifactId("scio-core"), "0.6.0", Nel.of("0.7.0"))
     val migration = Migration(
       update.groupId,
-      Nel.of(update.artifactId),
+      Nel.of(update.artifactId.name),
       Version("0.7.0"),
       Nel.of("I am a rewrite rule")
     )


### PR DESCRIPTION
This PR

* adds a new ArtifactId type that contains the name of an artifact as
  used in build files and names with cross version suffixes.
* changes Dependency and Update to use ArtifactId.
* changes SbtAlg to use "+ show stewardDependencies" and
  "+ show stewardUpdates" so we get dependencies and updates for all
  crossScalaVersions
* changes PruningAlg such that it marks a dependency only outdated if
  there are updates for all cross artifact names.

closes: #1156