### PR TITLE
Fix credential loading issue with courier on enterprise nexus setup.

### DIFF
--- a/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
+++ b/modules/plugin/src/main/scala/org/scalasteward/plugin/StewardPlugin.scala
@@ -39,7 +39,7 @@ object StewardPlugin extends AutoPlugin {
         val buildRoot = baseDirectory.in(ThisBuild).value
         val scalaBinaryVersionValue = scalaBinaryVersion.value
         val scalaVersionValue = scalaVersion.value
-        val sbtCredentials = credentials.value
+        val sbtCredentials = allCredentials.value
 
         val libraryDeps = libraryDependencies.value
           .filter(isDefinedInBuildFiles(_, sourcePositions, buildRoot))


### PR DESCRIPTION
At my place of work we have an enterprise/secured nexus setup.  the normal `credentials` key doesn't load the credentials correct for multi project builds, but `allCredentials` does.

This change will help us deploy it internally for updating our private GHE repos.

see: https://github.com/sbt/sbt/pull/4855/files/c31e0b6b550b9da9f98d3a8289283df9ade11323

Thanks!