### PR TITLE
Optimize docker image size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,36 +170,22 @@ lazy val metadataSettings = Def.settings(
 )
 
 lazy val dockerSettings = Def.settings(
-  dockerCommands := Seq(
-    Cmd("FROM", Option(System.getenv("DOCKER_BASE_IMAGE")).getOrElse("openjdk:8")),
-    Cmd("ARG", "DEBIAN_FRONTEND=noninteractive"),
-    ExecCmd("RUN", "apt-get", "update"),
-    ExecCmd("RUN", "apt-get", "install", "-y", "apt-transport-https", "firejail"),
-    ExecCmd(
-      "RUN",
-      "sh",
-      "-c",
-      """echo \"deb https://dl.bintray.com/sbt/debian /\" | tee -a /etc/apt/sources.list.d/sbt.list"""
-    ),
-    ExecCmd(
-      "RUN",
-      "apt-key",
-      "adv",
-      "--keyserver",
-      "hkp://keyserver.ubuntu.com:80",
-      "--recv",
-      "2EE0EA64E40A89B84B2DF73499E82A75642AC823"
-    ),
-    ExecCmd("RUN", "apt-get", "update"),
-    ExecCmd("RUN", "apt-get", "install", "-y", "sbt"),
-    Cmd("WORKDIR", "/opt/docker"),
-    Cmd("ADD", "opt", "/opt"),
-    ExecCmd("RUN", "chmod", "0755", "/opt/docker/bin/scala-steward"),
-    ExecCmd("ENTRYPOINT", "/opt/docker/bin/scala-steward"),
-    ExecCmd("CMD", "")
-  ),
+  dockerBaseImage := Option(System.getenv("DOCKER_BASE_IMAGE")).getOrElse("openjdk:8-jre-alpine"),
+  dockerCommands ++= {
+    val getSbtVersion = sbtVersion.value
+    val sbtTgz = s"sbt-$getSbtVersion.tgz"
+    val sbtUrl = s"https://github.com/sbt/sbt/releases/download/v$getSbtVersion/$sbtTgz"
+    Seq(
+      Cmd("USER", "root"),
+      Cmd(
+        "RUN",
+        s"apk --no-cache add bash && wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz && ln sbt/bin/sbt /usr/bin"
+      )
+    )
+  },
   Docker / packageName := s"${gitHubOwner}/${name.value}",
-  dockerUpdateLatest := true
+  dockerUpdateLatest := true,
+  dockerEntrypoint += "--disable-sandbox"
 )
 
 lazy val noPublishSettings = Def.settings(

--- a/docs/running.md
+++ b/docs/running.md
@@ -71,14 +71,14 @@ run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "
 * Create a file `run.sh` with this content:
 
 ```
-echo "echo '$BITBUCKET_PASSWORD'" >pass.sh
+echo "#!/bin/sh"                  >> pass.sh  
+echo "echo '$BITBUCKET_PASSWORD'" >> pass.sh
 
 chmod +x pass.sh
 
 docker run -v $PWD:/opt/scala-steward \
     -v ~/.sbt/:/root/.sbt \
     -it fthomas/scala-steward:latest \
-    --disable-sandbox \
     --env-var LOG_LEVEL=TRACE \
     --do-not-fork \
     --workspace "/opt/scala-steward/workspace" \


### PR DESCRIPTION
This PR changes docker base image from debian`openjdk:8` to alpine `openjdk:8-jre-alpine`.

The motivation was to reduce the resulting image size. 
I replaced JDK with JRE since neither sbt nor scalac require JDK.
I also removed `firejail` from image and  put `--disable-sandbox` to docker entrypoint args to fix #347.

The resulting image size is reduced from 1.06GB to 208MB.
