### PR TITLE
Do not use show to display the output of sbt tasks

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
@@ -17,8 +17,8 @@
 package org.scalasteward.core.sbt
 
 object command {
-  val stewardUpdates = "show stewardUpdates"
-  val stewardDependencies = "show stewardDependencies"
+  val stewardUpdates = "stewardUpdates"
+  val stewardDependencies = "stewardDependencies"
   val crossStewardUpdates = s"+ $stewardUpdates"
   val crossStewardDependencies = s"+ $stewardDependencies"
   val reloadPlugins = "reload plugins"

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/parser.scala
@@ -28,11 +28,11 @@ object parser {
 
   /** Parses the output of our own `stewardDependencies` task. */
   def parseDependencies(lines: List[String]): List[Dependency] =
-    lines.flatMap(line => decode[Dependency](removeSbtNoise(line)).toList)
+    lines.flatMap(line => decode[Dependency](line).toList)
 
   def parseDependenciesAndUpdates(lines: List[String]): (List[Dependency], List[RawUpdate]) = {
     val (dependencies, updates) = lines.flatMap { line =>
-      parse(removeSbtNoise(line)).flatMap { json =>
+      parse(line).flatMap { json =>
         Decoder[Dependency].either(Decoder[RawUpdate]).decodeJson(json)
       }.toList
     }.separate
@@ -42,7 +42,4 @@ object parser {
       ArtifactId.combineCrossNames(Dependency.artifactId.compose(RawUpdate.dependency))(updates)
     )
   }
-
-  private def removeSbtNoise(s: String): String =
-    s.replace("[info]", "").trim
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/parserTest.scala
@@ -15,14 +15,14 @@ class parserTest extends AnyFunSuite with Matchers {
   test("parseDependencies") {
     val lines =
       """|[info] core / stewardDependencies
-         |[info]  { "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.7" }
-         |[info]  { "groupId": "com.github.pathikrit", "artifactId": { "name": "better-files", "crossNames": [ "better-files_2.12" ] }, "version": "3.6.0" }
-         |[info]  { "groupId": "org.typelevel", "artifactId": { "name": "cats-effect", "crossNames": [ "cats-effect_2.12" ] }, "version": "1.0.0" }
+         |{ "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.7" }
+         |{ "groupId": "com.github.pathikrit", "artifactId": { "name": "better-files", "crossNames": [ "better-files_2.12" ] }, "version": "3.6.0" }
+         |{ "groupId": "org.typelevel", "artifactId": { "name": "cats-effect", "crossNames": [ "cats-effect_2.12" ] }, "version": "1.0.0" }
          |sbt:project> stewardDependencies
-         |[info]  { "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.6" }
-         |[info]  { "groupId": "com.dwijnand", "artifactId": { "name": "sbt-travisci", "crossNames": [ ] }, "version": "1.1.3",  "sbtVersion": "1.0" }
-         |[info]  { "groupId": "com.eed3si9n", "artifactId": { "name": "sbt-assembly", "crossNames": [ ] }, "version": "0.14.8", "sbtVersion": "1.0", "configurations": "foo" }
-         |[info]  { "groupId": "com.geirsson", "artifactId": { "name": "sbt-scalafmt", "crossNames": [ ] }, "version": "1.6.0-RC4", "sbtVersion": "1.0" }
+         |{ "groupId": "org.scala-lang", "artifactId": { "name": "scala-library", "crossNames": [ ] }, "version": "2.12.6" }
+         |{ "groupId": "com.dwijnand", "artifactId": { "name": "sbt-travisci", "crossNames": [ ] }, "version": "1.1.3",  "sbtVersion": "1.0" }
+         |{ "groupId": "com.eed3si9n", "artifactId": { "name": "sbt-assembly", "crossNames": [ ] }, "version": "0.14.8", "sbtVersion": "1.0", "configurations": "foo" }
+         |{ "groupId": "com.geirsson", "artifactId": { "name": "sbt-scalafmt", "crossNames": [ ] }, "version": "1.6.0-RC4", "sbtVersion": "1.0" }
          |""".stripMargin.linesIterator.toList
     parseDependencies(lines) should contain theSameElementsAs List(
       Dependency(
@@ -75,11 +75,11 @@ class parserTest extends AnyFunSuite with Matchers {
   test("parseDependenciesAndUpdates") {
     val lines =
       """|[info] core / stewardDependencies
-         |[info] { "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
-         |[info] { "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
+         |{ "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
+         |{ "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }
          |[info] core / stewardUpdates
-         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
-         |[info] { "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
+         |{ "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier", "crossNames": [ "coursier_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
+         |{ "dependency": { "groupId": "io.get-coursier", "artifactId": { "name": "coursier-cats-interop", "crossNames": [ "coursier-cats-interop_2.12" ] }, "version": "2.0.0-RC5-2", "configurations": null, "sbtVersion": null, "scalaVersion": null }, "newerVersions": [ "2.0.0-RC5-3" ] }
          |""".stripMargin.linesIterator.toList
 
     val coursier =

--- a/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
+++ b/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
@@ -26,9 +26,9 @@ object StewardPlugin extends AutoPlugin {
 
   object autoImport {
     val stewardDependencies =
-      taskKey[String]("Dependencies as JSON for consumption by Scala Steward.")
+      taskKey[Unit]("Prints dependencies as JSON for consumption by Scala Steward.")
     val stewardUpdates =
-      taskKey[String]("Dependency updates as JSON for consumption by Scala Steward.")
+      taskKey[Unit]("Prints dependency updates as JSON for consumption by Scala Steward.")
   }
 
   import autoImport._
@@ -43,7 +43,7 @@ object StewardPlugin extends AutoPlugin {
         .filter(isDefinedInBuildFiles(_, sourcePositions))
         .map(moduleId => toDependency(moduleId, scalaVersionValue, scalaBinaryVersionValue))
 
-      dependencies.map(_.asJson).mkString(System.lineSeparator())
+      dependencies.map(_.asJson).foreach(println)
     },
     stewardUpdates := {
       val scalaBinaryVersionValue = scalaBinaryVersion.value
@@ -60,7 +60,7 @@ object StewardPlugin extends AutoPlugin {
           )
       }
 
-      updates.map(_.asJson).mkString(System.lineSeparator())
+      updates.map(_.asJson).foreach(println)
     }
   )
 


### PR DESCRIPTION
Using show in combination with "+" issues this warning sometimes:
```
[warn] Issuing a cross building command, but not all sub projects have
the same cross build configuration. This could result in subprojects
cross building against Scala versions that they are not compatible with.
Try issuing cross building command with tasks instead, since sbt will be
able to ensure that cross building is only done using configured project
and Scala version combinations that are configured.
```

In this case, `+ show stewardDependencies` only list dependencies
for `scalaVersion`. Not using show and printing in our tasks directly,
seems to have the desired effect of displaying dependencies for all
`crossScalaVersions`.