### PR TITLE
Add the ability to use default reviewers to bitbucket server

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -53,7 +53,8 @@ object Cli {
       processTimeout: FiniteDuration = 10.minutes,
       scalafixMigrations: Option[String] = None,
       cacheTtl: FiniteDuration = 2.hours,
-      cacheMissDelay: FiniteDuration = 0.milliseconds
+      cacheMissDelay: FiniteDuration = 0.milliseconds,
+      useDefaultReviewers: Boolean = false
   )
 
   final case class EnvVar(name: String, value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -24,6 +24,7 @@ import org.http4s.Uri
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli._
 import org.scalasteward.core.util.ApplicativeThrowable
+
 import scala.concurrent.duration._
 
 final class Cli[F[_]](implicit F: ApplicativeThrowable[F]) {
@@ -54,7 +55,7 @@ object Cli {
       scalafixMigrations: Option[String] = None,
       cacheTtl: FiniteDuration = 2.hours,
       cacheMissDelay: FiniteDuration = 0.milliseconds,
-      useDefaultReviewers: Boolean = false
+      bitbucketServerUseDefaultReviewers: Boolean = false
   )
 
   final case class EnvVar(name: String, value: String)

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -24,6 +24,7 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.util
 import org.scalasteward.core.vcs.data.AuthenticatedUser
+
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.process.Process
 
@@ -65,7 +66,7 @@ final case class Config(
     scalafixMigrations: Option[File],
     cacheTtl: FiniteDuration,
     cacheMissDelay: FiniteDuration,
-    useDefaultReviewers: Boolean
+    bitbucketServerUseDefaultReviewers: Boolean
 ) {
   def vcsUser[F[_]](implicit F: Sync[F]): F[AuthenticatedUser] = {
     val urlWithUser = util.uri.withUserInfo.set(UserInfo(vcsLogin, None))(vcsApiHost).renderString
@@ -99,7 +100,7 @@ object Config {
         scalafixMigrations = args.scalafixMigrations.map(_.toFile),
         cacheTtl = args.cacheTtl,
         cacheMissDelay = args.cacheMissDelay,
-        useDefaultReviewers = args.useDefaultReviewers
+        bitbucketServerUseDefaultReviewers = args.bitbucketServerUseDefaultReviewers
       )
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -64,7 +64,8 @@ final case class Config(
     processTimeout: FiniteDuration,
     scalafixMigrations: Option[File],
     cacheTtl: FiniteDuration,
-    cacheMissDelay: FiniteDuration
+    cacheMissDelay: FiniteDuration,
+    useDefaultReviewers: Boolean
 ) {
   def vcsUser[F[_]](implicit F: Sync[F]): F[AuthenticatedUser] = {
     val urlWithUser = util.uri.withUserInfo.set(UserInfo(vcsLogin, None))(vcsApiHost).renderString
@@ -97,7 +98,8 @@ object Config {
         processTimeout = args.processTimeout,
         scalafixMigrations = args.scalafixMigrations.map(_.toFile),
         cacheTtl = args.cacheTtl,
-        cacheMissDelay = args.cacheMissDelay
+        cacheMissDelay = args.cacheMissDelay,
+        useDefaultReviewers = args.useDefaultReviewers
       )
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
@@ -18,12 +18,9 @@ package org.scalasteward.core.bitbucketserver.http4s
 
 import cats.effect.Sync
 import cats.implicits._
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.{Decoder, Encoder}
 import org.http4s.{Request, Uri}
 import org.scalasteward.core.bitbucketserver.http4s.Json.{Reviewer, User}
 import org.scalasteward.core.git.Branch
-import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg
 import org.scalasteward.core.vcs.data.PullRequestState.Open
@@ -34,7 +31,6 @@ import org.scalasteward.core.vcs.data._
   */
 class Http4sBitbucketServerApiAlg[F[_]](
     bitbucketApiHost: Uri,
-    user: AuthenticatedUser,
     modify: Repo => Request[F] => F[Request[F]],
     useReviewers: Boolean
 )(implicit client: HttpJsonClient[F], F: Sync[F])
@@ -119,7 +115,6 @@ final class StashUrls(base: Uri) {
       .withQueryParam("at", head)
       .withQueryParam("limit", "1000")
       .withQueryParam("direction", "outgoing")
-
 
   def branches(r: Repo): Uri = repo(r) / "branches"
 

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
@@ -16,12 +16,13 @@
 
 package org.scalasteward.core.bitbucketserver.http4s
 
-import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.implicits._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import org.http4s.{Request, Uri}
+import org.scalasteward.core.bitbucketserver.http4s.Json.{Reviewer, User}
+import org.scalasteward.core.git.Branch
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.util.HttpJsonClient
 import org.scalasteward.core.vcs.VCSApiAlg
@@ -33,6 +34,7 @@ import org.scalasteward.core.vcs.data._
   */
 class Http4sBitbucketServerApiAlg[F[_]: Sync](
     bitbucketApiHost: Uri,
+    user: AuthenticatedUser,
     modify: Repo => Request[F] => F[Request[F]]
 )(implicit client: HttpJsonClient[F])
     extends VCSApiAlg[F] {
@@ -46,8 +48,9 @@ class Http4sBitbucketServerApiAlg[F[_]: Sync](
     val toRef =
       Json.Ref("refs/heads/" + data.base.name, Json.Repository(repo.repo, Json.Project(repo.owner)))
 
-    val req =
-      Json.NewPR(
+    for {
+      reviewers <- getDefaultReviewers(repo)
+      req = Json.NewPR(
         title = data.title,
         description = data.body,
         state = Open,
@@ -56,13 +59,22 @@ class Http4sBitbucketServerApiAlg[F[_]: Sync](
         fromRef = fromRef,
         toRef = toRef,
         locked = false,
-        reviewers = List.empty
+        reviewers = reviewers
       )
-
-    client
-      .postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify(repo))
-      .map(pr => PullRequestOut(pr.links("self").head.href, pr.state, pr.title))
+      pr <- client.postWithBody[Json.PR, Json.NewPR](url.pullRequests(repo), req, modify(repo))
+    } yield PullRequestOut(pr.links("self").head.href, pr.state, pr.title)
   }
+
+  def getDefaultReviewers(repo: Repo): F[List[Reviewer]] =
+    client
+      .get[List[Json.Condition]](url.reviewers(repo), modify(repo))
+      .map(conditions =>
+        conditions
+          .flatMap(condition =>
+            condition.reviewers
+              .map(reviewer => Reviewer(User(reviewer.name)))
+          )
+      )
 
   override def getBranch(repo: Repo, branch: Branch): F[BranchOut] =
     client
@@ -84,74 +96,26 @@ class Http4sBitbucketServerApiAlg[F[_]: Sync](
 
   def ni(name: String): Nothing = throw new NotImplementedError(name)
 
-  object Json {
-    case class Page[A](values: List[A])
-
-    case class Repo(name: String, forkable: Boolean, project: Project, links: Links)
-
-    case class Project(key: String)
-
-    type Links = Map[String, NonEmptyList[Link]]
-
-    case class Link(href: Uri, name: Option[String])
-
-    case class PR(title: String, state: PullRequestState, links: Links)
-
-    case class NewPR(
-        title: String,
-        description: String,
-        state: PullRequestState,
-        open: Boolean,
-        closed: Boolean,
-        fromRef: Ref,
-        toRef: Ref,
-        locked: Boolean,
-        reviewers: List[Reviewer]
-    )
-
-    case class Ref(id: String, repository: Repository)
-
-    case class Repository(slug: String, project: Project)
-
-    case class Reviewer(user: User)
-
-    case class User(name: String)
-
-    case class Branches(values: NonEmptyList[Branch])
-
-    case class Branch(id: String, latestCommit: Sha1)
-
-    implicit def pageDecode[A: Decoder]: Decoder[Page[A]] = deriveDecoder
-    implicit val repoDecode: Decoder[Repo] = deriveDecoder
-    implicit val projectDecode: Decoder[Project] = deriveDecoder
-    implicit val linkDecoder: Decoder[Link] = deriveDecoder
-    implicit val uriDecoder: Decoder[Uri] = Decoder.decodeString.map(Uri.unsafeFromString)
-    implicit val prDecoder: Decoder[PR] = deriveDecoder
-    implicit val branchDecoder: Decoder[Branch] = deriveDecoder
-    implicit val branchesDecoder: Decoder[Branches] = deriveDecoder
-
-    implicit val encodeNewPR: Encoder[NewPR] = deriveEncoder
-    implicit val encodeRef: Encoder[Ref] = deriveEncoder
-    implicit val encodeRepository: Encoder[Repository] = deriveEncoder
-    implicit val encodeProject: Encoder[Project] = deriveEncoder
-    implicit val encodeReviewer: Encoder[Reviewer] = deriveEncoder
-    implicit val encodeUser: Encoder[User] = deriveEncoder
-  }
 }
 
 final class StashUrls(base: Uri) {
   val api: Uri = base / "rest" / "api" / "1.0"
+  val reviewerApi: Uri = base / "rest" / "default-reviewers" / "1.0"
 
   def repo(repo: Repo): Uri =
     api / "projects" / repo.owner / "repos" / repo.repo
 
   def pullRequests(r: Repo): Uri = repo(r) / "pull-requests"
 
+  def reviewers(repo: Repo): Uri =
+    reviewerApi / "projects" / repo.owner / "repos" / repo.repo / "conditions"
+
   def listPullRequests(r: Repo, head: String): Uri =
     pullRequests(r)
       .withQueryParam("at", head)
       .withQueryParam("limit", "1000")
       .withQueryParam("direction", "outgoing")
+
 
   def branches(r: Repo): Uri = repo(r) / "branches"
 

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Http4sBitbucketServerApiAlg.scala
@@ -33,10 +33,10 @@ import org.scalasteward.core.vcs.data._
   * https://docs.atlassian.com/bitbucket-server/rest/6.6.1/bitbucket-rest.html
   */
 class Http4sBitbucketServerApiAlg[F[_]](
-                                         bitbucketApiHost: Uri,
-                                         user: AuthenticatedUser,
-                                         modify: Repo => Request[F] => F[Request[F]],
-                                         useReviewers: Boolean
+    bitbucketApiHost: Uri,
+    user: AuthenticatedUser,
+    modify: Repo => Request[F] => F[Request[F]],
+    useReviewers: Boolean
 )(implicit client: HttpJsonClient[F], F: Sync[F])
     extends VCSApiAlg[F] {
   val url = new StashUrls(bitbucketApiHost)

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyList
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import org.http4s.Uri
+import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.vcs.data.PullRequestState
 
 object Json {
@@ -59,6 +60,10 @@ object Json {
 
   case class User(name: String)
 
+  case class Branches(values: NonEmptyList[Branch])
+
+  case class Branch(id: String, latestCommit: Sha1)
+
   implicit def pageDecode[A: Decoder]: Decoder[Page[A]] = deriveDecoder
   implicit val repoDecode: Decoder[Repo] = deriveDecoder
   implicit val projectDecode: Decoder[Project] = deriveDecoder
@@ -69,6 +74,8 @@ object Json {
   implicit val userDecoder: Decoder[User] = deriveDecoder
   implicit val defaultReviewerDecoder: Decoder[DefaultReviewer] = deriveDecoder
   implicit val conditionDecoder: Decoder[Condition] = deriveDecoder
+  implicit val branchDecoder: Decoder[Branch] = deriveDecoder
+  implicit val branchesDecoder: Decoder[Branches] = deriveDecoder
 
   implicit val encodeNewPR: Encoder[NewPR] = deriveEncoder
   implicit val encodeRef: Encoder[Ref] = deriveEncoder

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2018-2020 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.scalasteward.core.bitbucketserver.http4s
 
 import cats.data.NonEmptyList
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import org.http4s.Uri
 import org.scalasteward.core.vcs.data.PullRequestState
 
@@ -20,16 +36,16 @@ object Json {
   case class PR(title: String, state: PullRequestState, links: Links)
 
   case class NewPR(
-                    title: String,
-                    description: String,
-                    state: PullRequestState,
-                    open: Boolean,
-                    closed: Boolean,
-                    fromRef: Ref,
-                    toRef: Ref,
-                    locked: Boolean,
-                    reviewers: List[Reviewer]
-                  )
+      title: String,
+      description: String,
+      state: PullRequestState,
+      open: Boolean,
+      closed: Boolean,
+      fromRef: Ref,
+      toRef: Ref,
+      locked: Boolean,
+      reviewers: List[Reviewer]
+  )
 
   case class Ref(id: String, repository: Repository)
 

--- a/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/bitbucketserver/http4s/Json.scala
@@ -1,0 +1,63 @@
+package org.scalasteward.core.bitbucketserver.http4s
+
+import cats.data.NonEmptyList
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import org.http4s.Uri
+import org.scalasteward.core.vcs.data.PullRequestState
+
+object Json {
+  case class Page[A](values: List[A])
+
+  case class Repo(id: Int, name: String, forkable: Boolean, project: Project, links: Links)
+
+  case class Project(key: String)
+
+  type Links = Map[String, NonEmptyList[Link]]
+
+  case class Link(href: Uri, name: Option[String])
+
+  case class PR(title: String, state: PullRequestState, links: Links)
+
+  case class NewPR(
+                    title: String,
+                    description: String,
+                    state: PullRequestState,
+                    open: Boolean,
+                    closed: Boolean,
+                    fromRef: Ref,
+                    toRef: Ref,
+                    locked: Boolean,
+                    reviewers: List[Reviewer]
+                  )
+
+  case class Ref(id: String, repository: Repository)
+
+  case class Repository(slug: String, project: Project)
+
+  case class Condition(reviewers: List[DefaultReviewer])
+
+  case class DefaultReviewer(name: String)
+
+  case class Reviewer(user: User)
+
+  case class User(name: String)
+
+  implicit def pageDecode[A: Decoder]: Decoder[Page[A]] = deriveDecoder
+  implicit val repoDecode: Decoder[Repo] = deriveDecoder
+  implicit val projectDecode: Decoder[Project] = deriveDecoder
+  implicit val linkDecoder: Decoder[Link] = deriveDecoder
+  implicit val uriDecoder: Decoder[Uri] = Decoder.decodeString.map(Uri.unsafeFromString)
+  implicit val prDecoder: Decoder[PR] = deriveDecoder
+  implicit val reviewerDecoder: Decoder[Reviewer] = deriveDecoder
+  implicit val userDecoder: Decoder[User] = deriveDecoder
+  implicit val defaultReviewerDecoder: Decoder[DefaultReviewer] = deriveDecoder
+  implicit val conditionDecoder: Decoder[Condition] = deriveDecoder
+
+  implicit val encodeNewPR: Encoder[NewPR] = deriveEncoder
+  implicit val encodeRef: Encoder[Ref] = deriveEncoder
+  implicit val encodeRepository: Encoder[Repository] = deriveEncoder
+  implicit val encodeProject: Encoder[Project] = deriveEncoder
+  implicit val encodeReviewer: Encoder[Reviewer] = deriveEncoder
+  implicit val encodeUser: Encoder[User] = deriveEncoder
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -46,7 +46,8 @@ class VCSSelection[F[_]: Sync](implicit client: HttpJsonClient[F], user: Authent
 
   private def bitbucketServer(config: Config): Http4sBitbucketServerApiAlg[F] = {
     import org.scalasteward.core.bitbucket.http4s.authentication.addCredentials
-    new Http4sBitbucketServerApiAlg[F](config.vcsApiHost, _ => addCredentials(user))
+
+    new Http4sBitbucketServerApiAlg[F](config.vcsApiHost, user, _ => addCredentials(user), config.useDefaultReviewers)
   }
 
   def getAlg(config: Config): VCSApiAlg[F] = config.vcsType match {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -47,7 +47,12 @@ class VCSSelection[F[_]: Sync](implicit client: HttpJsonClient[F], user: Authent
   private def bitbucketServer(config: Config): Http4sBitbucketServerApiAlg[F] = {
     import org.scalasteward.core.bitbucket.http4s.authentication.addCredentials
 
-    new Http4sBitbucketServerApiAlg[F](config.vcsApiHost, user, _ => addCredentials(user), config.useDefaultReviewers)
+    new Http4sBitbucketServerApiAlg[F](
+      config.vcsApiHost,
+      user,
+      _ => addCredentials(user),
+      config.useDefaultReviewers
+    )
   }
 
   def getAlg(config: Config): VCSApiAlg[F] = config.vcsType match {

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -49,9 +49,8 @@ class VCSSelection[F[_]: Sync](implicit client: HttpJsonClient[F], user: Authent
 
     new Http4sBitbucketServerApiAlg[F](
       config.vcsApiHost,
-      user,
       _ => addCredentials(user),
-      config.useDefaultReviewers
+      config.bitbucketServerUseDefaultReviewers
     )
   }
 

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -47,7 +47,8 @@ object MockContext {
     processTimeout = 10.minutes,
     scalafixMigrations = None,
     cacheTtl = 1.hour,
-    cacheMissDelay = 0.milliseconds
+    cacheMissDelay = 0.milliseconds,
+    useDefaultReviewers = false
   )
 
   implicit val mockEffBracketThrowable: BracketThrowable[MockEff] = Sync[MockEff]

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -48,7 +48,7 @@ object MockContext {
     scalafixMigrations = None,
     cacheTtl = 1.hour,
     cacheMissDelay = 0.milliseconds,
-    useDefaultReviewers = false
+    bitbucketServerUseDefaultReviewers = false
   )
 
   implicit val mockEffBracketThrowable: BracketThrowable[MockEff] = Sync[MockEff]


### PR DESCRIPTION
I added the ability, for bitbucket server only, to use the default reviewers configured in the repository settings.

I just call the default-reviewers API of Bitbucket and add the list of the reviewer to the PR input.

Here the documentation:
https://docs.atlassian.com/bitbucket-server/rest/6.10.0/bitbucket-default-reviewers-rest.html

The feature can be enabled with the flag --use-default-reviewers that by default is set to false.