### PR TITLE
Remove duplicated versions in VersionsCache

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/coursier/VersionsCache.scala
@@ -40,7 +40,7 @@ final class VersionsCache[F[_]](
   def getVersions(dependency: Scope.Dependency, maxAge: Option[FiniteDuration]): F[List[Version]] =
     dependency.resolvers
       .parFlatTraverse(getVersionsImpl(dependency.value, _, maxAge.getOrElse(cacheTtl)))
-      .map(_.sorted)
+      .map(_.distinct.sorted)
 
   private def getVersionsImpl(
       dependency: Dependency,


### PR DESCRIPTION
The list of versions can contain duplicates if the dependency is provided
by two or more resolvers.