### PR TITLE
Use baseDirectory in runSteward sbt task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,8 +244,8 @@ runSteward := Def.inputTaskDyn {
     Seq("--whitelist", s"$home/.ivy2"),
     Seq("--whitelist", s"$home/.sbt"),
     Seq("--prune-repos=true")
-  ).flatten.mkString(" ")
-  (core.jvm / Compile / run).toTask(" " + args)
+  ).flatten.mkString(" ", " ", "")
+  (core.jvm / Compile / run).toTask(args)
 }.evaluated
 
 /// commands

--- a/build.sbt
+++ b/build.sbt
@@ -229,8 +229,8 @@ moduleRootPkg := rootPkg
 
 // Run Scala Steward from sbt for development and testing.
 // Do not do this in production.
-lazy val runSteward = inputKey[Unit]("")
-runSteward := Def.inputTaskDyn {
+lazy val runSteward = taskKey[Unit]("")
+runSteward := Def.taskDyn {
   val home = System.getenv("HOME")
   val projectDir = (LocalRootProject / baseDirectory).value
   val args = Seq(
@@ -246,7 +246,7 @@ runSteward := Def.inputTaskDyn {
     Seq("--prune-repos=true")
   ).flatten.mkString(" ", " ", "")
   (core.jvm / Compile / run).toTask(args)
-}.evaluated
+}.value
 
 /// commands
 


### PR DESCRIPTION
This makes runSteward independent of where the repo is checked out
locally.