### PR TITLE
should "allow" behave like white list?

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -6,13 +6,13 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 # The only dependencies which match the given pattern are updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
-updates.include  = [ { groupId = "com.example" } ]
+updates.allow  = [ { groupId = "com.example" } ]
 
 # The dependencies which match the given version pattern are updated.
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
-updates.allow  = [ { groupId = "com.example", artifactId="foo", version = "1.1" } ]
+updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1" } ]
 
 # The dependencies which match the given pattern are NOT updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -6,7 +6,13 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 # The only dependencies which match the given pattern are updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
-updates.allow  = [ { groupId = "com.example" } ]
+updates.include  = [ { groupId = "com.example" } ]
+
+# The dependencies which match the given version pattern are updated.
+# Each pattern must have `groupId`, `version` and optional `artifactId`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+# the following example will allow to update foo when version is 1.1.x
+updates.allow  = [ { groupId = "com.example", artifactId="foo", version = "1.1" } ]
 
 # The dependencies which match the given pattern are NOT updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -38,11 +38,8 @@ final case class UpdatesConfig(
     isIncluded(update) *> isAllowed(update) *> isIgnored(update)
 
   private def isIncluded(update: Update.Single): FilterResult = {
-    val includedGroup = include.filter(_.groupId === update.groupId)
-    val includedArtifact = includedGroup
-      .filter(_.artifactId.fold(true)(_ === update.artifactId.name))
-      .filter(_.version.fold(true)(update.nextVersion.startsWith))
-    val isIncluded = include.isEmpty || includedArtifact.nonEmpty
+    lazy val matched = UpdatePattern.findMatch(include, update)
+    val isIncluded = include.isEmpty || matched.byVersion.nonEmpty
     Either.cond(isIncluded, update, NotIncludedByConfig(update))
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -33,7 +33,9 @@ final case class UpdatesConfig(
 
   private def isAllowed(update: Update.Single): FilterResult = {
     val m = UpdatePattern.findMatch(allow, update)
-    if (m.byArtifactId.isEmpty || m.byVersion.nonEmpty) Right(update)
+    val isAllowGroup = allow.isEmpty || allow.filter(_.groupId === update.groupId).nonEmpty
+    val isAllowArtifact = m.byArtifactId.isEmpty || m.byVersion.nonEmpty
+    if (isAllowGroup && isAllowArtifact) Right(update)
     else Left(NotAllowedByConfig(update))
   }
 

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/UpdatesConfig.scala
@@ -21,7 +21,12 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto._
 import io.circe.{Decoder, Encoder}
 import org.scalasteward.core.data.Update
-import org.scalasteward.core.update.FilterAlg.{FilterResult, IgnoredByConfig, NotAllowedByConfig,NotIncludedByConfig}
+import org.scalasteward.core.update.FilterAlg.{
+  FilterResult,
+  IgnoredByConfig,
+  NotAllowedByConfig,
+  NotIncludedByConfig
+}
 
 final case class UpdatesConfig(
     allow: List[UpdatePattern] = List.empty,

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -52,7 +52,7 @@ object FilterAlg {
       case IgnoredGlobally(_)         => "ignored globally"
       case IgnoredByConfig(_)         => "ignored by config"
       case NotAllowedByConfig(_)      => "not allowed by config"
-      case NotIncludedByConfig(_)      => "not included by config"
+      case NotIncludedByConfig(_)     => "not included by config"
       case BadVersions(_)             => "bad versions"
       case NoSuitableNextVersion(_)   => "no suitable next version"
       case VersionOrderingConflict(_) => "version ordering conflict"

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -52,6 +52,7 @@ object FilterAlg {
       case IgnoredGlobally(_)         => "ignored globally"
       case IgnoredByConfig(_)         => "ignored by config"
       case NotAllowedByConfig(_)      => "not allowed by config"
+      case NotIncludedByConfig(_)      => "not included by config"
       case BadVersions(_)             => "bad versions"
       case NoSuitableNextVersion(_)   => "no suitable next version"
       case VersionOrderingConflict(_) => "version ordering conflict"
@@ -61,6 +62,7 @@ object FilterAlg {
   final case class IgnoredGlobally(update: Update.Single) extends RejectionReason
   final case class IgnoredByConfig(update: Update.Single) extends RejectionReason
   final case class NotAllowedByConfig(update: Update.Single) extends RejectionReason
+  final case class NotIncludedByConfig(update: Update.Single) extends RejectionReason
   final case class BadVersions(update: Update.Single) extends RejectionReason
   final case class NoSuitableNextVersion(update: Update.Single) extends RejectionReason
   final case class VersionOrderingConflict(update: Update.Single) extends RejectionReason

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -51,8 +51,8 @@ object FilterAlg {
     def show: String = this match {
       case IgnoredGlobally(_)         => "ignored globally"
       case IgnoredByConfig(_)         => "ignored by config"
+      case VersionPinnedByConfig(_)   => "version is pinned by config"
       case NotAllowedByConfig(_)      => "not allowed by config"
-      case NotIncludedByConfig(_)     => "not included by config"
       case BadVersions(_)             => "bad versions"
       case NoSuitableNextVersion(_)   => "no suitable next version"
       case VersionOrderingConflict(_) => "version ordering conflict"
@@ -61,8 +61,8 @@ object FilterAlg {
 
   final case class IgnoredGlobally(update: Update.Single) extends RejectionReason
   final case class IgnoredByConfig(update: Update.Single) extends RejectionReason
+  final case class VersionPinnedByConfig(update: Update.Single) extends RejectionReason
   final case class NotAllowedByConfig(update: Update.Single) extends RejectionReason
-  final case class NotIncludedByConfig(update: Update.Single) extends RejectionReason
   final case class BadVersions(update: Update.Single) extends RejectionReason
   final case class NoSuitableNextVersion(update: Update.Single) extends RejectionReason
   final case class VersionOrderingConflict(update: Update.Single) extends RejectionReason

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -25,7 +25,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
 
     config shouldBe RepoConfig(
       updates = UpdatesConfig(
-        allow = List(UpdatePattern(GroupId("eu.timepit"),None, None)),
+        allow = List(UpdatePattern(GroupId("eu.timepit"), None, None)),
         pin = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), Some("0.8."))),
         ignore = List(UpdatePattern(GroupId("org.acme"), None, Some("1.0"))),
         limit = Some(4)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -15,7 +15,8 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
     val content =
-      """|updates.allow  = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
+      """|updates.allow  = [ { groupId = "eu.timepit"} ]
+         |updates.pin  = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
          |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
          |updates.limit = 4
          |""".stripMargin
@@ -24,7 +25,8 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
 
     config shouldBe RepoConfig(
       updates = UpdatesConfig(
-        allow = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), Some("0.8."))),
+        allow = List(UpdatePattern(GroupId("eu.timepit"),None, None)),
+        pin = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), Some("0.8."))),
         ignore = List(UpdatePattern(GroupId("org.acme"), None, Some("1.0"))),
         limit = Some(4)
       )

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -71,13 +71,13 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     )
   }
 
-  test("ignore update via config updates.allow") {
+  test("ignore update via config updates.pin") {
     val update1 = Single("org.http4s" % "http4s-dsl" % "0.17.0", Nel.of("0.18.0"))
     val update2 = Single("eu.timepit" % "refined" % "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
       updates = UpdatesConfig(
-        allow = List(
+        pin = List(
           UpdatePattern(update1.groupId, None, Some("0.17")),
           UpdatePattern(update2.groupId, Some("refined"), Some("0.8"))
         )
@@ -92,7 +92,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     filtered shouldBe List(update2)
   }
 
-  test("ignore update via config updates.include") {
+  test("ignore update via config updates.allow") {
     val included = List(
       Single("org.my1" % "artifact" % "0.8.0", Nel.of("0.8.1")),
       Single("org.my2" % "artifact" % "0.8.0", Nel.of("0.8.1")),
@@ -106,7 +106,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
 
     val config = RepoConfig(
       updates = UpdatesConfig(
-        include = List(
+        allow = List(
           UpdatePattern(GroupId("org.my1"), None, Some("0.8")),
           UpdatePattern(GroupId("org.my2"), None, None),
           UpdatePattern(GroupId("org.my3"), Some("artifact"), None)

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -74,6 +74,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   test("ignore update via config updates.allow") {
     val update1 = Single("org.http4s" % "http4s-dsl" % "0.17.0", Nel.of("0.18.0"))
     val update2 = Single("eu.timepit" % "refined" % "0.8.0", Nel.of("0.8.1"))
+    val shouldNotAllow = Single("abc.def" % "ghi" % "0.8.0", Nel.of("0.8.1"))
 
     val config = RepoConfig(
       updates = UpdatesConfig(
@@ -85,7 +86,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     )
 
     val filtered = filterAlg
-      .localFilterMany(config, List(update1, update2))
+      .localFilterMany(config, List(update1, update2, shouldNotAllow))
       .runA(MockState.empty)
       .unsafeRunSync()
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -96,18 +96,18 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val included = List(
       Single("org.my1" % "artifact" % "0.8.0", Nel.of("0.8.1")),
       Single("org.my2" % "artifact" % "0.8.0", Nel.of("0.8.1")),
-      Single("org.my2" % "artifact" % "0.8.0", Nel.of("0.9.1")),
+      Single("org.my2" % "artifact" % "0.8.0", Nel.of("0.9.1"))
     )
     val notIncluded = List(
       Single("org.http4s" % "http4s-dsl" % "0.17.0", Nel.of("0.18.0")),
       Single("org.my1" % "artifact" % "0.8.0", Nel.of("0.9.1")),
-      Single("org.my3" % "abc" % "0.8.0", Nel.of("0.8.1")),
+      Single("org.my3" % "abc" % "0.8.0", Nel.of("0.8.1"))
     )
 
     val config = RepoConfig(
       updates = UpdatesConfig(
         include = List(
-          UpdatePattern(GroupId("org.my1") , None, Some("0.8")),
+          UpdatePattern(GroupId("org.my1"), None, Some("0.8")),
           UpdatePattern(GroupId("org.my2"), None, None),
           UpdatePattern(GroupId("org.my3"), Some("artifact"), None)
         )


### PR DESCRIPTION
The behavior of "allow" really confuse me, in document:
```properties
# The only dependencies which match the given pattern are updated.
# Each pattern must have `groupId`, and may have `artifactId` and `version`.
# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
updates.allow  = [ { groupId = "com.example" } ]
```
> The only dependencies which match the given pattern are updated.

I thought it should filler out everything else not in the "allow" list

But the current behavior is
When there are 3 artifacts
```scala
    val update1 = Single("org.http4s" % "http4s-dsl" % "0.17.0", Nel.of("0.18.0"))
    val update2 = Single("eu.timepit" % "refined" % "0.8.0", Nel.of("0.8.1"))
    val shouldNotAllow = Single("abc.def" % "ghi" % "0.8.0", Nel.of("0.8.1"))
```
And the rules is
```
        allow = List(
          UpdatePattern(update1.groupId, None, Some("0.17")),
          UpdatePattern(update2.groupId, Some("refined"), Some("0.8"))
        )
```
the artifacts after filter is `update1` and `shouldNotAllow`

but the group id of `sholdNotAllow` is not even listed in the allow list.

while my expectation is aligned with the doc, only `update2` should get update