### PR TITLE
Only check dependencies whose version is in source files

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -59,7 +59,7 @@ object Context {
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
-        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "7"))
+        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "8"))
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/DependencyInfo.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/DependencyInfo.scala
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.repocache
+package org.scalasteward.core.data
 
 import io.circe.Codec
-import io.circe.generic.semiauto._
-import org.scalasteward.core.data.{DependencyInfo, Version}
-import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.sbt.data.SbtVersion
+import io.circe.generic.semiauto.deriveCodec
 
-final case class RepoCache(
-    sha1: Sha1,
-    dependencyInfos: List[DependencyInfo],
-    maybeSbtVersion: Option[SbtVersion],
-    maybeScalafmtVersion: Option[Version],
-    maybeRepoConfig: Option[RepoConfig]
+final case class DependencyInfo(
+    dependency: Dependency,
+    filesContainingVersion: List[String]
 )
 
-object RepoCache {
-  implicit val repoCacheCodec: Codec[RepoCache] =
+object DependencyInfo {
+  implicit val dependencyInfoCodec: Codec[DependencyInfo] =
     deriveCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -40,8 +40,11 @@ final class PruningAlg[F[_]](
   def needsAttention(repo: Repo): F[Boolean] =
     repoCacheRepository.findCache(repo).flatMap {
       case Some(repoCache) =>
-        val dependencies = repoCache.dependencies
-          .map(_.copy(configurations = None))
+        val dependencies = repoCache.dependencyInfos
+          .collect {
+            case info if info.filesContainingVersion.nonEmpty =>
+              info.dependency.copy(configurations = None)
+          }
           .distinct
           .sortBy(d => (d.groupId, d.artifactId))
         val repoConfig = repoCache.maybeRepoConfig.getOrElse(RepoConfig.default)


### PR DESCRIPTION
For each dependency in a repository we now also cache the files that
contain its current version number. This is then used in PruningAlg
to discard dependencies whose version is not in any file. We don't need
to check for an update of a dependency if we can't bump the version
number later. This change will prune more repositories.

If pruning is the default, we will be able to use this file list later
in EditAlg instead of computing it there again.