### PR TITLE
Mark org.scala-lang:scalap as Scala dependency

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/FilterAlg.scala
@@ -78,6 +78,7 @@ object FilterAlg {
       case ("org.scala-lang", "scala-compiler") => true
       case ("org.scala-lang", "scala-library")  => true
       case ("org.scala-lang", "scala-reflect")  => true
+      case ("org.scala-lang", "scalap")         => true
       case ("org.typelevel", "scala-library")   => true
       case _                                    => false
     }


### PR DESCRIPTION
This means that `scalap` won't be updated unless `updates.includeScala`
is set to `true`.

See https://github.com/scalameta/scalameta/pull/2037#discussion_r416408389