### PR TITLE
Fix round-tripping of PullRequestsFrequency codec

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/PullRequestFrequency.scala
@@ -63,12 +63,14 @@ object PullRequestFrequency {
       case Weekly.render  => Right(Weekly)
       case Monthly.render => Right(Monthly)
       case other          =>
-        // cron4s supports 6 fields, but we only want to support the more
+        // cron4s requires exactly 6 fields, but we also want to support the more
         // common format with 5 fields. Therefore we're prepending the "seconds"
-        // field ourselves.
-        val errorOrCronExpr = Either.catchNonFatal(cron4s.Cron.unsafeParse("0 " + other))
-        errorOrCronExpr.leftMap(_.toString).map(CronExpr.apply)
+        // field ourselves if parsing the original string fails.
+        parseCron4s(other).orElse(parseCron4s("0 " + other)).leftMap(_.toString).map(CronExpr.apply)
     }
+
+  private def parseCron4s(s: String): Either[Throwable, cron4s.CronExpr] =
+    Either.catchNonFatal(cron4s.Cron.unsafeParse(s))
 
   implicit val pullRequestFrequencyEq: Eq[PullRequestFrequency] =
     Eq.fromUniversalEquals

--- a/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/repoconfig/PullRequestFrequencyTest.scala
@@ -1,5 +1,7 @@
 package org.scalasteward.core.repoconfig
 
+import io.circe.parser
+import io.circe.syntax._
 import org.scalasteward.core.util.Timestamp
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -23,5 +25,10 @@ class PullRequestFrequencyTest extends AnyFunSuite with Matchers {
   test("waitingTime: cron expr") {
     val Right(freq) = PullRequestFrequency.fromString("0 1 ? * *")
     freq.waitingTime(epoch, Timestamp(20.minutes.toMillis)) shouldBe Some(40.minutes)
+  }
+
+  test("CronExpr encode and then decode") {
+    val Right(freq) = PullRequestFrequency.fromString("0 0 1,15 * ?")
+    parser.decode[PullRequestFrequency](freq.asJson.spaces2) shouldBe Right(freq)
   }
 }


### PR DESCRIPTION
aaa4284fb1fcaef6f083c8f8b412c1e4cd2b8470 changed the parser for
`CronExpr` to only support expressions with 5 fields. Unfortunately I
forget to update the encoder to also emit only 5 fields. So the current
encoder/decoder pair doesn't round-trip which means we can't read
`RepoConfig`s with a cron expression that were serialized by
`RepoCacheAlg`.

This PR fixes round-tripping of the `PullRequestFrequency` encoder/decoder
by also allowing cron expressions with 6 fields.