### PR TITLE
Make frequency an optional field

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -22,7 +22,10 @@ import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
 final case class PullRequestsConfig(
     frequency: Option[PullRequestFrequency] = None
-)
+) {
+  def frequencyOrDefault: PullRequestFrequency =
+    frequency.getOrElse(PullRequestFrequency.default)
+}
 
 object PullRequestsConfig {
   implicit val customConfig: Configuration =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestsConfig.scala
@@ -21,7 +21,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredCodec
 
 final case class PullRequestsConfig(
-    frequency: PullRequestFrequency = PullRequestFrequency.default
+    frequency: Option[PullRequestFrequency] = None
 )
 
 object PullRequestsConfig {

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -130,9 +130,8 @@ final class PruningAlg[F[_]](
       repo: Repo,
       repoConfig: RepoConfig,
       updateStates: List[UpdateState]
-  ): F[(Boolean, List[Update.Single])] = {
-    val frequency = repoConfig.pullRequests.frequency.getOrElse(PullRequestFrequency.default)
-    newPullRequestsAllowed(repo, frequency).flatMap { allowed =>
+  ): F[(Boolean, List[Update.Single])] =
+    newPullRequestsAllowed(repo, repoConfig.pullRequests.frequencyOrDefault).flatMap { allowed =>
       val (outdatedStates, updates) = updateStates.collect {
         case s: DependencyOutdated if allowed => (s, s.update)
         case s: PullRequestOutdated           => (s, s.update)
@@ -146,7 +145,6 @@ final class PruningAlg[F[_]](
       }
       logger.info(message).as((isOutdated, updates))
     }
-  }
 
   private def newPullRequestsAllowed(repo: Repo, frequency: PullRequestFrequency): F[Boolean] =
     if (frequency === PullRequestFrequency.Asap) true.pure[F]

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/RepoConfigAlgTest.scala
@@ -30,7 +30,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val config = repoConfigAlg.readRepoConfigOrDefault(repo).runA(initialState).unsafeRunSync()
 
     config shouldBe RepoConfig(
-      pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Weekly),
+      pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Weekly)),
       updates = UpdatesConfig(
         allow = List(UpdatePattern(GroupId("eu.timepit"), None, None)),
         pin = List(
@@ -97,7 +97,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val content = """pullRequests.frequency = "@asap" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Asap))
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Asap)))
     )
   }
 
@@ -105,7 +105,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val content = """pullRequests.frequency = "@daily" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Daily))
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Daily)))
     )
   }
 
@@ -113,7 +113,7 @@ class RepoConfigAlgTest extends AnyFunSuite with Matchers {
     val content = """pullRequests.frequency = "@monthly" """
     val config = RepoConfigAlg.parseRepoConfig(content)
     config shouldBe Right(
-      RepoConfig(pullRequests = PullRequestsConfig(frequency = PullRequestFrequency.Monthly))
+      RepoConfig(pullRequests = PullRequestsConfig(frequency = Some(PullRequestFrequency.Monthly)))
     )
   }
 


### PR DESCRIPTION
This makes `PullRequests.frequency` an optional field so that the
default value is not persisted in `RepoCache` if that field is not set
by the user.

If the default is persisted now, it can't be easily changed later.