### PR TITLE
Run sbt in offline mode when querying dependencies

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/SbtAlg.scala
@@ -92,7 +92,7 @@ object SbtAlg {
       override def getDependencies(repo: Repo): F[List[Scope.Dependencies]] =
         for {
           repoDir <- workspaceAlg.repoDir(repo)
-          commands = List(crossStewardDependencies, reloadPlugins, stewardDependencies)
+          commands = List(setOffline, crossStewardDependencies, reloadPlugins, stewardDependencies)
           lines <- exec(sbtCmd(commands), repoDir)
           dependencies = parser.parseDependencies(lines)
           additionalDependencies <- getAdditionalDependencies(repo)

--- a/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/sbt/command.scala
@@ -17,6 +17,7 @@
 package org.scalasteward.core.sbt
 
 object command {
+  val setOffline = "set offline := true"
   val stewardUpdates = "stewardUpdates"
   val stewardDependencies = "stewardDependencies"
   val crossStewardUpdates = s"+ $stewardUpdates"

--- a/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/sbt/SbtAlgTest.scala
@@ -58,7 +58,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "sbt",
           "-batch",
           "-no-colors",
-          s";$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
+          s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
         List("read", s"$repoDir/project/build.properties"),
         List("read", s"$repoDir/.scalafmt.conf")


### PR DESCRIPTION
Scala Steward is still regularly blocked by Maven Central and I'm now
experimenting with a few things that might help reducing traffic. I'd be
surprised if this would make a difference (because sbt shouldn't need to
hit the internet just for printing dependencies) but I'm trying it
nonetheless.