### PR TITLE
Add config to specify how frequent PRs are created

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val core = myCrossProject("core")
       Dependencies.commonsIo,
       Dependencies.coursierCore,
       Dependencies.coursierCatsInterop,
+      Dependencies.cron4sCore,
       Dependencies.fs2Core,
       Dependencies.http4sAsyncHttpClient,
       Dependencies.http4sCirce,

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -16,8 +16,8 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 #   <CRON expression>
 #     PRs are created roughly according to the given CRON expression.
 #
-#     CRON expressions consist of six fields: seconds, minutes, hour of day,
-#     day of month, month, and day of week.
+#     CRON expressions consist of five fields:
+#     minutes, hour of day, day of month, month, and day of week.
 #
 #     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
 #     more information about the CRON expressions that are supported.
@@ -28,7 +28,7 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 #
 # Default: @asap
 #
-#pullRequests.frequency = "0 0 0 ? * 3" # every thursday on midnight
+#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
 pullRequests.frequency = "@weekly"
 
 # Only these dependencies which match the given patterns are updated.

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -28,7 +28,7 @@ You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward upd
 #
 # Default: @asap
 #
-#pullRequests.frequency = "0 0 * ? * 3" # every thursday on midnight
+#pullRequests.frequency = "0 0 0 ? * 3" # every thursday on midnight
 pullRequests.frequency = "@weekly"
 
 # Only these dependencies which match the given patterns are updated.

--- a/docs/repo-specific-configuration.md
+++ b/docs/repo-specific-configuration.md
@@ -3,6 +3,34 @@
 You can add `<YOUR_REPO>/.scala-steward.conf` to configure how Scala Steward updates your repository.
 
 ```properties
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+#
+# Possible values:
+#   @asap
+#     PRs are created without delay.
+#
+#   @daily | @weekly | @monthly
+#     PRs are created at least 1 day | 7 days | 30 days after the last PR.
+#
+#   <CRON expression>
+#     PRs are created roughly according to the given CRON expression.
+#
+#     CRON expressions consist of six fields: seconds, minutes, hour of day,
+#     day of month, month, and day of week.
+#
+#     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
+#     more information about the CRON expressions that are supported.
+#
+#     Note that the date parts of the CRON expression are matched exactly
+#     while the the time parts are only used to abide to the frequency of
+#     the given expression.
+#
+# Default: @asap
+#
+#pullRequests.frequency = "0 0 * ? * 3" # every thursday on midnight
+pullRequests.frequency = "@weekly"
+
 # Only these dependencies which match the given patterns are updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/PullRequestRepository.scala
@@ -23,7 +23,7 @@ import org.scalasteward.core.data.{CrossDependency, Update}
 import org.scalasteward.core.git.Sha1
 import org.scalasteward.core.persistence.KeyValueStore
 import org.scalasteward.core.update.UpdateAlg
-import org.scalasteward.core.util.DateTimeAlg
+import org.scalasteward.core.util.{DateTimeAlg, Timestamp}
 import org.scalasteward.core.vcs.data.{PullRequestState, Repo}
 
 final class PullRequestRepository[F[_]](
@@ -69,4 +69,7 @@ final class PullRequestRepository[F[_]](
           (url, data.baseSha1, data.state)
       }
     }
+
+  def lastPullRequestCreatedAt(repo: Repo): F[Option[Timestamp]] =
+    kvStore.get(repo).map(_.flatMap(_.values.map(_.entryCreatedAt).maxOption))
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -25,13 +25,15 @@ import scala.concurrent.duration._
 sealed trait PullRequestFrequency {
   def render: String
 
-  def timeout(lastCreated: Timestamp, now: Timestamp): FiniteDuration =
-    this match {
-      case Asap    => 0.nanoseconds
-      case Daily   => 1.day - lastCreated.until(now)
-      case Weekly  => 7.days - lastCreated.until(now)
-      case Monthly => 30.days - lastCreated.until(now)
+  def timeout(lastCreated: Timestamp, now: Timestamp): Option[FiniteDuration] = {
+    val period = this match {
+      case Asap    => None
+      case Daily   => Some(1.day)
+      case Weekly  => Some(7.days)
+      case Monthly => Some(30.days)
     }
+    period.map(_ - lastCreated.until(now)).filter(_.length > 0)
+  }
 }
 
 object PullRequestFrequency {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -56,21 +56,21 @@ object PullRequestFrequency {
 
   val default: PullRequestFrequency = Asap
 
-  def fromString(s: String): PullRequestFrequency =
+  def fromString(s: String): Either[String, PullRequestFrequency] =
     s.trim.toLowerCase match {
-      case Asap.render    => Asap
-      case Daily.render   => Daily
-      case Weekly.render  => Weekly
-      case Monthly.render => Monthly
+      case Asap.render    => Right(Asap)
+      case Daily.render   => Right(Daily)
+      case Weekly.render  => Right(Weekly)
+      case Monthly.render => Right(Monthly)
       case other =>
-        Either.catchNonFatal(cron4s.Cron.unsafeParse(other)).fold(_ => default, CronExpr.apply)
+        Either.catchNonFatal(cron4s.Cron.unsafeParse(other)).leftMap(_.toString).map(CronExpr.apply)
     }
 
   implicit val pullRequestFrequencyEq: Eq[PullRequestFrequency] =
     Eq.fromUniversalEquals
 
   implicit val pullRequestFrequencyDecoder: Decoder[PullRequestFrequency] =
-    Decoder[String].map(fromString)
+    Decoder[String].emap(fromString)
 
   implicit val pullRequestFrequencyEncoder: Encoder[PullRequestFrequency] =
     Encoder[String].contramap(_.render)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -62,7 +62,8 @@ object PullRequestFrequency {
       case Daily.render   => Daily
       case Weekly.render  => Weekly
       case Monthly.render => Monthly
-      case _              => Either.catchNonFatal(cron4s.Cron.unsafeParse(s)).fold(_ => default, CronExpr.apply)
+      case other =>
+        Either.catchNonFatal(cron4s.Cron.unsafeParse(other)).fold(_ => default, CronExpr.apply)
     }
 
   implicit val pullRequestFrequencyEq: Eq[PullRequestFrequency] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -33,7 +33,7 @@ sealed trait PullRequestFrequency {
       case _              => true
     }
 
-  def timeout(lastCreated: Timestamp, now: Timestamp): Option[FiniteDuration] = {
+  def waitingTime(lastCreated: Timestamp, now: Timestamp): Option[FiniteDuration] = {
     val nextPossible = this match {
       case Asap           => None
       case Daily          => Some(lastCreated + 1.day)

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -62,8 +62,12 @@ object PullRequestFrequency {
       case Daily.render   => Right(Daily)
       case Weekly.render  => Right(Weekly)
       case Monthly.render => Right(Monthly)
-      case other =>
-        Either.catchNonFatal(cron4s.Cron.unsafeParse(other)).leftMap(_.toString).map(CronExpr.apply)
+      case other          =>
+        // cron4s supports 6 fields, but we only want to support the more
+        // common format with 5 fields. Therefore we're prepending the "seconds"
+        // field ourselves.
+        val errorOrCronExpr = Either.catchNonFatal(cron4s.Cron.unsafeParse("0 " + other))
+        errorOrCronExpr.leftMap(_.toString).map(CronExpr.apply)
     }
 
   implicit val pullRequestFrequencyEq: Eq[PullRequestFrequency] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2020 Scala Steward contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.scalasteward.core.repoconfig
+
+import io.circe.{Decoder, Encoder}
+import org.scalasteward.core.repoconfig.PullRequestFrequency._
+import org.scalasteward.core.util.Timestamp
+import scala.concurrent.duration._
+
+sealed trait PullRequestFrequency {
+  def render: String
+
+  def elapsed(t1: Timestamp, t2: Timestamp): Boolean =
+    this match {
+      case Asap    => true
+      case Daily   => t1.until(t2) >= 1.day
+      case Weekly  => t1.until(t2) >= 7.days
+      case Monthly => t1.until(t2) >= 30.days
+    }
+}
+
+object PullRequestFrequency {
+  case object Asap extends PullRequestFrequency { val render = "@asap" }
+  case object Daily extends PullRequestFrequency { val render = "@daily" }
+  case object Weekly extends PullRequestFrequency { val render = "@weekly" }
+  case object Monthly extends PullRequestFrequency { val render = "@monthly" }
+
+  val default: PullRequestFrequency = Asap
+
+  def fromString(s: String): PullRequestFrequency =
+    s.trim.toLowerCase match {
+      case Asap.render    => Asap
+      case Daily.render   => Daily
+      case Weekly.render  => Weekly
+      case Monthly.render => Monthly
+      case _              => default
+    }
+
+  implicit val pullRequestFrequencyDecoder: Decoder[PullRequestFrequency] =
+    Decoder[String].map(fromString)
+
+  implicit val pullRequestFrequencyEncoder: Encoder[PullRequestFrequency] =
+    Encoder[String].contramap(_.render)
+}

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateStrategy.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestUpdateStrategy.scala
@@ -28,7 +28,7 @@ object PullRequestUpdateStrategy {
   final case object OnConflicts extends PullRequestUpdateStrategy { val name = "on-conflicts" }
   final case object Never extends PullRequestUpdateStrategy { val name = "never" }
 
-  val default = OnConflicts
+  val default: PullRequestUpdateStrategy = OnConflicts
 
   def fromString(value: String): PullRequestUpdateStrategy =
     value.trim.toLowerCase match {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -16,26 +16,18 @@
 
 package org.scalasteward.core.repoconfig
 
+import io.circe.Codec
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto._
-import io.circe.{Decoder, Encoder}
-import PullRequestUpdateStrategy.{prUpdateStrategyDecoder, prUpdateStrategyEncoder}
+import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
-final case class RepoConfig(
-    pullRequests: PullRequestsConfig = PullRequestsConfig(),
-    updates: UpdatesConfig = UpdatesConfig(),
-    updatePullRequests: PullRequestUpdateStrategy = PullRequestUpdateStrategy.default
+final case class PullRequestsConfig(
+    frequency: PullRequestFrequency = PullRequestFrequency.default
 )
 
-object RepoConfig {
-  val default: RepoConfig = RepoConfig()
-
+object PullRequestsConfig {
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults
 
-  implicit val repoConfigDecoder: Decoder[RepoConfig] =
-    deriveConfiguredDecoder
-
-  implicit val repoConfigEncoder: Encoder[RepoConfig] =
-    deriveConfiguredEncoder
+  implicit val pullRequestsConfigCodec: Codec[PullRequestsConfig] =
+    deriveConfiguredCodec
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -146,17 +146,17 @@ final class PruningAlg[F[_]](
     }
 
   private def newPullRequestsAllowed(repo: Repo, frequency: PullRequestFrequency): F[Boolean] =
-    if (frequency === PullRequestFrequency.Asap)
-      true.pure[F]
+    if (frequency === PullRequestFrequency.Asap) true.pure[F]
     else {
       pullRequestRepository.lastPullRequestCreatedAt(repo).flatMap {
         case None => true.pure[F]
         case Some(createdAt) =>
           dateTimeAlg.currentTimestamp.map(frequency.timeout(createdAt, _)).flatMap { timeout =>
-            if (timeout.length > 0) {
+            if (timeout.length <= 0) true.pure[F]
+            else {
               val message = s"Ignoring outdated dependencies for ${dateTime.showDuration(timeout)}"
               logger.info(message).as(false)
-            } else true.pure[F]
+            }
           }
       }
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -151,12 +151,11 @@ final class PruningAlg[F[_]](
       pullRequestRepository.lastPullRequestCreatedAt(repo).flatMap {
         case None => true.pure[F]
         case Some(createdAt) =>
-          dateTimeAlg.currentTimestamp.map(frequency.timeout(createdAt, _)).flatMap { timeout =>
-            if (timeout.length <= 0) true.pure[F]
-            else {
+          dateTimeAlg.currentTimestamp.map(frequency.timeout(createdAt, _)).flatMap {
+            case None => true.pure[F]
+            case Some(timeout) =>
               val message = s"Ignoring outdated dependencies for ${dateTime.showDuration(timeout)}"
               logger.info(message).as(false)
-            }
           }
       }
     }

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -22,17 +22,19 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.data._
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
-import org.scalasteward.core.repoconfig.RepoConfig
+import org.scalasteward.core.repoconfig.{PullRequestFrequency, RepoConfig}
 import org.scalasteward.core.update.PruningAlg._
 import org.scalasteward.core.update.data.UpdateState
 import org.scalasteward.core.update.data.UpdateState._
 import org.scalasteward.core.util
+import org.scalasteward.core.util.{dateTime, DateTimeAlg}
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
 import scala.concurrent.duration._
 
 final class PruningAlg[F[_]](
     implicit
+    dateTimeAlg: DateTimeAlg[F],
     logger: Logger[F],
     pullRequestRepository: PullRequestRepository[F],
     repoCacheRepository: RepoCacheRepository[F],
@@ -72,7 +74,7 @@ final class PruningAlg[F[_]](
         }
       }
       _ <- logger.info(util.logger.showUpdates(updates1.widen[Update]))
-      result <- checkUpdateStates(repo, updateStates1)
+      result <- checkUpdateStates(repo, repoConfig, updateStates1)
     } yield result
   }
 
@@ -125,21 +127,39 @@ final class PruningAlg[F[_]](
 
   private def checkUpdateStates(
       repo: Repo,
+      repoConfig: RepoConfig,
       updateStates: List[UpdateState]
-  ): F[(Boolean, List[Update.Single])] = {
-    val (outdatedStates, updates) = updateStates.collect {
-      case s: DependencyOutdated  => (s, s.update)
-      case s: PullRequestOutdated => (s, s.update)
-    }.separate
-    val isOutdated = outdatedStates.nonEmpty
-    val message = if (isOutdated) {
-      val states = util.string.indentLines(outdatedStates.map(_.toString).sorted)
-      s"${repo.show} is outdated:\n" + states
-    } else {
-      s"${repo.show} is up-to-date"
+  ): F[(Boolean, List[Update.Single])] =
+    newPullRequestsAllowed(repo, repoConfig.pullRequests.frequency).flatMap { allowed =>
+      val (outdatedStates, updates) = updateStates.collect {
+        case s: DependencyOutdated if allowed => (s, s.update)
+        case s: PullRequestOutdated           => (s, s.update)
+      }.separate
+      val isOutdated = outdatedStates.nonEmpty
+      val message = if (isOutdated) {
+        val states = util.string.indentLines(outdatedStates.map(_.toString).sorted)
+        s"${repo.show} is outdated:\n" + states
+      } else {
+        s"${repo.show} is up-to-date"
+      }
+      logger.info(message).as((isOutdated, updates))
     }
-    logger.info(message).as((isOutdated, updates))
-  }
+
+  private def newPullRequestsAllowed(repo: Repo, frequency: PullRequestFrequency): F[Boolean] =
+    if (frequency === PullRequestFrequency.Asap)
+      true.pure[F]
+    else {
+      pullRequestRepository.lastPullRequestCreatedAt(repo).flatMap {
+        case None => true.pure[F]
+        case Some(createdAt) =>
+          dateTimeAlg.currentTimestamp.map(frequency.timeout(createdAt, _)).flatMap { timeout =>
+            if (timeout.length > 0) {
+              val message = s"Ignoring outdated dependencies for ${dateTime.showDuration(timeout)}"
+              logger.info(message).as(false)
+            } else true.pure[F]
+          }
+      }
+    }
 }
 
 object PruningAlg {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -154,9 +154,9 @@ final class PruningAlg[F[_]](
         if (!frequency.onSchedule(now))
           logger.info(s"$ignoring according to $frequency").as(false)
         else {
-          val timeout = OptionT(pullRequestRepository.lastPullRequestCreatedAt(repo))
-            .subflatMap(frequency.timeout(_, now))
-          timeout.value.flatMap {
+          val waitingTime = OptionT(pullRequestRepository.lastPullRequestCreatedAt(repo))
+            .subflatMap(frequency.waitingTime(_, now))
+          waitingTime.value.flatMap {
             case None => true.pure[F]
             case Some(timeout) =>
               val message = s"$ignoring for ${dateTime.showDuration(timeout)}"

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -154,12 +154,12 @@ final class PruningAlg[F[_]](
         if (!frequency.onSchedule(now))
           logger.info(s"$ignoring according to $frequency").as(false)
         else {
-          val waitingTime = OptionT(pullRequestRepository.lastPullRequestCreatedAt(repo))
+          val maybeWaitingTime = OptionT(pullRequestRepository.lastPullRequestCreatedAt(repo))
             .subflatMap(frequency.waitingTime(_, now))
-          waitingTime.value.flatMap {
+          maybeWaitingTime.value.flatMap {
             case None => true.pure[F]
-            case Some(timeout) =>
-              val message = s"$ignoring for ${dateTime.showDuration(timeout)}"
+            case Some(waitingTime) =>
+              val message = s"$ignoring for ${dateTime.showDuration(waitingTime)}"
               logger.info(message).as(false)
           }
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -20,15 +20,25 @@ import cats.Order
 import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 final case class Timestamp(millis: Long) {
+  def +(finiteDuration: FiniteDuration): Timestamp =
+    Timestamp(millis + finiteDuration.toMillis)
+
+  def toInstant: Instant =
+    Instant.ofEpochMilli(millis)
+
   def until(that: Timestamp): FiniteDuration =
     FiniteDuration(that.millis - millis, TimeUnit.MILLISECONDS)
 }
 
 object Timestamp {
+  def from(instant: Instant): Timestamp =
+    Timestamp(instant.toEpochMilli)
+
   implicit val timestampCodec: Codec[Timestamp] =
     deriveUnwrappedCodec
 

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -20,7 +20,7 @@ import cats.Order
 import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
-import java.time.Instant
+import java.time.{Instant, LocalDateTime, ZoneOffset}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
@@ -28,16 +28,16 @@ final case class Timestamp(millis: Long) {
   def +(finiteDuration: FiniteDuration): Timestamp =
     Timestamp(millis + finiteDuration.toMillis)
 
-  def toInstant: Instant =
-    Instant.ofEpochMilli(millis)
+  def toLocalDateTime: LocalDateTime =
+    LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC)
 
   def until(that: Timestamp): FiniteDuration =
     FiniteDuration(that.millis - millis, TimeUnit.MILLISECONDS)
 }
 
 object Timestamp {
-  def from(instant: Instant): Timestamp =
-    Timestamp(instant.toEpochMilli)
+  def fromLocalDateTime(ldt: LocalDateTime): Timestamp =
+    Timestamp(ldt.toInstant(ZoneOffset.UTC).toEpochMilli)
 
   implicit val timestampCodec: Codec[Timestamp] =
     deriveUnwrappedCodec

--- a/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/Timestamp.scala
@@ -16,6 +16,8 @@
 
 package org.scalasteward.core.util
 
+import cats.Order
+import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.extras.semiauto.deriveUnwrappedCodec
 import java.util.concurrent.TimeUnit
@@ -29,4 +31,7 @@ final case class Timestamp(millis: Long) {
 object Timestamp {
   implicit val timestampCodec: Codec[Timestamp] =
     deriveUnwrappedCodec
+
+  implicit val timestampOrder: Order[Timestamp] =
+    Order.by(_.millis)
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
-  test("createOrUpdate >> findPullRequest") {
+  test("createOrUpdate >> findPullRequest >> lastPullRequestCreatedAt") {
     val repo = Repo("typelevel", "cats")
     val url = uri"https://github.com/typelevel/cats/pull/3291"
     val sha1 = Sha1(HexString("a2ced5793c2832ada8c14ba5c77e51c4bc9656a8"))
@@ -23,15 +23,18 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
     val p = for {
       _ <- pullRequestRepository.createOrUpdate(repo, url, sha1, update, PullRequestState.Open)
       result <- pullRequestRepository.findPullRequest(repo, update.crossDependency, "1.0.0")
-    } yield result
-    val (state, result) = p.run(MockState.empty).unsafeRunSync()
+      createdAt <- pullRequestRepository.lastPullRequestCreatedAt(repo)
+    } yield (result, createdAt)
+    val (state, (result, createdAt)) = p.run(MockState.empty).unsafeRunSync()
 
     val store = (config.workspace / "store/pull_requests/v1/typelevel/cats/pull_requests.json")
     result shouldBe Some((url, sha1, PullRequestState.Open))
+    createdAt.isDefined shouldBe true
     state.copy(files = Map.empty) shouldBe MockState.empty.copy(
       commands = Vector(
         List("read", store.toString),
         List("write", store.toString),
+        List("read", store.toString),
         List("read", store.toString)
       )
     )

--- a/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/nurture/PullRequestRepositoryTest.scala
@@ -27,7 +27,7 @@ class PullRequestRepositoryTest extends AnyFunSuite with Matchers {
     } yield (result, createdAt)
     val (state, (result, createdAt)) = p.run(MockState.empty).unsafeRunSync()
 
-    val store = (config.workspace / "store/pull_requests/v1/typelevel/cats/pull_requests.json")
+    val store = config.workspace / "store/pull_requests/v1/typelevel/cats/pull_requests.json"
     result shouldBe Some((url, sha1, PullRequestState.Open))
     createdAt.isDefined shouldBe true
     state.copy(files = Map.empty) shouldBe MockState.empty.copy(

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -9,8 +9,8 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
   val epoch: Timestamp = Timestamp(0L)
 
   test("onSchedule") {
-    val Right(thursday) = PullRequestFrequency.fromString("0 0 * ? * THU")
-    val Right(notThursday) = PullRequestFrequency.fromString("0 0 * ? * MON-WED,FRI-SUN")
+    val Right(thursday) = PullRequestFrequency.fromString("0 * ? * THU")
+    val Right(notThursday) = PullRequestFrequency.fromString("0 * ? * MON-WED,FRI-SUN")
     thursday.onSchedule(epoch) shouldBe true
     notThursday.onSchedule(epoch) shouldBe false
   }
@@ -21,7 +21,7 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
   }
 
   test("waitingTime: cron expr") {
-    val Right(freq) = PullRequestFrequency.fromString("0 0 * ? * *")
+    val Right(freq) = PullRequestFrequency.fromString("0 1 ? * *")
     freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -9,19 +9,19 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
   val epoch: Timestamp = Timestamp(0L)
 
   test("onSchedule") {
-    val thursday = PullRequestFrequency.fromString("0 0 * ? * THU")
-    val notThursday = PullRequestFrequency.fromString("0 0 * ? * MON-WED,FRI-SUN")
+    val Right(thursday) = PullRequestFrequency.fromString("0 0 * ? * THU")
+    val Right(notThursday) = PullRequestFrequency.fromString("0 0 * ? * MON-WED,FRI-SUN")
     thursday.onSchedule(epoch) shouldBe true
     notThursday.onSchedule(epoch) shouldBe false
   }
 
   test("waitingTime: @daily") {
-    val freq = PullRequestFrequency.fromString("@daily")
+    val Right(freq) = PullRequestFrequency.fromString("@daily")
     freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)
   }
 
   test("waitingTime: cron expr") {
-    val freq = PullRequestFrequency.fromString("0 0 * ? * *")
+    val Right(freq) = PullRequestFrequency.fromString("0 0 * ? * *")
     freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -6,13 +6,22 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
-  test("timeout: @daily") {
-    val freq = PullRequestFrequency.fromString("@daily")
-    freq.timeout(Timestamp(0L), Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)
+  val epoch: Timestamp = Timestamp(0L)
+
+  test("onSchedule") {
+    val thursday = PullRequestFrequency.fromString("0 0 * ? * 3")
+    val notThursday = PullRequestFrequency.fromString("0 0 * ? * 0,1,2,4,5,6")
+    thursday.onSchedule(epoch) shouldBe true
+    notThursday.onSchedule(epoch) shouldBe false
   }
 
-  test("timeout: cron expr") {
+  test("waitingTime: @daily") {
+    val freq = PullRequestFrequency.fromString("@daily")
+    freq.waitingTime(epoch, Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)
+  }
+
+  test("waitingTime: cron expr") {
     val freq = PullRequestFrequency.fromString("0 0 * ? * *")
-    freq.timeout(Timestamp(0L), Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
+    freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -9,7 +9,7 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
   val epoch: Timestamp = Timestamp(0L)
 
   test("onSchedule") {
-    val thursday = PullRequestFrequency.fromString("0 0 * ? * 3")
+    val thursday = PullRequestFrequency.fromString("0 0 * ? * THU")
     val notThursday = PullRequestFrequency.fromString("0 0 * ? * 0,1,2,4,5,6")
     thursday.onSchedule(epoch) shouldBe true
     notThursday.onSchedule(epoch) shouldBe false

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -10,7 +10,7 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
 
   test("onSchedule") {
     val thursday = PullRequestFrequency.fromString("0 0 * ? * THU")
-    val notThursday = PullRequestFrequency.fromString("0 0 * ? * 0,1,2,4,5,6")
+    val notThursday = PullRequestFrequency.fromString("0 0 * ? * MON-WED,FRI-SUN")
     thursday.onSchedule(epoch) shouldBe true
     notThursday.onSchedule(epoch) shouldBe false
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -1,0 +1,18 @@
+package org.scalasteward.core.repoconfig
+
+import org.scalasteward.core.util.Timestamp
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+
+class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
+  test("timeout: @daily") {
+    val freq = PullRequestFrequency.fromString("@daily")
+    freq.timeout(Timestamp(0L), Timestamp(18.hours.toMillis)) shouldBe Some(6.hours)
+  }
+
+  test("timeout: cron expr") {
+    val freq = PullRequestFrequency.fromString("0 0 * ? * *")
+    freq.timeout(Timestamp(0L), Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
+  }
+}

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -93,6 +93,30 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     config shouldBe Right(RepoConfig(updatePullRequests = PullRequestUpdateStrategy.Never))
   }
 
+  test("config with 'pullRequests.frequency = @daily'") {
+    val content = """pullRequests.frequency = "@daily" """
+    val config = RepoConfigAlg.parseRepoConfig(content)
+    config shouldBe Right(
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Daily))
+    )
+  }
+
+  test("config with 'pullRequests.frequency = @monthly'") {
+    val content = """pullRequests.frequency = "@monthly" """
+    val config = RepoConfigAlg.parseRepoConfig(content)
+    config shouldBe Right(
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Monthly))
+    )
+  }
+
+  test("malformed pullRequests.frequency") {
+    val content = """pullRequests.frequency = "quack" """
+    val config = RepoConfigAlg.parseRepoConfig(content)
+    config shouldBe Right(
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Asap))
+    )
+  }
+
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -93,6 +93,14 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     config shouldBe Right(RepoConfig(updatePullRequests = PullRequestUpdateStrategy.Never))
   }
 
+  test("config with 'pullRequests.frequency = @asap'") {
+    val content = """pullRequests.frequency = "@asap" """
+    val config = RepoConfigAlg.parseRepoConfig(content)
+    config shouldBe Right(
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Asap))
+    )
+  }
+
   test("config with 'pullRequests.frequency = @daily'") {
     val content = """pullRequests.frequency = "@daily" """
     val config = RepoConfigAlg.parseRepoConfig(content)

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -24,11 +24,13 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
          |               ]
          |updates.ignore = [ { groupId = "org.acme", version = "1.0" } ]
          |updates.limit = 4
+         |pullRequests.frequency = "@weekly"
          |""".stripMargin
     val initialState = MockState.empty.add(configFile, content)
     val config = repoConfigAlg.readRepoConfigOrDefault(repo).runA(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig(
+      pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Weekly),
       updates = UpdatesConfig(
         allow = List(UpdatePattern(GroupId("eu.timepit"), None, None)),
         pin = List(

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -117,14 +117,6 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     )
   }
 
-  test("malformed pullRequests.frequency") {
-    val content = """pullRequests.frequency = "quack" """
-    val config = RepoConfigAlg.parseRepoConfig(content)
-    config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Asap))
-    )
-  }
-
   test("malformed config") {
     val repo = Repo("fthomas", "scala-steward")
     val configFile = File.temp / "ws/fthomas/scala-steward/.scala-steward.conf"

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -55,7 +55,7 @@ class FilterAlgTest extends AnyFunSuite with Matchers {
   test("ignore update via config updates.ignore") {
     val update1 = Single("org.http4s" % "http4s-dsl" % "0.17.0", Nel.of("0.18.0"))
     val update2 = Single("eu.timepit" % "refined" % "0.8.0", Nel.of("0.8.1"))
-    val config = RepoConfig(
+    val config = RepoConfig(updates =
       UpdatesConfig(ignore = List(UpdatePattern(GroupId("eu.timepit"), Some("refined"), None)))
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -1,0 +1,72 @@
+package org.scalasteward.core.update
+
+import org.scalasteward.core.mock.MockContext._
+import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.vcs.data.Repo
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class PruningAlgTest extends AnyFunSuite with Matchers {
+  test("needsAttention") {
+    val repo = Repo("fthomas", "scalafix-test")
+    val repoCacheFile =
+      config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
+    val repoCacheContent =
+      s"""|{
+          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |  "dependencyInfos": [],
+          |  "maybeRepoConfig": {
+          |    "pullRequests": {
+          |      "frequency": "@daily"
+          |    }
+          |  }
+          |}""".stripMargin
+    val pullRequestsFile =
+      config.workspace / "store/pull_requests/v1/fthomas/scalafix-test/pull_requests.json"
+    val pullRequestsContent =
+      s"""|{
+          |  "https://github.com/fthomas/scalafix-test/pull/27" : {
+          |    "baseSha1" : "12def27a837ba6dc9e17406cbbe342fba3527c14",
+          |    "update" : {
+          |      "Single" : {
+          |        "crossDependency" : [
+          |          {
+          |            "groupId" : "org.scalatest",
+          |            "artifactId" : {
+          |              "name" : "scalatest",
+          |              "maybeCrossName" : "scalatest_2.12"
+          |            },
+          |            "version" : "3.0.8",
+          |            "sbtVersion" : null,
+          |            "scalaVersion" : null,
+          |            "configurations" : null
+          |          }
+          |        ],
+          |        "newerVersions" : [
+          |          "3.1.0"
+          |        ],
+          |        "newerGroupId" : null
+          |      }
+          |    },
+          |    "state" : "open",
+          |    "entryCreatedAt" : 1581969227183
+          |  }
+          |}""".stripMargin
+    val initial = MockState.empty
+      .add(repoCacheFile, repoCacheContent)
+      .add(pullRequestsFile, pullRequestsContent)
+    val state = pruningAlg.needsAttention(repo).runS(initial).unsafeRunSync()
+
+    state shouldBe initial.copy(
+      commands = Vector(
+        List("read", repoCacheFile.toString),
+        List("read", pullRequestsFile.toString)
+      ),
+      logs = Vector(
+        (None, "Find updates for fthomas/scalafix-test"),
+        (None, "Found 0 updates"),
+        (None, "fthomas/scalafix-test is up-to-date")
+      )
+    )
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.6"
   val coursierCore = "io.get-coursier" %% "coursier" % "2.0.0-RC6-9"
   val coursierCatsInterop = "io.get-coursier" %% "coursier-cats-interop" % coursierCore.revision
+  val cron4sCore = "com.github.alonsodomin.cron4s" %% "cron4s-core" % "0.6.0"
   val disciplineScalatest = "org.typelevel" %% "discipline-scalatest" % "1.0.0"
   val fs2Core = "co.fs2" %% "fs2-core" % "2.2.2"
   val http4sAsyncHttpClient = "org.http4s" %% "http4s-async-http-client" % "0.21.1"


### PR DESCRIPTION
This PR adds a new `pullRequests.frequency` option to `.scala-steward.conf` files which can be used to control how often or when Scala Steward is allowed to create pull requests. Possible values of this option are `@asap` (default), `@daily`, `@weekly`, `@monthly`, or a [cron4s](https://www.alonsodomin.me/cron4s/) compatible CRON expression. The effects of these values are explained in [repo-specific-configuration.md](https://github.com/fthomas/scala-steward/blob/aaa4284fb1fcaef6f083c8f8b412c1e4cd2b8470/docs/repo-specific-configuration.md).

Some example configs:
```hocon
# only create PRs on weekdays
pullRequests.frequency = "* * ? * mon-fri"

# wait 7 days after the last PR before creating new PRs
pullRequests.frequency = "@weekly"

# create PRs only once on mondays
pullRequests.frequency = "0 8 ? * MON"
```

Note that this option does not affect the number of pull requests Scala Steward creates when it is allowed to. So if the option is set to `@weekly` Scala Steward might create n PRs at a given time and then a week later it might create another m pull requests.

Closes #1316.