### PR TITLE
Implement getBranch for bitbucket server

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/VCSSelection.scala
@@ -46,7 +46,7 @@ class VCSSelection[F[_]: Sync](implicit client: HttpJsonClient[F], user: Authent
 
   private def bitbucketServer(config: Config): Http4sBitbucketServerApiAlg[F] = {
     import org.scalasteward.core.bitbucket.http4s.authentication.addCredentials
-    new Http4sBitbucketServerApiAlg[F](config.vcsApiHost, user, _ => addCredentials(user))
+    new Http4sBitbucketServerApiAlg[F](config.vcsApiHost, _ => addCredentials(user))
   }
 
   def getAlg(config: Config): VCSApiAlg[F] = config.vcsType match {


### PR DESCRIPTION
Hi,

In this PR I implemented the getBranch method into the Bitbucket Server algebra that since now was throwing a NotImplemented exception.

I changed the `UserOut(user.login)` to `UserOut(repo.owner)` because in Bitbucket server the repo owner is not the username but the project name and this impact on the URI generation.

Thanks, Andrea

