### PR TITLE
Bugfix: wrong Gitlab project URL

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -66,7 +66,7 @@ private[http4s] object GitlabJsonCodec {
       owner <- c
         .downField("owner")
         .as[UserOut]
-        .orElse(c.downField("namespace").downField("name").as[String].map(UserOut(_)))
+        .orElse(c.downField("namespace").downField("full_path").as[String].map(UserOut(_)))
       cloneUrl <- c.downField("http_url_to_repo").as[Uri]
       parent <- c
         .downField("forked_from_project")

--- a/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlgTest.scala
@@ -185,7 +185,7 @@ class Http4sGitlabApiAlgTest extends AnyFunSuite with Matchers {
         "last_activity_at": "2019-05-20T04:31:10.797Z",
         "namespace": {
           "id": 5239389,
-          "name": "foo",
+          "name": "foo description",
           "path": "foo",
           "kind": "user",
           "full_path": "foo",


### PR DESCRIPTION
I have a project (Gitlab) which is currently resolved by scala-steward as follows 
```
https://gitlab.redacted.com/api/v4/projects/Redacted%20Products%2Fsome-service/repository/branches/master
```
which results in a `org.scalasteward.core.util.UnexpectedResponse` with 404.
The correct url should be 
```
https://gitlab.redacted.com/api/v4/projects/redacted%2Fsome-service/repository/branches/master
```

The Gitlab `/project/:id` response from the API looks as follows:
```
{ 
  "id":10,
  "name":"Redacted Products",
  "path":"redacted",
  "kind":"group",
  "full_path":"redacted",
  "parent_id":null,
  "avatar_url":"/uploads/-/system/group/avatar/10/redacted.png",
  "web_url":"https://gitlab.redacted.com/groups/redacted"
}
```

Currently, Scala Steward looks for the path of the project under `name`, but it should actually be looking under `full_path`. This MR adresses that issue, by changing the field where Scala Steward looks for the project path.

Fixes https://github.com/fthomas/scala-steward/issues/1263