### PR TITLE
Allow editing all .yml files and not only .travis.yml

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/io/package.scala
@@ -35,11 +35,10 @@ package object io {
 
   private def isGenericSourceFile(file: File): Boolean = {
     val name = file.name
-    val allowedByExtension = file.extension.exists(Set(".scala", ".sbt", ".sc"))
-    def allowedByName: Boolean = Set(".travis.yml").contains(name)
+    val allowedByExtension = file.extension.exists(Set(".scala", ".sbt", ".sc", ".yml"))
     def allowedBySuffix: Boolean =
       Set(".sbt.shared").exists(suffix => name.endsWith(suffix) && !name.startsWith(suffix))
-    allowedByExtension || allowedByName || allowedBySuffix
+    allowedByExtension || allowedBySuffix
   }
 
   private def isSbtUpdate(update: Update): Boolean =


### PR DESCRIPTION
There is no good reason to edit only `.travis.yml` files bot not other
YAML files that are used by other CI providers like CircleCI or GitHub
Actions.