### PR TITLE
Remove sbt and scalafmt version from RepoCache

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -60,7 +60,7 @@ object Context {
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
-        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "8"))
+        new RepoCacheRepository[F](new JsonKeyValueStore("repos", "9"))
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Version.scala
@@ -19,7 +19,6 @@ package org.scalasteward.core.data
 import cats.Order
 import cats.implicits._
 import eu.timepit.refined.types.numeric.NonNegInt
-import io.circe.{Codec, Decoder, Encoder}
 import scala.annotation.tailrec
 
 final case class Version(value: String) {
@@ -96,9 +95,6 @@ object Version {
       val (c1, c2) = padToSameLength(v1.alnumComponents, v2.alnumComponents, Component.Empty)
       c1.compare(c2)
     }
-
-  implicit val versionCodec: Codec[Version] =
-    Codec.from(Decoder[String].map(Version.apply), Encoder[String].contramap(_.value))
 
   private def padToSameLength[A](l1: List[A], l2: List[A], elem: A): (List[A], List[A]) = {
     val maxLength = math.max(l1.length, l2.length)

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -18,16 +18,13 @@ package org.scalasteward.core.repocache
 
 import io.circe.Codec
 import io.circe.generic.semiauto._
-import org.scalasteward.core.data.{DependencyInfo, Version}
+import org.scalasteward.core.data.DependencyInfo
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.repoconfig.RepoConfig
-import org.scalasteward.core.sbt.data.SbtVersion
 
 final case class RepoCache(
     sha1: Sha1,
     dependencyInfos: List[DependencyInfo],
-    maybeSbtVersion: Option[SbtVersion],
-    maybeScalafmtVersion: Option[Version],
     maybeRepoConfig: Option[RepoConfig]
 )
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -24,7 +24,6 @@ import org.scalasteward.core.data.{Dependency, DependencyInfo}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
 import org.scalasteward.core.sbt.SbtAlg
-import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.util.MonadThrowable
 import org.scalasteward.core.util.logger.LoggerOps
 import org.scalasteward.core.vcs.data.{Repo, RepoOut}
@@ -40,7 +39,6 @@ final class RepoCacheAlg[F[_]](
     repoCacheRepository: RepoCacheRepository[F],
     repoConfigAlg: RepoConfigAlg[F],
     sbtAlg: SbtAlg[F],
-    scalafmtAlg: ScalafmtAlg[F],
     vcsApiAlg: VCSApiAlg[F],
     vcsRepoAlg: VCSRepoAlg[F],
     F: MonadThrowable[F]
@@ -83,16 +81,8 @@ final class RepoCacheAlg[F[_]](
       latestSha1 <- gitAlg.latestSha1(repo, branch)
       dependencies <- sbtAlg.getDependencies(repo)
       dependencyInfos <- dependencies.traverse(gatherDependencyInfo(repo, _))
-      maybeSbtVersion <- sbtAlg.getSbtVersion(repo)
-      maybeScalafmtVersion <- scalafmtAlg.getScalafmtVersion(repo)
       maybeRepoConfig <- repoConfigAlg.readRepoConfig(repo)
-    } yield RepoCache(
-      latestSha1,
-      dependencyInfos,
-      maybeSbtVersion,
-      maybeScalafmtVersion,
-      maybeRepoConfig
-    )
+    } yield RepoCache(latestSha1, dependencyInfos, maybeRepoConfig)
 
   private def gatherDependencyInfo(repo: Repo, dependency: Dependency): F[DependencyInfo] =
     gitAlg.findFilesContaining(repo, dependency.version).map(DependencyInfo(dependency, _))


### PR DESCRIPTION
These are not needed anymore because sbt and scalafmt-core are included
as dependencies.