### PR TITLE
Add Git repo manager as prefix to key value stores

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -51,6 +51,7 @@ object Context {
       implicit0(httpExistenceClient: HttpExistenceClient[F]) <- HttpExistenceClient.create[F]
       implicit0(user: AuthenticatedUser) <- Resource.liftF(config.vcsUser[F])
     } yield {
+      val kvsPrefix = Some(config.vcsType.asString)
       implicit val dateTimeAlg: DateTimeAlg[F] = DateTimeAlg.create[F]
       implicit val fileAlg: FileAlg[F] = FileAlg.create[F]
       implicit val processAlg: ProcessAlg[F] = ProcessAlg.create[F](blocker)
@@ -60,22 +61,22 @@ object Context {
       implicit val gitAlg: GitAlg[F] = GitAlg.create[F]
       implicit val httpJsonClient: HttpJsonClient[F] = new HttpJsonClient[F]
       implicit val repoCacheRepository: RepoCacheRepository[F] =
-        new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "4"))
+        new RepoCacheRepository[F](new JsonKeyValueStore("repo_cache", "1", kvsPrefix))
       implicit val selfCheckAlg: SelfCheckAlg[F] = new SelfCheckAlg[F]
       val vcsSelection = new VCSSelection[F]
       implicit val vcsApiAlg: VCSApiAlg[F] = vcsSelection.getAlg(config)
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
       implicit val vcsExtraAlg: VCSExtraAlg[F] = VCSExtraAlg.create[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
-        new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "1"))
+        new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "1", kvsPrefix))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create
       implicit val versionsCache: VersionsCache[F] =
-        new VersionsCache[F](config.cacheTtl, new JsonKeyValueStore("versions", "3"))
+        new VersionsCache[F](config.cacheTtl, new JsonKeyValueStore("versions", "1"))
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
-        new RefreshErrorAlg[F](new JsonKeyValueStore("refresh_error", "1"))
+        new RefreshErrorAlg[F](new JsonKeyValueStore("refresh_error", "1", kvsPrefix))
       implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F]
       implicit val migrationAlg: MigrationAlg[F] = MigrationAlg.create[F]
       implicit val editAlg: EditAlg[F] = new EditAlg[F]

--- a/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/persistence/JsonKeyValueStoreTest.scala
@@ -16,9 +16,9 @@ class JsonKeyValueStoreTest extends AnyFunSuite with Matchers {
     } yield (v1, v3)
     val (state, value) = p.run(MockState.empty).unsafeRunSync()
 
-    val k1File = config.workspace / "store" / "test_v0" / "k1" / "test.json"
-    val k2File = config.workspace / "store" / "test_v0" / "k2" / "test.json"
-    val k3File = config.workspace / "store" / "test_v0" / "k3" / "test.json"
+    val k1File = config.workspace / "store" / "test" / "v0" / "k1" / "test.json"
+    val k2File = config.workspace / "store" / "test" / "v0" / "k2" / "test.json"
+    val k3File = config.workspace / "store" / "test" / "v0" / "k3" / "test.json"
     value shouldBe (Some("v1") -> None)
     state shouldBe MockState.empty.copy(
       commands = Vector(


### PR DESCRIPTION
This allows the same workspace to be used for multiple Scala Steward
instances that use different Git repo manager.