### PR TITLE
Mergify: method squash, strict mode, add travis legacy comment

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,10 @@ pull_request_rules:
     conditions:
       - author=scala-steward
       - status-success=Travis CI - Pull Request
+      # or, using the legacy travis-ci.org service:
+      # - status-success=continuous-integration/travis-ci/pr
     actions:
       merge:
-        method: merge
+        method: squash
+        strict: true
+


### PR DESCRIPTION
I just installed mergify on my own repos and figured out, that the file here didn't work for me, because I still used the legacy version of travis. The added comment would have saved me some time.

Furthermore I think it makes sense to:
- enable strict merging (https://doc.mergify.io/merge-action.html?highlight=strict#strict-merge)
- set the merge method to squash to avoid unnecessary merge bubbles in the commit history