### PR TITLE
Support version suffixes in `UpdatePattern`

### DIFF
--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -5,11 +5,15 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 ```properties
 # The only dependencies which match the given pattern are updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# The version is treated as a prefix of the new version, unless it starts with
+# ".*" then it is treated as a suffix.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 updates.allow  = [ { groupId = "com.example" } ]
 
 # The dependencies which match the given pattern are NOT updated.
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# The version is treated as a prefix of the new version, unless it starts with
+# ".*" then it is treated as a suffix.
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -6,8 +6,6 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 # Only these dependencies which match the given patterns are updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
-# The version is treated as a prefix of the new version, unless it starts with
-# ".*" then it is treated as a suffix.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 updates.allow  = [ { groupId = "com.example" } ]
 
@@ -17,13 +15,11 @@ updates.allow  = [ { groupId = "com.example" } ]
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
-updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1" } ]
+updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." } ]
 
 # The dependencies which match the given pattern are NOT updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
-# The version is treated as a prefix of the new version, unless it starts with
-# ".*" then it is treated as a suffix.
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
@@ -39,6 +35,17 @@ updates.limit = 5
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
 updatePullRequests = "always" | "on-conflicts" | "never"
+```
+
+The version information given in the patterns above can be in two formats:
+1. just a `version` field that is treated as a prefix of the version
+2. a structure consisting of `prefix` and / or `suffix` that are matched against the beginning or the end of the version
+
+```properties
+version = "1.1."
+version = { prefix = "1.1." }
+version = { suffix = "jre8" }
+version = { prefix = "1.1.", suffix = "jre8" }
 ```
 
 ## Ignore lines

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -69,7 +69,7 @@ object FilterAlg {
       .flatMap(checkVersionOrdering)
 
   private def localFilter(update: Update.Single, repoConfig: RepoConfig): FilterResult =
-    globalFilter(update).flatMap(repoConfig.updates.keep)
+    repoConfig.updates.keep(update).flatMap(globalFilter)
 
   def isIgnoredGlobally(dependency: Dependency): Boolean =
     ((dependency.groupId.value, dependency.artifactId.name) match {
@@ -146,6 +146,7 @@ object FilterAlg {
           // https://github.com/scala-js/scala-js/issues/3865
           "0.6.30"
         ).contains
-      case _ => _ => false
+      case _ =>
+        _ => false
     }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -16,7 +16,12 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"
     val content =
       """|updates.allow  = [ { groupId = "eu.timepit"} ]
-         |updates.pin  = [ { groupId = "eu.timepit", artifactId = "refined", version = "0.8." } ]
+         |updates.pin  = [
+         |                 { groupId = "eu.timepit", artifactId = "refined.1", version = "0.8." },
+         |                 { groupId = "eu.timepit", artifactId = "refined.2", version = { prefix="0.8." } },
+         |                 { groupId = "eu.timepit", artifactId = "refined.3", version = { suffix="jre" } },
+         |                 { groupId = "eu.timepit", artifactId = "refined.4", version = { prefix="0.8.", suffix="jre" } }
+         |               ]
          |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
          |updates.limit = 4
          |""".stripMargin
@@ -26,8 +31,31 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     config shouldBe RepoConfig(
       updates = UpdatesConfig(
         allow = List(UpdatePattern(GroupId("eu.timepit"), None, None)),
-        pin = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), Some("0.8."))),
-        ignore = List(UpdatePattern(GroupId("org.acme"), None, Some("1.0"))),
+        pin = List(
+          UpdatePattern(
+            GroupId("eu.timepit"),
+            Some("refined.1"),
+            Some(UpdatePattern.Version(Some("0.8."), None))
+          ),
+          UpdatePattern(
+            GroupId("eu.timepit"),
+            Some("refined.2"),
+            Some(UpdatePattern.Version(Some("0.8."), None))
+          ),
+          UpdatePattern(
+            GroupId("eu.timepit"),
+            Some("refined.3"),
+            Some(UpdatePattern.Version(None, Some("jre")))
+          ),
+          UpdatePattern(
+            GroupId("eu.timepit"),
+            Some("refined.4"),
+            Some(UpdatePattern.Version(Some("0.8."), Some("jre")))
+          )
+        ),
+        ignore = List(
+          UpdatePattern(GroupId("org.acme"), None, Some(UpdatePattern.Version(Some("1.0"), None)))
+        ),
         limit = Some(4)
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -78,8 +78,12 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val config = RepoConfig(
       updates = UpdatesConfig(
         pin = List(
-          UpdatePattern(update1.groupId, None, Some("0.17")),
-          UpdatePattern(update2.groupId, Some("refined"), Some("0.8"))
+          UpdatePattern(update1.groupId, None, Some(UpdatePattern.Version(Some("0.17"), None))),
+          UpdatePattern(
+            update2.groupId,
+            Some("refined"),
+            Some(UpdatePattern.Version(Some("0.8"), None))
+          )
         )
       )
     )
@@ -107,7 +111,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val config = RepoConfig(
       updates = UpdatesConfig(
         allow = List(
-          UpdatePattern(GroupId("org.my1"), None, Some("0.8")),
+          UpdatePattern(GroupId("org.my1"), None, Some(UpdatePattern.Version(Some("0.8"), None))),
           UpdatePattern(GroupId("org.my2"), None, None),
           UpdatePattern(GroupId("org.my3"), Some("artifact"), None)
         )
@@ -132,7 +136,11 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val config = RepoConfig(
       updates = UpdatesConfig(
         pin = List(
-          UpdatePattern(update.groupId, Some(update.artifactId.name), Some(".*jre8"))
+          UpdatePattern(
+            update.groupId,
+            Some(update.artifactId.name),
+            Some(UpdatePattern.Version(None, Some("jre8")))
+          )
         )
       )
     )
@@ -155,7 +163,11 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
     val config = RepoConfig(
       updates = UpdatesConfig(
         ignore = List(
-          UpdatePattern(update.groupId, Some(update.artifactId.name), Some(".*jre11"))
+          UpdatePattern(
+            update.groupId,
+            Some(update.artifactId.name),
+            Some(UpdatePattern.Version(None, Some("jre11")))
+          )
         )
       )
     )
@@ -166,5 +178,32 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
       .unsafeRunSync()
 
     filtered shouldBe List(update.copy(newerVersions = Nel.of("7.3.0.jre8")))
+  }
+
+  test("ignore update via config updates.pin using prefix and suffix") {
+    val update =
+      Single(
+        "com.microsoft.sqlserver" % "mssql-jdbc" % "7.2.2.jre8",
+        Nel.of("7.2.2.jre11", "7.3.0.jre8", "7.3.0.jre11")
+      )
+
+    val config = RepoConfig(
+      updates = UpdatesConfig(
+        pin = List(
+          UpdatePattern(
+            update.groupId,
+            Some(update.artifactId.name),
+            Some(UpdatePattern.Version(Some("7.2."), Some("jre8")))
+          )
+        )
+      )
+    )
+
+    val filtered = filterAlg
+      .localFilterMany(config, List(update))
+      .runA(MockState.empty)
+      .unsafeRunSync()
+
+    filtered shouldBe List()
   }
 }


### PR DESCRIPTION
This PR implements the idea proposed by @fthomas in a [comment](https://github.com/fthomas/scala-steward/issues/1038#issuecomment-543178540) to issue #1038:

> `UpdatePattern`, which is used for `.scala-steward.conf`, allows to match versions but only via `startsWith`. In this case we want to match a version if it ends with `jre8`. I would propose to change the version matching code to `endsWith` when `UpdatePattern.version` starts with `.*`.

After finishing this I realised one shortcoming: it is not possible to restrict  for the same artefact the prefix and the suffix. E.g pin a major version and enforce `jre8`. One solution would be to use `.*` as a separator between prefix and suffix, e.g. `7..*jre8` (there are 2 dots so it matches only against version 7 and not against version 70)

fixes #1038 