### PR TITLE
Don't use default resolvers for getting versions

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -61,7 +61,7 @@ object Context {
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
-        new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "2"))
+        new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "3"))
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -77,9 +77,7 @@ object CoursierAlg {
       ): F[Option[Uri]] =
         (for {
           maybeFetchResult <- fetch
-            .addRepositories(
-              extraResolvers.map(resolver => MavenRepository.apply(resolver.location)): _*
-            )
+            .addRepositories(extraResolvers.map(toCoursierRepository): _*)
             .addDependencies(coursierDependency)
             .addArtifactTypes(coursier.Type.pom, coursier.Type.ivy)
             .ioResult

--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/CoursierAlg.scala
@@ -39,10 +39,7 @@ trait CoursierAlg[F[_]] {
       extraResolvers: List[Resolver] = List.empty
   ): F[Option[Uri]]
 
-  def getVersions(
-      dependency: Dependency,
-      extraResolvers: List[Resolver] = List.empty
-  ): F[List[Version]]
+  def getVersions(dependency: Dependency, resolvers: List[Resolver]): F[List[Version]]
 
   final def getArtifactIdUrlMapping(dependencies: List[Dependency])(
       implicit F: Applicative[F]
@@ -65,7 +62,7 @@ object CoursierAlg {
     val sbtPluginReleases =
       ivy"https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/[defaultPattern]"
     val fetch = coursier.Fetch[F](cache).addRepositories(sbtPluginReleases)
-    val versions = coursier.Versions[F](cache).addRepositories(sbtPluginReleases)
+    val versions = coursier.Versions[F](cache).withRepositories(List(sbtPluginReleases))
 
     new CoursierAlg[F] {
       override def getArtifactUrl(
@@ -111,12 +108,10 @@ object CoursierAlg {
 
       override def getVersions(
           dependency: Dependency,
-          extraResolvers: List[Resolver] = List.empty
+          resolvers: List[Resolver]
       ): F[List[Version]] =
         versions
-          .addRepositories(
-            extraResolvers.map(resolver => MavenRepository.apply(resolver.location)): _*
-          )
+          .addRepositories(resolvers.map(toCoursierRepository): _*)
           .withModule(toCoursierModule(dependency))
           .versions()
           .map(_.available.map(Version.apply).sorted)
@@ -132,6 +127,9 @@ object CoursierAlg {
       ModuleName(dependency.artifactId.crossName),
       dependency.attributes
     )
+
+  private def toCoursierRepository(resolver: Resolver): coursier.Repository =
+    MavenRepository.apply(resolver.location)
 
   private def getScmUrlOrHomePage(info: Info): Option[Uri] =
     (info.scm.flatMap(_.url).toList :+ info.homePage)

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCache.scala
@@ -26,7 +26,7 @@ final case class RepoCache(
     sha1: Sha1,
     dependencyInfos: List[DependencyInfo],
     maybeRepoConfig: Option[RepoConfig],
-    additionalResolvers: List[Resolver]
+    resolvers: List[Resolver]
 )
 
 object RepoCache {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -47,7 +47,7 @@ final class PruningAlg[F[_]](
           .sorted
         val repoConfig = repoCache.maybeRepoConfig.getOrElse(RepoConfig.default)
         for {
-          updates <- updateAlg.findUpdates(dependencies, repoConfig, repoCache.additionalResolvers)
+          updates <- updateAlg.findUpdates(dependencies, repoCache.resolvers, repoConfig)
           updateStates <- findAllUpdateStates(repo, repoCache, dependencies, updates)
           attentionNeeded <- checkUpdateStates(repo, updateStates)
         } yield attentionNeeded

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -32,12 +32,9 @@ final class UpdateAlg[F[_]](
     versionsCacheAlg: VersionsCacheAlg[F],
     F: Monad[F]
 ) {
-  def findUpdate(
-      dependency: Dependency,
-      additionalResolvers: List[Resolver]
-  ): F[Option[Update.Single]] =
+  def findUpdate(dependency: Dependency, resolvers: List[Resolver]): F[Option[Update.Single]] =
     for {
-      newerVersions0 <- versionsCacheAlg.getNewerVersions(dependency, additionalResolvers)
+      newerVersions0 <- versionsCacheAlg.getNewerVersions(dependency, resolvers)
       maybeUpdate0 = Nel.fromList(newerVersions0).map { newerVersions1 =>
         Update.Single(CrossDependency(dependency), newerVersions1.map(_.value))
       }
@@ -46,8 +43,8 @@ final class UpdateAlg[F[_]](
 
   def findUpdates(
       dependencies: List[Dependency],
-      repoConfig: RepoConfig,
-      resolvers: List[Resolver]
+      resolvers: List[Resolver],
+      repoConfig: RepoConfig
   ): F[List[Update.Single]] =
     for {
       _ <- logger.info(s"Find updates")

--- a/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
+++ b/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
@@ -31,7 +31,7 @@ object StewardPlugin extends AutoPlugin {
     val stewardUpdates =
       taskKey[Unit]("Prints dependency updates as JSON for consumption by Scala Steward.")
     val stewardResolvers =
-      taskKey[Unit]("Resolvers as JSON for consumption by Scala Steward.")
+      taskKey[Unit]("Prints resolvers as JSON for consumption by Scala Steward.")
   }
 
   import autoImport._
@@ -70,9 +70,10 @@ object StewardPlugin extends AutoPlugin {
     },
     stewardResolvers := {
       val log = streams.value.log
-      resolvers.value.toList
+      fullResolvers.value
         .collect {
-          case repo: MavenRepository => Resolver(repo.name, repo.root)
+          case repo: MavenRepository if !repo.root.startsWith("file://") =>
+            Resolver(repo.name, repo.root)
         }
         .map(_.asJson)
         .foreach(s => log.info(s))


### PR DESCRIPTION
This changes two things:

* `stewardResolvers` now uses `fullResolvers` instead of `resolvers`
* `CoursierAlg.getVersions` doesn't use any default resolvers

That means that `getVersions` now uses exactly the same Maven repositories
as used in the build.