### PR TITLE
Mark com.nequissimus:sort-imports:36845576 as an invalid version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ workspace/
 
 .bloop/
 .metals/
+metals.sbt

--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -115,6 +115,11 @@ object FilterAlg {
     (groupId.value, artifactId.name) match {
       case ("com.google.guava", "guava") =>
         List("r03", "r05", "r06", "r07", "r08", "r09").contains
+      case ("com.nequissimus", "sort-imports") =>
+        List(
+          // https://github.com/beautiful-scala/sbt-scalastyle/pull/13
+          "36845576"
+        ).contains
       case ("commons-collections", "commons-collections") =>
         List(
           "20030418.083655",


### PR DESCRIPTION
It appears that the first version of [NeQuissimus/sort-imports](https://github.com/NeQuissimus/sort-imports) scalafix rule was published with an incorrect version back in June [36845576](https://search.maven.org/artifact/com.nequissimus/sort-imports_2.12), which is getting picked up by Scala Steward as the latest version. See the following PR https://github.com/beautiful-scala/sbt-scalastyle/pull/13.

Could this version be ignored globally by Scala Steward?

cc @NeQuissimus 