### PR TITLE
Fix labeling for versions with a leading zero

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/SemVer.scala
@@ -64,11 +64,24 @@ object SemVer {
     case object BuildMetadata extends Change("build-metadata")
   }
 
-  def getChange(from: SemVer, to: SemVer): Option[Change] =
-    if (from.major =!= to.major) Some(Major)
+  def getChange(from: SemVer, to: SemVer): Option[Change] = {
+    val zero = NonNegBigInt.unsafeFrom(0)
+    if (
+      from.major === zero && to.major === zero &&
+      (from.minor =!= zero ||
+      to.minor =!= zero ||
+      from.patch =!= zero ||
+      to.patch =!= zero)
+    )
+      getChange(
+        from.copy(major = from.minor, minor = from.patch, patch = zero),
+        to.copy(major = to.minor, minor = to.patch, patch = zero)
+      )
+    else if (from.major =!= to.major) Some(Major)
     else if (from.minor =!= to.minor) Some(Minor)
     else if (from.preRelease =!= to.preRelease) Some(PreRelease)
     else if (from.patch =!= to.patch) Some(Patch)
     else if (from.buildMetadata =!= to.buildMetadata) Some(BuildMetadata)
     else None
+  }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/data/SemVerTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/data/SemVerTest.scala
@@ -72,6 +72,14 @@ class SemVerTest extends AnyFunSuite with Matchers {
       SemVer(2, 3, 4, Some("M1"), None)
     ) shouldBe None
     SemVer.getChange(SemVer(0, 20, 0, Some("M4"), None), SemVer(0, 20, 3, None, None)) shouldBe
-      Some(Change.PreRelease)
+      Some(Change.Minor)
+    SemVer.getChange(SemVer(0, 1, 0, None, None), SemVer(0, 2, 0, None, None)) shouldBe
+      Some(Change.Major)
+    SemVer.getChange(SemVer(0, 0, 1, None, None), SemVer(0, 0, 2, None, None)) shouldBe
+      Some(Change.Major)
+    SemVer.getChange(SemVer(0, 0, 0, None, None), SemVer(0, 0, 1, None, None)) shouldBe
+      Some(Change.Major)
+    SemVer.getChange(SemVer(0, 0, 0, None, None), SemVer(0, 0, 0, None, None)) shouldBe
+      None
   }
 }


### PR DESCRIPTION
Properly handle labeling of changes where where the version is like `0.x.y`
