### PR TITLE
Fix Gitlab repository url generation

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/gitlab/http4s/Http4sGitlabApiAlg.scala
@@ -62,7 +62,7 @@ private[http4s] object GitlabJsonCodec {
   }
   implicit val repoOutDecoder: Decoder[RepoOut] = Decoder.instance { c =>
     for {
-      name <- c.downField("name").as[String]
+      name <- c.downField("path").as[String]
       owner <- c
         .downField("owner")
         .as[UserOut]


### PR DESCRIPTION
The slug used to be picked from the `name` key in the `https://gitlab.com/api/v4/projects/:project_id` response, however this path refers to the human-readable name and not the actual slug, which is the `path` key (see image below)

This MR fixes it.

![image](https://user-images.githubusercontent.com/6578011/74345413-5ee5fb00-4dae-11ea-96f6-ed988c5fe5be.png)

Edit: a little more context, when trying to start the project on a Gitlab instance, the URL generation for the default branch would yield an incorrect result because it would try to build it from the human-readable name, see the log below

```
[info] 2020-02-12 15:09:12,176 INFO   
[info]   ____            _         ____  _                             _
[info]  / ___|  ___ __ _| | __ _  / ___|| |_ _____      ____ _ _ __ __| |
[info]  \___ \ / __/ _` | |/ _` | \___ \| __/ _ \ \ /\ / / _` | '__/ _` |
[info]   ___) | (_| (_| | | (_| |  ___) | ||  __/\ V  V / (_| | | | (_| |
[info]  |____/ \___\__,_|_|\__,_| |____/ \__\___| \_/\_/ \__,_|_|  \__,_|
[info]  v0.5.0-225-2147c92e-SNAPSHOT
[info]  
[info] 2020-02-12 15:09:12,184 INFO  Run self checks
[info] 2020-02-12 15:09:13,525 INFO  Add global sbt plugins
[info] 2020-02-12 15:09:13,552 INFO  Clean workspace /home/victor/tmp/scala-steward
[info] 2020-02-12 15:09:13,657 INFO  ──────────── Steward victor.viale/phone-number-locator ────────────
[info] 2020-02-12 15:09:13,661 INFO  Check cache of victor.viale/phone-number-locator
[info] 2020-02-12 15:09:14,474 ERROR Check cache of victor.viale/phone-number-locator failed
vvvvvvvv
[info] org.scalasteward.core.util.UnexpectedResponse: uri: https://<my gitlab instance>/api/v4/projects/victor.viale%2FPhone%20Number%20Locator/repository/branches/master
^^^^^^^^
[info] method: GET
[info] status: 404 Not Found
[info] headers: Headers(Server: nginx, Date: Wed, 12 Feb 2020 14:09:14 GMT, Content-Type: application/json, Content-Length: 35, Connection: keep-alive, Cache-Control: no-cache, Vary: Origin, X-Content-Type-Options: nosniff, X-Frame-Options: SAMEORIGIN, X-Request-Id: RlDDX80vtt8, X-Runtime: 0.024397)
[info] body: {"message":"404 Project Not Found"}

```
