### PR TITLE
Cache versions again

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -22,7 +22,7 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.Client
 import org.http4s.client.asynchttpclient.AsyncHttpClient
-import org.scalasteward.core.coursier.{CoursierAlg, VersionsCacheFacade}
+import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -69,13 +69,9 @@ object Context {
       implicit val pullRequestRepository: PullRequestRepository[F] =
         new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "1"))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
-      implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create(config.cacheTtl)
-      implicit val versionsCacheAlg: VersionsCacheFacade[F] =
-        new VersionsCacheFacade[F](
-          config.cacheTtl,
-          config.cacheMissDelay,
-          new JsonKeyValueStore("versions", "2")
-        )
+      implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create
+      implicit val versionsCache: VersionsCache[F] =
+        new VersionsCache[F](config.cacheTtl, new JsonKeyValueStore("versions", "3"))
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Resolver.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Resolver.scala
@@ -20,8 +20,17 @@ import cats.Order
 import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.semiauto._
+import org.scalasteward.core.data.Resolver._
 
-sealed trait Resolver extends Product with Serializable
+sealed trait Resolver extends Product with Serializable {
+  val path: String = {
+    val url = this match {
+      case MavenRepository(_, location) => location
+      case IvyRepository(_, pattern)    => pattern.takeWhile(!Set('[', '(')(_))
+    }
+    url.replace(":", "")
+  }
+}
 
 object Resolver {
   final case class MavenRepository(name: String, location: String) extends Resolver

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -18,7 +18,7 @@ package org.scalasteward.core.update
 
 import cats.Monad
 import cats.implicits._
-import org.scalasteward.core.coursier.VersionsCacheFacade
+import org.scalasteward.core.coursier.VersionsCache
 import org.scalasteward.core.data._
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.update.UpdateAlg._
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 final class UpdateAlg[F[_]](
     implicit
     filterAlg: FilterAlg[F],
-    versionsCache: VersionsCacheFacade[F],
+    versionsCache: VersionsCache[F],
     F: Monad[F]
 ) {
   def findUpdate(

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -4,10 +4,10 @@ import better.files.File
 import cats.Parallel
 import cats.effect.Sync
 import org.http4s.Uri
-import org.scalasteward.core.TestInstances.{ioContextShift, ioTimer}
+import org.scalasteward.core.TestInstances.ioContextShift
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.{Config, SupportedVCS}
-import org.scalasteward.core.coursier.{CoursierAlg, VersionsCacheFacade}
+import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.{Author, GitAlg}
 import org.scalasteward.core.io.{MockFileAlg, MockProcessAlg, MockWorkspaceAlg}
@@ -57,7 +57,7 @@ object MockContext {
   implicit val processAlg: MockProcessAlg = new MockProcessAlg
   implicit val workspaceAlg: MockWorkspaceAlg = new MockWorkspaceAlg
 
-  implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create(config.cacheTtl)
+  implicit val coursierAlg: CoursierAlg[MockEff] = CoursierAlg.create
   implicit val dateTimeAlg: DateTimeAlg[MockEff] = DateTimeAlg.create
   implicit val gitAlg: GitAlg[MockEff] = GitAlg.create
   implicit val user: AuthenticatedUser = AuthenticatedUser("scala-steward", "token")
@@ -67,12 +67,8 @@ object MockContext {
   implicit val cacheRepository: RepoCacheRepository[MockEff] =
     new RepoCacheRepository[MockEff](new JsonKeyValueStore("repo_cache", "1"))
   implicit val filterAlg: FilterAlg[MockEff] = new FilterAlg[MockEff]
-  implicit val versionsCacheAlg: VersionsCacheFacade[MockEff] =
-    new VersionsCacheFacade[MockEff](
-      config.cacheTtl,
-      config.cacheMissDelay,
-      new JsonKeyValueStore("versions", "1")
-    )
+  implicit val versionsCacheAlg: VersionsCache[MockEff] =
+    new VersionsCache[MockEff](config.cacheTtl, new JsonKeyValueStore("versions", "1"))
   implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
   implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -28,7 +28,6 @@ exec java -DROOT_LOG_LEVEL=INFO -DLOG_LEVEL=INFO -jar ${JAR} \
   --env-var "SBT_OPTS=-Xmx2048m -Xss8m -XX:MaxMetaspaceSize=512m" \
   --sign-commits \
   --cache-ttl 6hours \
-  --cache-miss-delay 1second \
   --process-timeout 20min \
   --whitelist $HOME/.cache/coursier \
   --whitelist $HOME/.coursier \


### PR DESCRIPTION
Versions are now again cached by `VersionsCache` to better control when
a request to a remote repository happens (see https://github.com/fthomas/scala-steward/pull/1259#issuecomment-579591682 for a reason why we want to do this).

This partly reverts the changes of https://github.com/fthomas/scala-steward/pull/1241.
An improvement over the last time we cached the versions ourself is that
we are now taking resolvers into account. Ignoring resolvers was one of
the main motivations for creating #1241 in the first place.