### PR TITLE
Allow special characters in passwords to work

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -81,7 +81,7 @@ run
 * Create a file `run.sh` with this content:
 
 ```
-echo "echo $BITBUCKET_PASSWORD" >pass.sh
+echo "echo '$BITBUCKET_PASSWORD'" >pass.sh
 
 chmod +x pass.sh
 


### PR DESCRIPTION
When using a `!` in your password, `echo $PASSWORD` will not work, it needs to be escaped.

I've updated the example in the documentation.