### PR TITLE
Rename BuildSystem to BuildTool

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -24,7 +24,6 @@ import org.http4s.Uri
 import org.http4s.syntax.literals._
 import org.scalasteward.core.application.Cli._
 import org.scalasteward.core.util.ApplicativeThrowable
-
 import scala.concurrent.duration._
 
 final class Cli[F[_]](implicit F: ApplicativeThrowable[F]) {

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -24,7 +24,6 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.util
 import org.scalasteward.core.vcs.data.AuthenticatedUser
-
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.process.Process
 

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Context.scala
@@ -22,9 +22,9 @@ import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.client.Client
 import org.http4s.client.asynchttpclient.AsyncHttpClient
-import org.scalasteward.core.buildsystem.BuildSystemDispatcher
-import org.scalasteward.core.buildsystem.maven.MavenAlg
-import org.scalasteward.core.buildsystem.sbt.SbtAlg
+import org.scalasteward.core.buildtool.BuildToolDispatcher
+import org.scalasteward.core.buildtool.maven.MavenAlg
+import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.GitAlg
@@ -83,7 +83,7 @@ object Context {
       implicit val updateAlg: UpdateAlg[F] = new UpdateAlg[F]
       implicit val mavenAlg: MavenAlg[F] = MavenAlg.create[F]
       implicit val sbtAlg: SbtAlg[F] = SbtAlg.create[F]
-      implicit val buildSystemDispatcher: BuildSystemDispatcher[F] = BuildSystemDispatcher.create[F]
+      implicit val buildToolDispatcher: BuildToolDispatcher[F] = BuildToolDispatcher.create[F]
       implicit val refreshErrorAlg: RefreshErrorAlg[F] =
         new RefreshErrorAlg[F](new JsonKeyValueStore("refresh_error", "1", kvsPrefix))
       implicit val repoCacheAlg: RepoCacheAlg[F] = new RepoCacheAlg[F]

--- a/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/StewardAlg.scala
@@ -22,7 +22,7 @@ import cats.effect.ExitCode
 import cats.implicits._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.buildsystem.sbt.SbtAlg
+import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.nurture.NurtureAlg

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/BuildToolAlg.scala
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.sbt
+package org.scalasteward.core.buildtool
 
-object command {
-  val setOffline = "set offline := true"
-  val stewardDependencies = "stewardDependencies"
-  val crossStewardDependencies = s"+ $stewardDependencies"
-  val reloadPlugins = "reload plugins"
-  val scalafix = "scalafix"
-  val testScalafix = "test:scalafix"
-  val scalafixEnable = "scalafixEnable"
+import org.scalasteward.core.data.Scope
+import org.scalasteward.core.scalafix.Migration
+import org.scalasteward.core.util.Nel
+import org.scalasteward.core.vcs.data.Repo
+
+trait BuildToolAlg[F[_]] {
+  def containsBuild(repo: Repo): F[Boolean]
+
+  def getDependencies(repo: Repo): F[List[Scope.Dependencies]]
+
+  def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit]
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/MavenAlg.scala
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.maven
+package org.scalasteward.core.buildtool.maven
 
 import better.files.File
 import cats.Monad
 import cats.implicits._
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildsystem.BuildSystemAlg
+import org.scalasteward.core.buildtool.BuildToolAlg
 import org.scalasteward.core.data._
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
-trait MavenAlg[F[_]] extends BuildSystemAlg[F]
+trait MavenAlg[F[_]] extends BuildToolAlg[F]
 
 object MavenAlg {
   def create[F[_]](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/command.scala
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem
+package org.scalasteward.core.buildtool.maven
 
-import org.scalasteward.core.data.Scope
-import org.scalasteward.core.scalafix.Migration
-import org.scalasteward.core.util.Nel
-import org.scalasteward.core.vcs.data.Repo
-
-trait BuildSystemAlg[F[_]] {
-  def containsBuild(repo: Repo): F[Boolean]
-
-  def getDependencies(repo: Repo): F[List[Scope.Dependencies]]
-
-  def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit]
+object command {
+  val listDependencies = "dependency:list"
+  val listRepositories = "dependency:list-repositories"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/maven/parser.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.maven
+package org.scalasteward.core.buildtool.maven
 
 import atto.Atto._
 import atto._

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.sbt
+package org.scalasteward.core.buildtool.sbt
 
 import better.files.File
 import cats.data.OptionT
@@ -22,9 +22,9 @@ import cats.implicits._
 import cats.{Functor, Monad}
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildsystem.BuildSystemAlg
-import org.scalasteward.core.buildsystem.sbt.command._
-import org.scalasteward.core.buildsystem.sbt.data.SbtVersion
+import org.scalasteward.core.buildtool.BuildToolAlg
+import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Dependency, Resolver, Scope}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
@@ -32,7 +32,7 @@ import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.util.Nel
 import org.scalasteward.core.vcs.data.Repo
 
-trait SbtAlg[F[_]] extends BuildSystemAlg[F] {
+trait SbtAlg[F[_]] extends BuildToolAlg[F] {
   def addGlobalPluginTemporarily[A](plugin: FileData)(fa: F[A]): F[A]
 
   def addGlobalPlugins[A](fa: F[A]): F[A]

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.sbt.data
+package org.scalasteward.core.buildtool.sbt
 
-import cats.Order
-import cats.implicits._
-import io.circe.Codec
-import io.circe.generic.extras.semiauto._
-import org.scalasteward.core.data.Version
-
-final case class SbtVersion(value: String) {
-  def toVersion: Version = Version(value)
-}
-
-object SbtVersion {
-  implicit val sbtVersionCodec: Codec[SbtVersion] =
-    deriveUnwrappedCodec
-
-  implicit val sbtVersionOrder: Order[SbtVersion] =
-    Order[String].contramap(_.value)
+object command {
+  val setOffline = "set offline := true"
+  val stewardDependencies = "stewardDependencies"
+  val crossStewardDependencies = s"+ $stewardDependencies"
+  val reloadPlugins = "reload plugins"
+  val scalafix = "scalafix"
+  val testScalafix = "test:scalafix"
+  val scalafixEnable = "scalafixEnable"
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/SbtVersion.scala
@@ -14,9 +14,22 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.maven
+package org.scalasteward.core.buildtool.sbt.data
 
-object command {
-  val listDependencies = "dependency:list"
-  val listRepositories = "dependency:list-repositories"
+import cats.Order
+import cats.implicits._
+import io.circe.Codec
+import io.circe.generic.extras.semiauto._
+import org.scalasteward.core.data.Version
+
+final case class SbtVersion(value: String) {
+  def toVersion: Version = Version(value)
+}
+
+object SbtVersion {
+  implicit val sbtVersionCodec: Codec[SbtVersion] =
+    deriveUnwrappedCodec
+
+  implicit val sbtVersionOrder: Order[SbtVersion] =
+    Order[String].contramap(_.value)
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/data/ScalaVersion.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.sbt.data
+package org.scalasteward.core.buildtool.sbt.data
 
 import cats.Order
 import cats.implicits._

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem
+package org.scalasteward.core.buildtool
 
 import cats.Functor
 import cats.implicits._
-import org.scalasteward.core.BuildInfo
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 import org.scalasteward.core.io.{FileAlg, FileData}
-import org.scalasteward.core.buildsystem.sbt.data.SbtVersion
 
 package object sbt {
   val defaultScalaBinaryVersion: String =
-    BuildInfo.scalaBinaryVersion
+    org.scalasteward.core.BuildInfo.scalaBinaryVersion
 
   def sbtDependency(sbtVersion: SbtVersion): Option[Dependency] =
     if (sbtVersion.toVersion >= Version("1.0.0"))

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/parser.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildsystem.sbt
+package org.scalasteward.core.buildtool.sbt
 
 import cats.implicits._
 import io.circe.Decoder
 import io.circe.parser._
-import org.scalasteward.core.buildsystem.sbt.data.SbtVersion
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data._
 
 object parser {

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Dependency.scala
@@ -20,7 +20,7 @@ import cats.Order
 import cats.implicits._
 import io.circe.Codec
 import io.circe.generic.semiauto._
-import org.scalasteward.core.buildsystem.sbt.data.{SbtVersion, ScalaVersion}
+import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 
 final case class Dependency(
     groupId: GroupId,

--- a/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/edit/EditAlg.scala
@@ -21,7 +21,7 @@ import cats.Traverse
 import cats.implicits._
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
-import org.scalasteward.core.buildsystem.BuildSystemDispatcher
+import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.data.Update
 import org.scalasteward.core.io.{isSourceFile, FileAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.MigrationAlg
@@ -29,7 +29,7 @@ import org.scalasteward.core.util._
 import org.scalasteward.core.vcs.data.Repo
 
 final class EditAlg[F[_]](implicit
-    buildSystemDispatcher: BuildSystemDispatcher[F],
+    buildToolDispatcher: BuildToolDispatcher[F],
     fileAlg: FileAlg[F],
     logger: Logger[F],
     migrationAlg: MigrationAlg,
@@ -63,6 +63,6 @@ final class EditAlg[F[_]](implicit
   def applyScalafixMigrations(repo: Repo, update: Update): F[Unit] =
     Nel.fromList(migrationAlg.findMigrations(update)).traverse_ { migrations =>
       logger.info(s"Applying migrations: $migrations") >>
-        buildSystemDispatcher.runMigrations(repo, migrations)
+        buildToolDispatcher.runMigrations(repo, migrations)
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala
@@ -29,8 +29,8 @@ import org.scalasteward.core.git.{Branch, GitAlg}
 import org.scalasteward.core.repocache.RepoCacheRepository
 import org.scalasteward.core.repoconfig.{PullRequestUpdateStrategy, RepoConfigAlg}
 import org.scalasteward.core.scalafix.MigrationAlg
-import org.scalasteward.core.util.{DateTimeAlg, HttpExistenceClient}
 import org.scalasteward.core.util.logger.LoggerOps
+import org.scalasteward.core.util.{DateTimeAlg, HttpExistenceClient}
 import org.scalasteward.core.vcs.data.{NewPullRequestData, Repo}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSExtraAlg, VCSRepoAlg}
 import org.scalasteward.core.{git, util, vcs}

--- a/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repocache/RepoCacheAlg.scala
@@ -20,7 +20,7 @@ import cats.Parallel
 import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.application.Config
-import org.scalasteward.core.buildsystem.BuildSystemDispatcher
+import org.scalasteward.core.buildtool.BuildToolDispatcher
 import org.scalasteward.core.data.{Dependency, DependencyInfo}
 import org.scalasteward.core.git.GitAlg
 import org.scalasteward.core.repoconfig.RepoConfigAlg
@@ -30,7 +30,7 @@ import org.scalasteward.core.vcs.data.{Repo, RepoOut}
 import org.scalasteward.core.vcs.{VCSApiAlg, VCSRepoAlg}
 
 final class RepoCacheAlg[F[_]](implicit
-    buildSystemDispatcher: BuildSystemDispatcher[F],
+    buildToolDispatcher: BuildToolDispatcher[F],
     config: Config,
     gitAlg: GitAlg[F],
     logger: Logger[F],
@@ -78,7 +78,7 @@ final class RepoCacheAlg[F[_]](implicit
     for {
       branch <- gitAlg.currentBranch(repo)
       latestSha1 <- gitAlg.latestSha1(repo, branch)
-      dependencies <- buildSystemDispatcher.getDependencies(repo)
+      dependencies <- buildToolDispatcher.getDependencies(repo)
       dependencyInfos <-
         dependencies
           .traverse(_.traverse(_.traverse(gatherDependencyInfo(repo, _))))

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -19,7 +19,7 @@ package org.scalasteward.core.scalafmt
 import cats.data.Nested
 import cats.implicits._
 import cats.{Functor, Monad}
-import org.scalasteward.core.buildsystem.sbt.defaultScalaBinaryVersion
+import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
 import org.scalasteward.core.data.{Dependency, Version}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.vcs.data.Repo

--- a/modules/core/src/main/scala/org/scalasteward/core/update/GroupMigrations.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/GroupMigrations.scala
@@ -17,14 +17,13 @@
 package org.scalasteward.core.update
 
 import cats.implicits._
-import org.scalasteward.core.data._
-import org.scalasteward.core.application.Config
-import org.scalasteward.core.io.FileAlg
-import org.scalasteward.core.util.Nel
-import org.scalasteward.core.util.MonadThrowable
-import io.circe.config.parser
 import io.circe.Decoder
+import io.circe.config.parser
 import io.circe.generic.extras.{semiauto, Configuration}
+import org.scalasteward.core.application.Config
+import org.scalasteward.core.data._
+import org.scalasteward.core.io.FileAlg
+import org.scalasteward.core.util.{MonadThrowable, Nel}
 
 trait GroupMigrations {
   def findUpdateWithNewerGroupId(dependency: Dependency): Option[Update.Single]

--- a/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/UpdateAlg.scala
@@ -16,15 +16,13 @@
 
 package org.scalasteward.core.update
 
-import cats.Monad
+import cats.{Eval, Monad}
 import cats.implicits._
 import org.scalasteward.core.coursier.VersionsCache
 import org.scalasteward.core.data._
 import org.scalasteward.core.repoconfig.RepoConfig
 import org.scalasteward.core.util.Nel
 import scala.concurrent.duration.FiniteDuration
-import org.scalasteward.core.update.GroupMigrations
-import cats.Eval
 
 final class UpdateAlg[F[_]](implicit
     filterAlg: FilterAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/util/HttpJsonClient.scala
@@ -22,8 +22,7 @@ import io.circe.{Decoder, Encoder}
 import org.http4s.Method.{GET, POST}
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.client.Client
-import org.http4s.{DecodeFailure, Headers, HttpVersion, Method, Request, Response, Status, Uri}
-
+import org.http4s._
 import scala.util.control.NoStackTrace
 
 final class HttpJsonClient[F[_]: Sync](implicit

--- a/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/vcs/data/NewPullRequestData.scala
@@ -20,7 +20,6 @@ import cats.implicits._
 import io.circe.Encoder
 import io.circe.generic.semiauto._
 import org.http4s.Uri
-import org.scalasteward.core.BuildInfo
 import org.scalasteward.core.data.{GroupId, ReleaseRelatedUrl, SemVer, Update}
 import org.scalasteward.core.git
 import org.scalasteward.core.git.Branch
@@ -59,7 +58,7 @@ object NewPullRequestData {
        |
        |If you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.
        |
-       |Configure Scala Steward for your repository with a [`${RepoConfigAlg.repoConfigBasename}`](https://github.com/fthomas/scala-steward/blob/${BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.
+       |Configure Scala Steward for your repository with a [`${RepoConfigAlg.repoConfigBasename}`](https://github.com/fthomas/scala-steward/blob/${org.scalasteward.core.BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.
        |
        |Have a fantastic day writing Scala!
        |

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -1,18 +1,18 @@
-package org.scalasteward.core.buildsystem
+package org.scalasteward.core.buildtool
 
-import org.scalasteward.core.buildsystem.sbt.command._
-import org.scalasteward.core.mock.MockContext.{buildSystemDispatcher, config}
+import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.mock.MockContext.{buildToolDispatcher, config}
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-class BuildSystemDispatcherTest extends AnyFunSuite with Matchers {
+class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
   test("getDependencies") {
     val repo = Repo("typelevel", "cats")
     val repoDir = config.workspace / repo.show
     val initial = MockState.empty
-    val state = buildSystemDispatcher.getDependencies(repo).runS(initial).unsafeRunSync()
+    val state = buildToolDispatcher.getDependencies(repo).runS(initial).unsafeRunSync()
 
     state shouldBe initial.copy(commands =
       Vector(

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/MavenAlgTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.buildsystem.maven
+package org.scalasteward.core.buildtool.maven
 
 import better.files.File
 import org.scalasteward.core.mock.MockContext._

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/maven/parserTest.scala
@@ -1,4 +1,4 @@
-package org.scalasteward.core.buildsystem.maven
+package org.scalasteward.core.buildtool.maven
 
 import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.ArtifactId

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -1,7 +1,7 @@
-package org.scalasteward.core.buildsystem.sbt
+package org.scalasteward.core.buildtool.sbt
 
 import cats.data.StateT
-import org.scalasteward.core.buildsystem.sbt.command._
+import org.scalasteward.core.buildtool.sbt.command._
 import org.scalasteward.core.data.{GroupId, Version}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/parserTest.scala
@@ -1,8 +1,8 @@
-package org.scalasteward.core.buildsystem.sbt
+package org.scalasteward.core.buildtool.sbt
 
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.buildsystem.sbt.data.SbtVersion
-import org.scalasteward.core.buildsystem.sbt.parser._
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
+import org.scalasteward.core.buildtool.sbt.parser._
 import org.scalasteward.core.data.Resolver.{Credentials, IvyRepository, MavenRepository}
 import org.scalasteward.core.data.{ArtifactId, Scope}
 import org.scalatest.funsuite.AnyFunSuite

--- a/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/coursier/CoursierAlgTest.scala
@@ -2,7 +2,7 @@ package org.scalasteward.core.coursier
 
 import org.http4s.syntax.literals._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.buildsystem.sbt.data.{SbtVersion, ScalaVersion}
+import org.scalasteward.core.buildtool.sbt.data.{SbtVersion, ScalaVersion}
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState

--- a/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/git/gitTest.scala
@@ -1,15 +1,15 @@
 package org.scalasteward.core.git
 
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalasteward.core.TestSyntax._
+import org.scalasteward.core.data.Update
+import org.scalasteward.core.data.Update.Single
+import org.scalasteward.core.repoconfig.CommitsConfig
+import org.scalasteward.core.update.show
+import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.scalasteward.core.TestSyntax._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalasteward.core.data.Update.Single
-import org.scalasteward.core.data.Update
-import org.scalasteward.core.util.Nel
-import org.scalasteward.core.update.show
-import org.scalasteward.core.repoconfig.CommitsConfig
 
 class gitTest extends AnyFunSuite with Matchers with ScalaCheckPropertyChecks {
   implicit val updateArbitrary: Arbitrary[Update] = Arbitrary(for {

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -7,9 +7,9 @@ import org.http4s.Uri
 import org.scalasteward.core.TestInstances.ioContextShift
 import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.application.{Config, SupportedVCS}
-import org.scalasteward.core.buildsystem.BuildSystemDispatcher
-import org.scalasteward.core.buildsystem.maven.MavenAlg
-import org.scalasteward.core.buildsystem.sbt.SbtAlg
+import org.scalasteward.core.buildtool.BuildToolDispatcher
+import org.scalasteward.core.buildtool.maven.MavenAlg
+import org.scalasteward.core.buildtool.sbt.SbtAlg
 import org.scalasteward.core.coursier.{CoursierAlg, VersionsCache}
 import org.scalasteward.core.edit.EditAlg
 import org.scalasteward.core.git.{Author, GitAlg}
@@ -80,7 +80,7 @@ object MockContext {
   implicit val updateAlg: UpdateAlg[MockEff] = new UpdateAlg[MockEff]
   implicit val mavenAlg: MavenAlg[MockEff] = MavenAlg.create
   implicit val sbtAlg: SbtAlg[MockEff] = SbtAlg.create
-  implicit val buildSystemDispatcher: BuildSystemDispatcher[MockEff] = BuildSystemDispatcher.create
+  implicit val buildToolDispatcher: BuildToolDispatcher[MockEff] = BuildToolDispatcher.create
   implicit val editAlg: EditAlg[MockEff] = new EditAlg[MockEff]
   implicit val repoConfigAlg: RepoConfigAlg[MockEff] = new RepoConfigAlg[MockEff]
   implicit val pullRequestRepository: PullRequestRepository[MockEff] =

--- a/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/FilterAlgTest.scala
@@ -2,8 +2,8 @@ package org.scalasteward.core.update
 
 import cats.implicits._
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.data.Update.Single
+import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId}
 import org.scalasteward.core.mock.MockContext.filterAlg
 import org.scalasteward.core.mock.MockState
 import org.scalasteward.core.repoconfig.{RepoConfig, UpdatePattern, UpdatesConfig}

--- a/modules/core/src/test/scala/org/scalasteward/core/update/GroupMigrationsTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/GroupMigrationsTest.scala
@@ -4,10 +4,10 @@ import org.scalasteward.core.TestSyntax._
 import org.scalasteward.core.data.{ArtifactId, GroupId, Update}
 import org.scalasteward.core.mock.MockContext._
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.update.GroupMigrations.GroupIdChange
 import org.scalasteward.core.util.Nel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.scalasteward.core.update.GroupMigrations.GroupIdChange
 
 class GroupMigrationsTest extends AnyFunSuite with Matchers {
 

--- a/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/vcs/data/NewPullRequestDataTest.scala
@@ -2,9 +2,8 @@ package org.scalasteward.core.vcs.data
 
 import io.circe.syntax._
 import org.http4s.syntax.literals._
-import org.scalasteward.core.BuildInfo
 import org.scalasteward.core.TestSyntax._
-import org.scalasteward.core.buildsystem.sbt.data.SbtVersion
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{ReleaseRelatedUrl, Update, Version}
 import org.scalasteward.core.git.{Branch, Sha1}
 import org.scalasteward.core.nurture.UpdateData
@@ -31,7 +30,7 @@ class NewPullRequestDataTest extends AnyFunSuite with Matchers {
       .spaces2 shouldBe
       raw"""|{
            |  "title" : "Update logback-classic to 1.2.3",
-           |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nConfigure Scala Steward for your repository with a [`.scala-steward.conf`](https://github.com/fthomas/scala-steward/blob/${BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n\nlabels: library-update, semver-patch",
+           |  "body" : "Updates ch.qos.logback:logback-classic from 1.2.0 to 1.2.3.\n\n\nI'll automatically update this PR to resolve conflicts as long as you don't change it yourself.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback, just mention me in the comments below.\n\nConfigure Scala Steward for your repository with a [`.scala-steward.conf`](https://github.com/fthomas/scala-steward/blob/${org.scalasteward.core.BuildInfo.gitHeadCommit}/docs/repo-specific-configuration.md) file.\n\nHave a fantastic day writing Scala!\n\n<details>\n<summary>Ignore future updates</summary>\n\nAdd this to your `.scala-steward.conf` file to ignore future updates of this dependency:\n```\nupdates.ignore = [ { groupId = \"ch.qos.logback\", artifactId = \"logback-classic\" } ]\n```\n</details>\n\nlabels: library-update, semver-patch",
            |  "head" : "scala-steward:update/logback-classic-1.2.3",
            |  "base" : "master"
            |}""".stripMargin

--- a/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
+++ b/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
@@ -18,9 +18,8 @@ package org.scalasteward.plugin
 
 import sbt.Keys._
 import sbt._
-
-import scala.util.matching.Regex
 import scala.util.Try
+import scala.util.matching.Regex
 
 object StewardPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements


### PR DESCRIPTION
Because it is shorter and "build tool" seems to be more prevalent than
"build system" in Scala land.