### PR TITLE
Don't use default resolvers for finding artifact URL

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -1,7 +1,7 @@
 package org.scalasteward.core.coursier
 
 import org.http4s.syntax.literals._
-import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Resolver}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.sbt.data.{SbtVersion, ScalaVersion}
@@ -9,11 +9,13 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class CoursierAlgTest extends AnyFunSuite with Matchers {
+  val resolvers = List(Resolver("public", "https://repo1.maven.org/maven2/"))
+
   test("getArtifactUrl: library") {
     val dep =
       Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     val (state, result) = coursierAlg
-      .getArtifactUrl(dep)
+      .getArtifactUrl(dep, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
@@ -27,7 +29,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       "2.1.0-M7"
     )
     val (state, result) = coursierAlg
-      .getArtifactUrl(dep)
+      .getArtifactUrl(dep, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
@@ -41,7 +43,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       "0.8.20"
     )
     val (state1, result1) = coursierAlg
-      .getArtifactUrl(dep1)
+      .getArtifactUrl(dep1, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state1 shouldBe MockState.empty
@@ -53,7 +55,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       "9.0.1"
     )
     val (state2, result2) = coursierAlg
-      .getArtifactUrl(dep2)
+      .getArtifactUrl(dep2, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state2 shouldBe MockState.empty
@@ -67,7 +69,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       "1.10.5"
     )
     val (state, result) = coursierAlg
-      .getArtifactUrl(dep)
+      .getArtifactUrl(dep, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
@@ -81,7 +83,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       "0.9.6"
     )
     val (state, result) = coursierAlg
-      .getArtifactUrl(dep)
+      .getArtifactUrl(dep, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
@@ -97,7 +99,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       Some(ScalaVersion("2.12"))
     )
     val (state, result) = coursierAlg
-      .getArtifactUrl(dep)
+      .getArtifactUrl(dep, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty
@@ -112,7 +114,8 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       Some(SbtVersion("1.0")),
       Some(ScalaVersion("2.12"))
     )
-    val (state, result) = coursierAlg.getArtifactUrl(dep).run(MockState.empty).unsafeRunSync()
+    val (state, result) =
+      coursierAlg.getArtifactUrl(dep, resolvers).run(MockState.empty).unsafeRunSync()
     state shouldBe MockState.empty
     result shouldBe Some(uri"https://github.com/sbt/sbt-release")
   }
@@ -123,7 +126,7 @@ class CoursierAlgTest extends AnyFunSuite with Matchers {
       Dependency(GroupId("org.typelevel"), ArtifactId("cats-effect", "cats-effect_2.12"), "1.0.0")
     )
     val (state, result) = coursierAlg
-      .getArtifactIdUrlMapping(dependencies)
+      .getArtifactIdUrlMapping(dependencies, resolvers)
       .run(MockState.empty)
       .unsafeRunSync()
     state shouldBe MockState.empty


### PR DESCRIPTION
The same as #1236 but for `CoursierAlg.getArtifactUrl`.

Prerequisite for #1088.