### PR TITLE
Store timestamp when a PullRequestData is created

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -72,7 +72,7 @@ object Context {
       implicit val vcsRepoAlg: VCSRepoAlg[F] = VCSRepoAlg.create[F](config, gitAlg)
       implicit val vcsExtraAlg: VCSExtraAlg[F] = VCSExtraAlg.create[F]
       implicit val pullRequestRepository: PullRequestRepository[F] =
-        new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "1", kvsPrefix))
+        new PullRequestRepository[F](new JsonKeyValueStore("pull_requests", "2", kvsPrefix))
       implicit val scalafmtAlg: ScalafmtAlg[F] = ScalafmtAlg.create[F]
       implicit val coursierAlg: CoursierAlg[F] = CoursierAlg.create[F]
       implicit val versionsCache: VersionsCache[F] =

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -114,7 +114,7 @@ final class PruningAlg[F[_]](
         pullRequestRepository.findPullRequest(repo, crossDependency, update.nextVersion).map {
           case None =>
             DependencyOutdated(crossDependency, update)
-          case Some((uri, _, state)) if state === Closed =>
+          case Some((uri, _, Closed)) =>
             PullRequestClosed(crossDependency, update, uri)
           case Some((uri, baseSha1, _)) if baseSha1 === repoCache.sha1 =>
             PullRequestUpToDate(crossDependency, update, uri)

--- a/modules/core/src/main/scala/org/scalasteward/core/util/DateTimeAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/DateTimeAlg.scala
@@ -16,14 +16,17 @@
 
 package org.scalasteward.core.util
 
-import cats.Monad
 import cats.effect.Sync
 import cats.implicits._
+import cats.{Functor, Monad}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 trait DateTimeAlg[F[_]] {
   def currentTimeMillis: F[Long]
+
+  final def currentTimestamp(implicit F: Functor[F]): F[Timestamp] =
+    currentTimeMillis.map(Timestamp.apply)
 
   final def timed[A](fa: F[A])(implicit F: Monad[F]): F[(A, FiniteDuration)] =
     for {

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -14,23 +14,14 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.nurture
+package org.scalasteward.core.util
 
 import io.circe.Codec
-import io.circe.generic.semiauto._
-import org.scalasteward.core.data.Update
-import org.scalasteward.core.git.Sha1
-import org.scalasteward.core.util.Timestamp
-import org.scalasteward.core.vcs.data.PullRequestState
+import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
 
-final case class PullRequestData(
-    baseSha1: Sha1,
-    update: Update,
-    state: PullRequestState,
-    entryCreatedAt: Timestamp
-)
+final case class Timestamp(millis: Long)
 
-object PullRequestData {
-  implicit val pullRequestDataCodec: Codec[PullRequestData] =
-    deriveCodec
+object Timestamp {
+  implicit val timestampCodec: Codec[Timestamp] =
+    deriveUnwrappedCodec
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -28,41 +28,11 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
 
     val store = (config.workspace / "store/pull_requests/v1/typelevel/cats/pull_requests.json")
     result shouldBe Some((url, sha1, PullRequestState.Open))
-    state shouldBe MockState.empty.copy(
+    state.copy(files = Map.empty) shouldBe MockState.empty.copy(
       commands = Vector(
         List("read", store.toString),
         List("write", store.toString),
         List("read", store.toString)
-      ),
-      files = Map(
-        store ->
-          """|{
-             |  "https://github.com/typelevel/cats/pull/3291" : {
-             |    "baseSha1" : "a2ced5793c2832ada8c14ba5c77e51c4bc9656a8",
-             |    "update" : {
-             |      "Single" : {
-             |        "crossDependency" : [
-             |          {
-             |            "groupId" : "org.portable-scala",
-             |            "artifactId" : {
-             |              "name" : "sbt-scalajs-crossproject",
-             |              "maybeCrossName" : null
-             |            },
-             |            "version" : "0.6.1",
-             |            "sbtVersion" : null,
-             |            "scalaVersion" : null,
-             |            "configurations" : null
-             |          }
-             |        ],
-             |        "newerVersions" : [
-             |          "1.0.0"
-             |        ],
-             |        "newerGroupId" : null
-             |      }
-             |    },
-             |    "state" : "open"
-             |  }
-             |}""".stripMargin
       )
     )
   }


### PR DESCRIPTION
This is in preparation for #1316. We store the timestamp when a
`PullRequestData` is created for the first time. This can later be
used to determine the duration since the last created pull request.