### PR TITLE
Use Coursier to double-check our version ordering

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -49,11 +49,12 @@ object FilterAlg {
   sealed trait RejectionReason {
     def update: Update.Single
     def show: String = this match {
-      case IgnoredGlobally(_)       => "ignored globally"
-      case IgnoredByConfig(_)       => "ignored by config"
-      case NotAllowedByConfig(_)    => "not allowed by config"
-      case BadVersions(_)           => "bad versions"
-      case NoSuitableNextVersion(_) => "no suitable next version"
+      case IgnoredGlobally(_)         => "ignored globally"
+      case IgnoredByConfig(_)         => "ignored by config"
+      case NotAllowedByConfig(_)      => "not allowed by config"
+      case BadVersions(_)             => "bad versions"
+      case NoSuitableNextVersion(_)   => "no suitable next version"
+      case VersionOrderingConflict(_) => "version ordering conflict"
     }
   }
 
@@ -62,11 +63,13 @@ object FilterAlg {
   final case class NotAllowedByConfig(update: Update.Single) extends RejectionReason
   final case class BadVersions(update: Update.Single) extends RejectionReason
   final case class NoSuitableNextVersion(update: Update.Single) extends RejectionReason
+  final case class VersionOrderingConflict(update: Update.Single) extends RejectionReason
 
   def globalFilter(update: Update.Single): FilterResult =
     removeBadVersions(update)
       .flatMap(isIgnoredGlobally)
       .flatMap(selectSuitableNextVersion)
+      .flatMap(checkVersionOrdering)
 
   private def localFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
     globalFilter(update).flatMap(repoConfig.updates.keep)
@@ -100,6 +103,12 @@ object FilterAlg {
       case Some(next) => Right(update.copy(newerVersions = Nel.of(next.value)))
       case None       => Left(NoSuitableNextVersion(update))
     }
+  }
+
+  private def checkVersionOrdering(update: Update.Single): FilterResult = {
+    val nextVersionIsGreater =
+      coursier.core.Version(update.currentVersion) < coursier.core.Version(update.nextVersion)
+    if (nextVersionIsGreater) Right(update) else Left(VersionOrderingConflict(update))
   }
 
   private def removeBadVersions(update: Update.Single): FilterResult =


### PR DESCRIPTION
If #1209 is merged, our own `Order[Version]` will become more important.
To prevent that it does something stupid, this adds a double-check which
uses coursier.core.Version to verify that the next version of an update
is greater than the current. Once our own ordering is battle-tested
enough, this can be removed again.