### PR TITLE
docs: Add Avast to community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Consider creating PR to add your company to the list and join the community.
 
 * [Adform](https://site.adform.com/)
 * [AutoScout24](https://www.autoscout24.de/)
+* [Avast](https://avast.com)
 * [Besedo](https://www.besedo.com/)
 * [Bitrock](http://www.bitrock.it/)
 * [Chartboost](https://www.chartboost.com/)

--- a/docs/running.md
+++ b/docs/running.md
@@ -106,3 +106,8 @@ docker run -v $PWD:/opt/scala-steward \
 `BITBUCKET_USERNAME=<myuser> BITBUCKET_PASSWORD=<mypass> ./run.sh`
 
 [migrations]: https://github.com/fthomas/scala-steward/blob/master/docs/scalafix-migrations.md
+
+### Running On-premise (GitHub Enterprise)
+
+There is an article on how they run Scala Steward on-premise at Avast:
+* [Running Scala Steward On-premise](https://engineering.avast.io/running-scala-steward-on-premise)


### PR DESCRIPTION
docs: Mention article about how Avast runs Steward in "running"

Hello,

I would like to add Avast to the community list of companies using it. I also wrote an article on how we run Scala Steward internally so I thought it would be good to mention in the docs describing how to run Scala Steward because there are certain parts that are not fully described. Thanks.