### PR TITLE
Use Uri as return type of CoursierAlg.getArtifactUrl

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpExistenceClient.scala
@@ -34,8 +34,6 @@ final class HttpExistenceClient[F[_]](statusCache: Cache[Status])(
     mode: Mode[F],
     F: MonadThrowable[F]
 ) {
-  def exists(uri: String): F[Boolean] = F.fromEither(Uri.fromString(uri)).flatMap(exists)
-
   def exists(uri: Uri): F[Boolean] =
     status(uri).map(_ === Status.Ok).handleErrorWith { throwable =>
       logger.debug(throwable)(s"Failed to check if $uri exists").as(false)

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSExtraAlg.scala
@@ -18,13 +18,14 @@ package org.scalasteward.core.vcs
 
 import cats.Monad
 import cats.implicits._
+import org.http4s.Uri
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.util.HttpExistenceClient
 import org.scalasteward.core.vcs
 
 trait VCSExtraAlg[F[_]] {
-  def getBranchCompareUrl(repoUrl: String, update: Update): F[Option[String]]
-  def getReleaseNoteUrl(repoUrl: String, update: Update): F[Option[String]]
+  def getBranchCompareUrl(repoUrl: Uri, update: Update): F[Option[Uri]]
+  def getReleaseNoteUrl(repoUrl: Uri, update: Update): F[Option[Uri]]
 }
 
 object VCSExtraAlg {
@@ -33,10 +34,10 @@ object VCSExtraAlg {
       existenceClient: HttpExistenceClient[F],
       F: Monad[F]
   ): VCSExtraAlg[F] = new VCSExtraAlg[F] {
-    override def getBranchCompareUrl(repoUrl: String, update: Update): F[Option[String]] =
+    override def getBranchCompareUrl(repoUrl: Uri, update: Update): F[Option[Uri]] =
       vcs.possibleCompareUrls(repoUrl, update).findM(existenceClient.exists)
 
-    override def getReleaseNoteUrl(repoUrl: String, update: Update): F[Option[String]] =
+    override def getReleaseNoteUrl(repoUrl: Uri, update: Update): F[Option[Uri]] =
       vcs.possibleChangelogUrls(repoUrl, update).findM(existenceClient.exists)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.coursier
 
+import org.http4s.syntax.literals._
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
@@ -16,7 +17,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
-    result shouldBe Some("https://github.com/typelevel/cats-effect")
+    result shouldBe Some(uri"https://github.com/typelevel/cats-effect")
   }
 
   test("getArtifactUrl: defaults to homepage") {
@@ -30,7 +31,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
-    result shouldBe Some("https://github.com/playframework/play-ws")
+    result shouldBe Some(uri"https://github.com/playframework/play-ws")
   }
 
   test("getArtifactUrl: sbt plugin on Maven Central") {
@@ -46,7 +47,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
-    result shouldBe Some("https://github.com/xerial/sbt-sonatype")
+    result shouldBe Some(uri"https://github.com/xerial/sbt-sonatype")
   }
 
   test("getArtifactUrl: sbt plugin on sbt-plugin-releases") {
@@ -58,7 +59,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       Some(ScalaVersion("2.12"))
     )
     val result = coursierAlg.getArtifactUrl(dep).runA(MockState.empty).unsafeRunSync()
-    result shouldBe Some("https://github.com/sbt/sbt-release")
+    result shouldBe Some(uri"https://github.com/sbt/sbt-release")
   }
 
   test("getArtifactIdUrlMapping") {
@@ -72,8 +73,8 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       .unsafeRunSync()
     state shouldBe MockState.empty
     result shouldBe Map(
-      "cats-core" -> "https://github.com/typelevel/cats",
-      "cats-effect" -> "https://github.com/typelevel/cats-effect"
+      "cats-core" -> uri"https://github.com/typelevel/cats",
+      "cats-effect" -> uri"https://github.com/typelevel/cats-effect"
     )
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSExtraAlgTest.scala
@@ -32,13 +32,13 @@ class VCSExtraAlgTest extends AnyFunSuite with Matchers {
 
   test("getBranchCompareUrl") {
     vcsExtraAlg
-      .getBranchCompareUrl("https://github.com/foo/foo", updateFoo)
+      .getBranchCompareUrl(uri"https://github.com/foo/foo", updateFoo)
       .unsafeRunSync() shouldBe None
     vcsExtraAlg
-      .getBranchCompareUrl("https://github.com/foo/bar", updateBar)
-      .unsafeRunSync() shouldBe Some("https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
+      .getBranchCompareUrl(uri"https://github.com/foo/bar", updateBar)
+      .unsafeRunSync() shouldBe Some(uri"https://github.com/foo/bar/compare/v0.1.0...v0.2.0")
     vcsExtraAlg
-      .getBranchCompareUrl("https://github.com/foo/buz", updateBuz)
+      .getBranchCompareUrl(uri"https://github.com/foo/buz", updateBuz)
       .unsafeRunSync() shouldBe None
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/VCSPackageTest.scala
@@ -1,5 +1,6 @@
 package org.scalasteward.core.vcs
 
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.application.SupportedVCS.{GitHub, Gitlab}
 import org.scalasteward.core.data.Update
@@ -24,34 +25,39 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
   }
 
   test("possibleCompareUrls") {
-    possibleCompareUrls("https://github.com/foo/bar", update) shouldBe List(
+    possibleCompareUrls(uri"https://github.com/foo/bar", update)
+      .map(_.renderString) shouldBe List(
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
       "https://github.com/foo/bar/compare/1.2.0...1.2.3",
       "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
     // should canonicalize (drop last slash)
-    possibleCompareUrls("https://github.com/foo/bar/", update) shouldBe List(
+    possibleCompareUrls(uri"https://github.com/foo/bar/", update)
+      .map(_.renderString) shouldBe List(
       "https://github.com/foo/bar/compare/v1.2.0...v1.2.3",
       "https://github.com/foo/bar/compare/1.2.0...1.2.3",
       "https://github.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
 
-    possibleCompareUrls("https://gitlab.com/foo/bar", update) shouldBe List(
+    possibleCompareUrls(uri"https://gitlab.com/foo/bar", update)
+      .map(_.renderString) shouldBe List(
       "https://gitlab.com/foo/bar/compare/v1.2.0...v1.2.3",
       "https://gitlab.com/foo/bar/compare/1.2.0...1.2.3",
       "https://gitlab.com/foo/bar/compare/release-1.2.0...release-1.2.3"
     )
-    possibleCompareUrls("https://bitbucket.org/foo/bar", update) shouldBe List(
+    possibleCompareUrls(uri"https://bitbucket.org/foo/bar", update)
+      .map(_.renderString) shouldBe List(
       "https://bitbucket.org/foo/bar/compare/v1.2.3..v1.2.0#diff",
       "https://bitbucket.org/foo/bar/compare/1.2.3..1.2.0#diff",
       "https://bitbucket.org/foo/bar/compare/release-1.2.3..release-1.2.0#diff"
     )
 
-    possibleCompareUrls("https://scalacenter.github.io/scalafix/", update) shouldBe List()
+    possibleCompareUrls(uri"https://scalacenter.github.io/scalafix/", update) shouldBe List()
   }
 
   test("possibleChangelogUrls: github.com") {
-    possibleChangelogUrls("https://github.com/foo/bar", update) shouldBe List(
+    possibleChangelogUrls(uri"https://github.com/foo/bar", update)
+      .map(_.renderString) shouldBe List(
       "https://github.com/foo/bar/blob/master/CHANGELOG.md",
       "https://github.com/foo/bar/blob/master/CHANGELOG.markdown",
       "https://github.com/foo/bar/blob/master/CHANGELOG.rst",
@@ -83,16 +89,19 @@ class VCSPackageTest extends AnyFunSuite with Matchers {
   }
 
   test("possibleChangelogUrls: gitlab.com") {
-    possibleChangelogUrls("https://gitlab.com/foo/bar", update) shouldBe
+    possibleChangelogUrls(uri"https://gitlab.com/foo/bar", update)
+      .map(_.renderString) shouldBe
       possibleChangelogFilenames.map(name => s"https://gitlab.com/foo/bar/blob/master/$name")
   }
 
   test("possibleChangelogUrls: bitbucket.org") {
-    possibleChangelogUrls("https://bitbucket.org/foo/bar", update) shouldBe
+    possibleChangelogUrls(uri"https://bitbucket.org/foo/bar", update)
+      .map(_.renderString) shouldBe
       possibleChangelogFilenames.map(name => s"https://bitbucket.org/foo/bar/master/$name")
   }
 
   test("possibleChangelogUrls: homepage") {
-    possibleChangelogUrls("https://scalacenter.github.io/scalafix/", update) shouldBe List()
+    possibleChangelogUrls(uri"https://scalacenter.github.io/scalafix/", update)
+      .map(_.renderString) shouldBe List()
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
+import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{Update, Version}
 import org.scalasteward.core.git.{Branch, Sha1}
@@ -44,14 +45,14 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
 
     NewPullRequestData.fromTo(
       Update.Group("com.example" % Nel.of("foo", "bar") % "1.2.0", Nel.of("1.2.3")),
-      Some("http://example.com/compare/v1.2.0...v1.2.3")
+      Some(uri"http://example.com/compare/v1.2.0...v1.2.3")
     ) shouldBe "[from 1.2.0 to 1.2.3](http://example.com/compare/v1.2.0...v1.2.3)"
   }
 
   test("links to release notes/changelog") {
     NewPullRequestData.releaseNote(None) shouldBe None
 
-    NewPullRequestData.releaseNote(Some("https://github.com/foo/foo/CHANGELOG.rst")) shouldBe Some(
+    NewPullRequestData.releaseNote(Some(uri"https://github.com/foo/foo/CHANGELOG.rst")) shouldBe Some(
       "[Release Notes/Changelog](https://github.com/foo/foo/CHANGELOG.rst)"
     )
   }
@@ -59,12 +60,12 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
   test("showing artifacts with URL in Markdown format") {
     NewPullRequestData.artifactsWithOptionalUrl(
       Update.Single("com.example" % "foo" % "1.2.0", Nel.of("1.2.3")),
-      Map("foo" -> "https://github.com/foo/foo")
+      Map("foo" -> uri"https://github.com/foo/foo")
     ) shouldBe "[com.example:foo](https://github.com/foo/foo)"
 
     NewPullRequestData.artifactsWithOptionalUrl(
       Update.Group("com.example" % Nel.of("foo", "bar") % "1.2.0", Nel.of("1.2.3")),
-      Map("foo" -> "https://github.com/foo/foo", "bar" -> "https://github.com/bar/bar")
+      Map("foo" -> uri"https://github.com/foo/foo", "bar" -> uri"https://github.com/bar/bar")
     ) shouldBe
       """
         |* [com.example:foo](https://github.com/foo/foo)


### PR DESCRIPTION
This prevents errors like this in `HttpExistenceClient`:
```
org.http4s.ParseFailure: Invalid URI: Invalid input '{', expected Pchar, '/', '?', '#' or 'EOI' (line 1, column 29):
https://github.com/JodaOrg/${joda.artifactId}/compare/v2.2.0...v2.2.1
```