### PR TITLE
Revert "Revert "Parallelize UpdateAlg.findUpdate""

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -1,6 +1,7 @@
 package org.scalasteward.core.mock
 
 import better.files.File
+import cats.Parallel
 import cats.effect.Sync
 import org.http4s.Uri
 import org.scalasteward.core.TestInstances.ioContextShift
@@ -49,6 +50,7 @@ object MockContext {
   )
 
   implicit val mockEffBracketThrowable: BracketThrowable[MockEff] = Sync[MockEff]
+  implicit val mockEffParallel: Parallel[MockEff] = Parallel.identity
 
   implicit val fileAlg: MockFileAlg = new MockFileAlg
   implicit val mockLogger: MockLogger = new MockLogger


### PR DESCRIPTION
Reverts fthomas/scala-steward#1215

It seems that checking for updates sequentially didn't help with not being blacklisted by Maven Central. Other services are also seeing 403s from Maven Central (see https://twitter.com/dwijnand/status/1213406224450048001), so maybe it is not entirely Scala Steward's fault.

I'll now trying out the [Maven Central mirror on Google Cloud Storage](https://cloudplatform.googleblog.com/2015/11/faster-builds-for-Java-developers-with-Maven-Central-mirror.html) via [Coursier's mirrors mechanism](https://get-coursier.io/blog/2019/07/05/1.1.0-M14.html#mirrors):
```
~$ cat .config/coursier/mirror.properties 
gcs-maven-central.from=https://repo1.maven.org/maven2
gcs-maven-central.to=https://maven-central.storage-download.googleapis.com/repos/central/data/
```