### PR TITLE
Throttle (concurrent) requests to Maven Central

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -50,6 +50,7 @@ object Context {
       implicit0(logger: Logger[F]) <- Resource.liftF(Slf4jLogger.create[F])
       implicit0(httpExistenceClient: HttpExistenceClient[F]) <- HttpExistenceClient.create[F]
       implicit0(user: AuthenticatedUser) <- Resource.liftF(config.vcsUser[F])
+      updateAlgRateLimiter <- RateLimiter.create[F]
     } yield {
       implicit val dateTimeAlg: DateTimeAlg[F] = DateTimeAlg.create[F]
       implicit val fileAlg: FileAlg[F] = FileAlg.create[F]
@@ -70,7 +71,7 @@ object Context {
         new PullRequestRepository[F](new JsonKeyValueStore("prs", "5"))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create
-      implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
+      implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F](updateAlgRateLimiter)
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
         new RefreshErrorAlg[F](new JsonKeyValueStore("repos_refresh_errors", "1"))

--- a/modules/core/src/main/scala/org/scalasteward/core/util/RateLimiter.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/RateLimiter.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.util
+
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Concurrent, Resource, Timer}
+import cats.implicits._
+import com.github.benmanes.caffeine.cache.Caffeine
+import scala.concurrent.duration._
+import scalacache.CatsEffect.modes._
+import scalacache.Entry
+import scalacache.caffeine.CaffeineCache
+
+trait RateLimiter[F[_]] {
+  def limitUnseen[A](key: String)(fa: F[A]): F[A]
+}
+
+object RateLimiter {
+  def create[F[_]](implicit timer: Timer[F], F: Concurrent[F]): Resource[F, RateLimiter[F]] =
+    for {
+      cache <- Resource.make(F.delay {
+        CaffeineCache(Caffeine.newBuilder().maximumSize(65536L).build[String, Entry[Unit]]())
+      })(_.close().void)
+      semaphore <- Resource.liftF(Semaphore(1))
+    } yield new RateLimiter[F] {
+      override def limitUnseen[A](key: String)(fa: F[A]): F[A] =
+        cache.get(key).flatMap {
+          case Some(_) => fa
+          case None    => semaphore.withPermit(timer.sleep(250.millis) *> fa <* cache.put(key)(()))
+        }
+    }
+}


### PR DESCRIPTION
Scala Steward has become so fast that it is now frequently being
blacklisted by Maven Central despite using Coursier's caching layer.
Previous attempts to prevent that (#1215 and #1216) were't successful
so I'm now trying to limit the rate of calls to Coursier that
potentially result in a call to Maven Central.