### PR TITLE
Improve the wording of the documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ You can control the update of individual dependencies or of all dependencies
 belonging to a group by specifying version prefixes for them:
 
 ```properties
-updates.allow = [
+updates.pin = [
   # Allow x.y to x.(y+1), but not to (x+1).y
   { groupId = "a.group.id", artifactId="a.name", version="x." },
   # Allow x.y.z to x.y.(z+1), but not to x.(y+1)

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -3,18 +3,22 @@
 You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward updates your repository.
 
 ```properties
-# The only dependencies which match the given pattern are updated.
+# Only these dependencies which match the given patterns are updated.
+#
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 updates.allow  = [ { groupId = "com.example" } ]
 
 # The dependencies which match the given version pattern are updated.
+# Dependencies that are not listed will be updated.
+#
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1" } ]
 
 # The dependencies which match the given pattern are NOT updated.
+#
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]


### PR DESCRIPTION
Improve the wording of the documentation after the merge of #1254

The FAQ entry  added in #1275 should mention `pin` not `allow` after  #1229 

I tried to rephrase the docs in the `Repository-specific configuration`. 
Feel free to ignore or further change them. 