### PR TITLE
add context to json paring errors

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -22,7 +22,7 @@ import io.circe.{Decoder, Encoder}
 import org.http4s.Method.{GET, POST}
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.Client
-import org.http4s.{Headers, Method, Request, Response, Status, Uri}
+import org.http4s.{DecodeFailure, Headers, HttpVersion, Method, Request, Response, Status, Uri}
 
 import scala.util.control.NoStackTrace
 
@@ -43,7 +43,7 @@ final class HttpJsonClient[F[_]: Sync](
   private def request[A: Decoder](method: Method, uri: Uri, modify: ModReq): F[A] =
     client.expectOr[A](modify(Request[F](method, uri)))(resp =>
       toUnexpectedResponse(uri, method, resp)
-    )(jsonOf[F, A])
+    )(jsonOf[F, A].transform(_.leftMap(failure => JsonParseError(uri, method, failure))))
 
   private def toUnexpectedResponse(
       uri: Uri,
@@ -53,6 +53,17 @@ final class HttpJsonClient[F[_]: Sync](
     val body = response.body.through(fs2.text.utf8Decode).compile.string
     body.map(UnexpectedResponse(uri, method, response.headers, response.status, _))
   }
+}
+
+final case class JsonParseError(
+    uri: Uri,
+    method: Method,
+    underlying: DecodeFailure
+) extends DecodeFailure {
+  val message = s"uri: $uri\nmethod: $method\nmessage: ${underlying.message}"
+  override def cause: Option[Throwable] = underlying.some
+  override def toHttpResponse[F[_]](httpVersion: HttpVersion): Response[F] =
+    underlying.toHttpResponse(httpVersion)
 }
 
 final case class UnexpectedResponse(


### PR DESCRIPTION
Wraps decoding errors into a case calls including uri and method. It makes it possible to identify the origin of the error.

The error I got on my CI server:
<details>

```
org.http4s.MalformedMessageBodyFailure: Malformed message body: Invalid JSON: empty body
	at org.http4s.jawn.JawnInstances$.defaultJawnEmptyBodyMessage(JawnInstances.scala:42)
	at org.http4s.jawn.JawnInstances.jawnEmptyBodyMessage(JawnInstances.scala:17)
	at org.http4s.jawn.JawnInstances.jawnEmptyBodyMessage$(JawnInstances.scala:16)
	at org.http4s.circe.package$.jawnEmptyBodyMessage(package.scala:3)
	at org.http4s.circe.CirceInstances.$anonfun$jsonDecoderByteBufferImpl$1(CirceInstances.scala:41)
	at scala.util.Either.flatMap(Either.scala:352)
	at cats.data.EitherT.$anonfun$subflatMap$1(EitherT.scala:365)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:85)
	at cats.effect.IO$Map.apply(IO.scala:1504)
	at cats.effect.IO$Map.apply(IO.scala:1502)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:142)
	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:359)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:380)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:323)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:139)
	at cats.effect.internals.IORunLoop$.startCancelable(IORunLoop.scala:41)
	at cats.effect.internals.IOBracket$BracketStart.run(IOBracket.scala:88)
	at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:67)
	at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:35)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:89)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:89)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:89)
	at cats.effect.internals.Trampoline.execute(Trampoline.scala:43)
	at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:42)
	at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:136)
	at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:125)
	at org.http4s.client.asynchttpclient.AsyncHttpClient$$anon$1.$anonfun$onCompleted$1(AsyncHttpClient.scala:126)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
	at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:359)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:380)
	at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:323)
	at cats.effect.internals.IOShift$Tick.run(IOShift.scala:35)
	at cats.effect.internals.PoolUtils$$anon$2$$anon$3.run(PoolUtils.scala:52)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
</details>