### PR TITLE
Add default .scala-steward.conf for Scala Steward itself

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,7 @@ runSteward := Def.taskDyn {
   val args = Seq(
     Seq("--workspace", s"$projectDir/workspace"),
     Seq("--repos-file", s"$projectDir/repos.md"),
-    Seq("--repos-default-config", s"$projectDir/default.scala-steward.conf"),
+    Seq("--default-repo-config", s"$projectDir/default.scala-steward.conf"),
     Seq("--git-author-email", s"me@$projectName.org"),
     Seq("--vcs-login", projectName),
     Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),

--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,7 @@ runSteward := Def.taskDyn {
   val args = Seq(
     Seq("--workspace", s"$projectDir/workspace"),
     Seq("--repos-file", s"$projectDir/repos.md"),
-    Seq("--repos-default-config", s"$projectDir/.scala-steward.conf"),
+    Seq("--repos-default-config", s"$projectDir/default.scala-steward.conf"),
     Seq("--git-author-email", s"me@$projectName.org"),
     Seq("--vcs-login", projectName),
     Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),

--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,7 @@ runSteward := Def.taskDyn {
   val args = Seq(
     Seq("--workspace", s"$projectDir/workspace"),
     Seq("--repos-file", s"$projectDir/repos.md"),
+    Seq("--repos-default-config", s"$projectDir/.scala-steward.conf"),
     Seq("--git-author-email", s"me@$projectName.org"),
     Seq("--vcs-login", projectName),
     Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),

--- a/docs/running.md
+++ b/docs/running.md
@@ -6,6 +6,7 @@ sbt stage
 ./modules/core/.jvm/target/universal/stage/bin/scala-steward \
   --workspace  "$STEWARD_DIR/workspace" \
   --repos-file "$STEWARD_DIR/repos.md" \
+  --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -24,6 +25,7 @@ sbt docker:publishLocal
 docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
   --workspace  "/opt/scala-steward/workspace" \
   --repos-file "/opt/scala-steward/repos.md" \
+  --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -71,7 +73,7 @@ The file should contain a single line: `credentials += Credentials("Some Nexus R
 ```
 sbt
 project core
-run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
+run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/opt/scala-steward/.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
 ```
 
 
@@ -93,6 +95,7 @@ docker run -v $PWD:/opt/scala-steward \
     --do-not-fork \
     --workspace "/opt/scala-steward/workspace" \
     --repos-file "/opt/scala-steward/repos.md" \
+    --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
     --git-ask-pass "/opt/scala-steward/pass.sh" \
     --git-author-email "myemail@company.xyz" \
     --vcs-type "bitbucket" \

--- a/docs/running.md
+++ b/docs/running.md
@@ -6,7 +6,7 @@ sbt stage
 ./modules/core/.jvm/target/universal/stage/bin/scala-steward \
   --workspace  "$STEWARD_DIR/workspace" \
   --repos-file "$STEWARD_DIR/repos.md" \
-  --repos-default-conf "$STEWARD_DIR/.scala-steward.conf" \
+  --repos-default-conf "$STEWARD_DIR/default.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -25,7 +25,7 @@ sbt docker:publishLocal
 docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
   --workspace  "/opt/scala-steward/workspace" \
   --repos-file "/opt/scala-steward/repos.md" \
-  --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
+  --repos-default-conf "/opt/scala-steward/default.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -73,7 +73,7 @@ The file should contain a single line: `credentials += Credentials("Some Nexus R
 ```
 sbt
 project core
-run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/path/.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
+run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/path/default.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
 ```
 
 
@@ -95,7 +95,7 @@ docker run -v $PWD:/opt/scala-steward \
     --do-not-fork \
     --workspace "/opt/scala-steward/workspace" \
     --repos-file "/opt/scala-steward/repos.md" \
-    --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
+    --repos-default-conf "/opt/scala-steward/default.scala-steward.conf" \
     --git-ask-pass "/opt/scala-steward/pass.sh" \
     --git-author-email "myemail@company.xyz" \
     --vcs-type "bitbucket" \

--- a/docs/running.md
+++ b/docs/running.md
@@ -6,7 +6,7 @@ sbt stage
 ./modules/core/.jvm/target/universal/stage/bin/scala-steward \
   --workspace  "$STEWARD_DIR/workspace" \
   --repos-file "$STEWARD_DIR/repos.md" \
-  --repos-default-conf "/opt/scala-steward/.scala-steward.conf" \
+  --repos-default-conf "$STEWARD_DIR/.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \

--- a/docs/running.md
+++ b/docs/running.md
@@ -73,7 +73,7 @@ The file should contain a single line: `credentials += Credentials("Some Nexus R
 ```
 sbt
 project core
-run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/opt/scala-steward/.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
+run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/path/.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
 ```
 
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -6,7 +6,7 @@ sbt stage
 ./modules/core/.jvm/target/universal/stage/bin/scala-steward \
   --workspace  "$STEWARD_DIR/workspace" \
   --repos-file "$STEWARD_DIR/repos.md" \
-  --repos-default-conf "$STEWARD_DIR/default.scala-steward.conf" \
+  --default-repo-conf "$STEWARD_DIR/default.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -25,7 +25,7 @@ sbt docker:publishLocal
 docker run -v $STEWARD_DIR:/opt/scala-steward -it fthomas/scala-steward:latest \
   --workspace  "/opt/scala-steward/workspace" \
   --repos-file "/opt/scala-steward/repos.md" \
-  --repos-default-conf "/opt/scala-steward/default.scala-steward.conf" \
+  --default-repo-conf "/opt/scala-steward/default.scala-steward.conf" \
   --git-author-email ${EMAIL} \
   --vcs-api-host "https://api.github.com" \
   --vcs-login ${LOGIN} \
@@ -73,7 +73,7 @@ The file should contain a single line: `credentials += Credentials("Some Nexus R
 ```
 sbt
 project core
-run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --repos-default-conf "/path/default.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
+run --disable-sandbox --do-not-fork --workspace "/path/workspace" --repos-file "/path/repos.md" --default-repo-conf "/path/default.scala-steward.conf" --git-ask-pass "/path/pass.sh" --git-author-email "email@example.org" --vcs-type "gitlab" --vcs-api-host "https://gitlab.com/api/v4/" --vcs-login "gitlab.steward"
 ```
 
 
@@ -95,7 +95,7 @@ docker run -v $PWD:/opt/scala-steward \
     --do-not-fork \
     --workspace "/opt/scala-steward/workspace" \
     --repos-file "/opt/scala-steward/repos.md" \
-    --repos-default-conf "/opt/scala-steward/default.scala-steward.conf" \
+    --default-repo-conf "/opt/scala-steward/default.scala-steward.conf" \
     --git-ask-pass "/opt/scala-steward/pass.sh" \
     --git-author-email "myemail@company.xyz" \
     --vcs-type "bitbucket" \

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -37,7 +37,7 @@ object Cli {
   final case class Args(
       workspace: String,
       reposFile: String,
-      reposDefaultConf: String,
+      reposDefaultConf: String = ".scala-steward.conf",
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
       vcsType: SupportedVCS = SupportedVCS.GitHub,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -37,7 +37,7 @@ object Cli {
   final case class Args(
       workspace: String,
       reposFile: String,
-      reposDefaultConf: String = "default.scala-steward.conf",
+      defaultRepoConf: String = "default.scala-steward.conf",
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
       vcsType: SupportedVCS = SupportedVCS.GitHub,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -37,6 +37,7 @@ object Cli {
   final case class Args(
       workspace: String,
       reposFile: String,
+      reposDefaultConf: String,
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
       vcsType: SupportedVCS = SupportedVCS.GitHub,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -37,7 +37,7 @@ object Cli {
   final case class Args(
       workspace: String,
       reposFile: String,
-      reposDefaultConf: String = ".scala-steward.conf",
+      reposDefaultConf: String = "default.scala-steward.conf",
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
       vcsType: SupportedVCS = SupportedVCS.GitHub,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -24,6 +24,7 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.util
 import org.scalasteward.core.vcs.data.AuthenticatedUser
+
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.process.Process
 

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -32,7 +32,7 @@ import scala.sys.process.Process
   * == [[reposDefaultConfigFile]] ==
   * Location of default repo configuration file.
   * This will be used if target repo doesn't have custom configuration.
-  * Note if this file doesn't exist, [[org.scalasteward.core.repoconfig.RepoConfig.default]] will be applied
+  * Note if this file doesn't exist, empty configuration will be applied
   *
   * == [[vcsApiHost]] ==
   * REST API v3 endpoints prefix

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -29,7 +29,7 @@ import scala.sys.process.Process
 
 /** Configuration for scala-steward.
   *
-  * == [[reposDefaultConfigFile]] ==
+  * == [[defaultRepoConfigFile]] ==
   * Location of default repo configuration file.
   * This will be used if target repo doesn't have custom configuration.
   * Note if this file doesn't exist, empty configuration will be applied
@@ -54,7 +54,7 @@ import scala.sys.process.Process
 final case class Config(
     workspace: File,
     reposFile: File,
-    reposDefaultConfigFile: File,
+    defaultRepoConfigFile: File,
     gitAuthor: Author,
     vcsType: SupportedVCS,
     vcsApiHost: Uri,
@@ -90,7 +90,7 @@ object Config {
       Config(
         workspace = args.workspace.toFile,
         reposFile = args.reposFile.toFile,
-        reposDefaultConfigFile = args.reposDefaultConf.toFile,
+        defaultRepoConfigFile = args.defaultRepoConf.toFile,
         gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
         vcsType = args.vcsType,
         vcsApiHost = args.vcsApiHost,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -24,11 +24,15 @@ import org.scalasteward.core.application.Cli.EnvVar
 import org.scalasteward.core.git.Author
 import org.scalasteward.core.util
 import org.scalasteward.core.vcs.data.AuthenticatedUser
-
 import scala.concurrent.duration.FiniteDuration
 import scala.sys.process.Process
 
 /** Configuration for scala-steward.
+  *
+  * == [[reposDefaultConfigFile]] ==
+  * Location of default repo configuration file.
+  * This will be used if target repo doesn't have custom configuration.
+  * Note if this file doesn't exist, [[org.scalasteward.core.repoconfig.RepoConfig.default]] will be applied
   *
   * == [[vcsApiHost]] ==
   * REST API v3 endpoints prefix

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -50,6 +50,7 @@ import scala.sys.process.Process
 final case class Config(
     workspace: File,
     reposFile: File,
+    reposDefaultConfigFile: File,
     gitAuthor: Author,
     vcsType: SupportedVCS,
     vcsApiHost: Uri,
@@ -85,6 +86,7 @@ object Config {
       Config(
         workspace = args.workspace.toFile,
         reposFile = args.reposFile.toFile,
+        reposDefaultConfigFile = args.reposDefaultConf.toFile,
         gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
         vcsType = args.vcsType,
         vcsApiHost = args.vcsApiHost,

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,7 +31,7 @@ final case class RepoConfig(
 }
 
 object RepoConfig {
-  val default: RepoConfig = RepoConfig()
+  private[core] val default: RepoConfig = RepoConfig()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,7 +31,7 @@ final case class RepoConfig(
 }
 
 object RepoConfig {
-  private[core] val default: RepoConfig = RepoConfig()
+  private[repoconfig] val empty: RepoConfig = RepoConfig()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -50,7 +50,9 @@ final class RepoConfigAlg[F[_]](implicit
     readConfiguration(config.reposDefaultConfigFile).map(_.getOrElse(RepoConfig.default))
 
   def readRepoConfig(repo: Repo): F[Option[RepoConfig]] =
-    workspaceAlg.repoDir(repo).flatMap(projectRootDir => readConfiguration(projectRootDir / repoConfigBasename))
+    workspaceAlg
+      .repoDir(repo)
+      .flatMap(projectRootDir => readConfiguration(projectRootDir / repoConfigBasename))
 
   private def readConfiguration(configFile: File): F[Option[RepoConfig]] = {
     val maybeRepoConfig = OptionT(fileAlg.readFile(configFile)).map(parseRepoConfig).flatMapF {

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -43,7 +43,7 @@ final class RepoConfigAlg[F[_]](implicit
 
   /**
     * Default configuration will try to read .scala-steward.conf in the root
-    * If not found - fallback to [[RepoConfig.default]]
+    * If not found - fallback to empty configuration
     * Note it's not lazy since we want to get config updates if you decide to change config in the middle of the process
     */
   def defaultRepoConfig(): F[RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -37,8 +37,7 @@ final class RepoConfigAlg[F[_]](implicit
 ) {
   def readRepoConfigOrDefault(repo: Repo): F[RepoConfig] =
     readRepoConfig(repo).flatMap { config =>
-      if (config.isDefined) F.pure(config.get)
-      else defaultRepoConfig()
+      config.map(F.pure).getOrElse(defaultRepoConfig())
     }
 
   /**

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -37,7 +37,7 @@ final class RepoConfigAlg[F[_]](implicit
 ) {
   def readRepoConfigOrDefault(repo: Repo): F[RepoConfig] =
     readRepoConfig(repo).flatMap { config =>
-      config.map(F.pure).getOrElse(defaultRepoConfig())
+      config.map(F.pure).getOrElse(defaultRepoConfig)
     }
 
   /**
@@ -45,7 +45,7 @@ final class RepoConfigAlg[F[_]](implicit
     * if not found - fallback to empty configuration.
     * Note it's not lazy since we want to get config updates if you decide to change config in the middle of the process
     */
-  def defaultRepoConfig(): F[RepoConfig] =
+  val defaultRepoConfig: F[RepoConfig] =
     readRepoConfigFromFile(config.defaultRepoConfigFile).map(_.getOrElse(RepoConfig.empty))
 
   def readRepoConfig(repo: Repo): F[Option[RepoConfig]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -41,7 +41,7 @@ final class RepoConfigAlg[F[_]](implicit
     }
 
   /**
-    * Default configuration will try to read .scala-steward.conf in the root
+    * Default configuration will try to read [[config.reposDefaultConfigFile]] first
     * If not found - fallback to empty configuration
     * Note it's not lazy since we want to get config updates if you decide to change config in the middle of the process
     */

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -41,8 +41,7 @@ final class RepoConfigAlg[F[_]](implicit
     }
 
   /**
-    * Default configuration will try to read [[config.reposDefaultConfigFile]] first
-    * If not found - fallback to empty configuration
+    * Default configuration will try to read file specified in config.reposDefaultConfig first; if not found - fallback to empty configuration.
     * Note it's not lazy since we want to get config updates if you decide to change config in the middle of the process
     */
   def defaultRepoConfig(): F[RepoConfig] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -43,9 +43,8 @@ final class RepoConfigAlg[F[_]](implicit
   /**
     * Default configuration will try to read file specified in config.reposDefaultConfig first;
     * if not found - fallback to empty configuration.
-    * Note it's not lazy since we want to get config updates if you decide to change config in the middle of the process
     */
-  val defaultRepoConfig: F[RepoConfig] =
+  lazy val defaultRepoConfig: F[RepoConfig] =
     readRepoConfigFromFile(config.defaultRepoConfigFile).map(_.getOrElse(RepoConfig.empty))
 
   def readRepoConfig(repo: Repo): F[Option[RepoConfig]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -27,7 +27,6 @@ import org.scalasteward.core.repoconfig.RepoConfigAlg._
 import org.scalasteward.core.util.MonadThrowable
 import org.scalasteward.core.vcs.data.Repo
 
-
 final class RepoConfigAlg[F[_]](implicit
     fileAlg: FileAlg[F],
     logger: Logger[F],
@@ -44,9 +43,8 @@ final class RepoConfigAlg[F[_]](implicit
     * Default configuration will try to read .scala-steward.conf in the root
     * If not found - fallback to [[RepoConfig.default]]
     */
-  lazy val defaultRepoConfig: F[RepoConfig] = {
+  lazy val defaultRepoConfig: F[RepoConfig] =
     workspaceAlg.rootDir.flatMap(readConfiguration(_).map(_.getOrElse(RepoConfig.default)))
-  }
 
   def readRepoConfig(repo: Repo): F[Option[RepoConfig]] =
     workspaceAlg.repoDir(repo).flatMap(readConfiguration)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -74,8 +74,8 @@ final class PruningAlg[F[_]](implicit
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      repoConfig <- OptionT.fromOption[F](repoCache.maybeRepoConfig)
-        .getOrElseF(repoConfigAlg.defaultRepoConfig)
+      repoConfig <-
+        OptionT.fromOption[F](repoCache.maybeRepoConfig).getOrElseF(repoConfigAlg.defaultRepoConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)
       outdatedDeps = collectOutdatedDependencies(updateStates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -74,8 +74,7 @@ final class PruningAlg[F[_]](implicit
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      defaultConfig <- repoConfigAlg.defaultRepoConfig
-      repoConfig = repoCache.maybeRepoConfig.getOrElse(defaultConfig)
+      repoConfig <- OptionT.fromOption[F](repoCache.maybeRepoConfig).getOrElseF(repoConfigAlg.defaultRepoConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)
       outdatedDeps = collectOutdatedDependencies(updateStates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -74,7 +74,8 @@ final class PruningAlg[F[_]](implicit
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      repoConfig <- OptionT.fromOption[F](repoCache.maybeRepoConfig).getOrElseF(repoConfigAlg.defaultRepoConfig)
+      repoConfig <- OptionT.fromOption[F](repoCache.maybeRepoConfig)
+        .getOrElseF(repoConfigAlg.defaultRepoConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)
       outdatedDeps = collectOutdatedDependencies(updateStates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -23,14 +23,15 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.data._
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
-import org.scalasteward.core.repoconfig.{PullRequestFrequency, RepoConfig, UpdatesConfig}
+import org.scalasteward.core.repoconfig.{PullRequestFrequency, RepoConfig, RepoConfigAlg, UpdatesConfig}
 import org.scalasteward.core.update.PruningAlg._
 import org.scalasteward.core.update.data.UpdateState
 import org.scalasteward.core.update.data.UpdateState._
 import org.scalasteward.core.util
-import org.scalasteward.core.util.{dateTime, DateTimeAlg}
+import org.scalasteward.core.util.{DateTimeAlg, dateTime}
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
+
 import scala.concurrent.duration._
 
 final class PruningAlg[F[_]](implicit
@@ -38,6 +39,7 @@ final class PruningAlg[F[_]](implicit
     logger: Logger[F],
     pullRequestRepository: PullRequestRepository[F],
     repoCacheRepository: RepoCacheRepository[F],
+    repoConfigAlg: RepoConfigAlg[F],
     updateAlg: UpdateAlg[F],
     F: Monad[F]
 ) {
@@ -64,10 +66,12 @@ final class PruningAlg[F[_]](implicit
       repoCache: RepoCache,
       dependencies: List[Scope.Dependency]
   ): F[(Boolean, List[Update.Single])] = {
-    val repoConfig = repoCache.maybeRepoConfig.getOrElse(RepoConfig.default)
+
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
+      defaultConfig <- repoConfigAlg.defaultRepoConfig
+      repoConfig = repoCache.maybeRepoConfig.getOrElse(defaultConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)
       outdatedDeps = collectOutdatedDependencies(updateStates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -75,7 +75,7 @@ final class PruningAlg[F[_]](implicit
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      defaultConfig <- repoConfigAlg.defaultRepoConfig
+      defaultConfig <- repoConfigAlg.defaultRepoConfig()
       repoConfig = repoCache.maybeRepoConfig.getOrElse(defaultConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -74,7 +74,7 @@ final class PruningAlg[F[_]](implicit
     val depsWithoutResolvers = dependencies.map(_.value).distinct
     for {
       _ <- logger.info(s"Find updates for ${repo.show}")
-      defaultConfig <- repoConfigAlg.defaultRepoConfig()
+      defaultConfig <- repoConfigAlg.defaultRepoConfig
       repoConfig = repoCache.maybeRepoConfig.getOrElse(defaultConfig)
       updates0 <- updateAlg.findUpdates(dependencies, repoConfig, None)
       updateStates0 <- findAllUpdateStates(repo, repoCache, depsWithoutResolvers, updates0)

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -23,12 +23,17 @@ import io.chrisdavenport.log4cats.Logger
 import org.scalasteward.core.data._
 import org.scalasteward.core.nurture.PullRequestRepository
 import org.scalasteward.core.repocache.{RepoCache, RepoCacheRepository}
-import org.scalasteward.core.repoconfig.{PullRequestFrequency, RepoConfig, RepoConfigAlg, UpdatesConfig}
+import org.scalasteward.core.repoconfig.{
+  PullRequestFrequency,
+  RepoConfig,
+  RepoConfigAlg,
+  UpdatesConfig
+}
 import org.scalasteward.core.update.PruningAlg._
 import org.scalasteward.core.update.data.UpdateState
 import org.scalasteward.core.update.data.UpdateState._
 import org.scalasteward.core.util
-import org.scalasteward.core.util.{DateTimeAlg, dateTime}
+import org.scalasteward.core.util.{dateTime, DateTimeAlg}
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
 

--- a/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/update/PruningAlg.scala
@@ -36,7 +36,6 @@ import org.scalasteward.core.util
 import org.scalasteward.core.util.{dateTime, DateTimeAlg}
 import org.scalasteward.core.vcs.data.PullRequestState.Closed
 import org.scalasteward.core.vcs.data.Repo
-
 import scala.concurrent.duration._
 
 final class PruningAlg[F[_]](implicit

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -16,7 +16,7 @@ class CliTest extends AnyFunSuite with Matchers {
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
-        List("--repos-default-conf", "c"),
+        List("--default-repo-conf", "c"),
         List("--git-author-email", "d"),
         List("--vcs-type", "gitlab"),
         List("--vcs-api-host", "http://example.com"),

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -44,6 +44,30 @@ class CliTest extends AnyFunSuite with Matchers {
     )
   }
 
+  test("parseArgs minimal version") {
+    cli.parseArgs(
+      List(
+        List("--workspace", "a"),
+        List("--repos-file", "b"),
+        List("--git-author-email", "d"),
+        List("--vcs-login", "e"),
+        List("--git-ask-pass", "f")
+      ).flatten
+    ) shouldBe Right(
+      Cli.Args(
+        workspace = "a",
+        reposFile = "b",
+        gitAuthorEmail = "d",
+        vcsLogin = "e",
+        gitAskPass = "f"
+      )
+    )
+  }
+
+  test("parseArgs fail if required option not provided") {
+    cli.parseArgs(Nil).isLeft shouldBe true
+  }
+
   test("env-var without equals sign") {
     Cli.envVarArgParser(None, "SBT_OPTS").isLeft shouldBe true
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -16,6 +16,7 @@ class CliTest extends AnyFunSuite with Matchers {
       List(
         List("--workspace", "a"),
         List("--repos-file", "b"),
+        List("--repos-default-conf", "c"),
         List("--git-author-email", "d"),
         List("--vcs-type", "gitlab"),
         List("--vcs-api-host", "http://example.com"),
@@ -30,6 +31,7 @@ class CliTest extends AnyFunSuite with Matchers {
       Cli.Args(
         workspace = "a",
         reposFile = "b",
+        reposDefaultConf = "c",
         gitAuthorEmail = "d",
         vcsType = SupportedVCS.Gitlab,
         vcsApiHost = uri"http://example.com",

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -31,7 +31,7 @@ class CliTest extends AnyFunSuite with Matchers {
       Cli.Args(
         workspace = "a",
         reposFile = "b",
-        reposDefaultConf = "c",
+        defaultRepoConf = "c",
         gitAuthorEmail = "d",
         vcsType = SupportedVCS.Gitlab,
         vcsApiHost = uri"http://example.com",

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -31,6 +31,7 @@ object MockContext {
   implicit val config: Config = Config(
     workspace = File.temp / "ws",
     reposFile = File.temp / "repos.md",
+    reposDefaultConfigFile = File.temp / ".scala-steward.conf",
     gitAuthor = Author("Bot Doe", "bot@example.org"),
     vcsType = SupportedVCS.GitHub,
     vcsApiHost = Uri(),

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -31,7 +31,7 @@ object MockContext {
   implicit val config: Config = Config(
     workspace = File.temp / "ws",
     reposFile = File.temp / "repos.md",
-    reposDefaultConfigFile = File.temp / "default.scala-steward.conf",
+    defaultRepoConfigFile = File.temp / "default.scala-steward.conf",
     gitAuthor = Author("Bot Doe", "bot@example.org"),
     vcsType = SupportedVCS.GitHub,
     vcsApiHost = Uri(),

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -31,7 +31,7 @@ object MockContext {
   implicit val config: Config = Config(
     workspace = File.temp / "ws",
     reposFile = File.temp / "repos.md",
-    reposDefaultConfigFile = File.temp / ".scala-steward.conf",
+    reposDefaultConfigFile = File.temp / "default.scala-steward.conf",
     gitAuthor = Author("Bot Doe", "bot@example.org"),
     vcsType = SupportedVCS.GitHub,
     vcsApiHost = Uri(),

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -60,7 +60,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.reposDefaultConfigFile.toString),
+        List("read", config.defaultRepoConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -168,7 +168,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.reposDefaultConfigFile.toString),
+        List("read", config.defaultRepoConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -286,7 +286,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.reposDefaultConfigFile.toString),
+        List("read", config.defaultRepoConfigFile.toString),
         List("read", versionsFile.toString),
         List("read", pullRequestsFile.toString),
         List("read", versionsFile.toString),

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -60,7 +60,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.defaultRepoConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -168,7 +167,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.defaultRepoConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -286,7 +284,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", config.defaultRepoConfigFile.toString),
         List("read", versionsFile.toString),
         List("read", pullRequestsFile.toString),
         List("read", versionsFile.toString),

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -11,6 +11,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
+    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -60,6 +61,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
+        List("read", repoDefaultConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -74,6 +76,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
+    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -167,6 +170,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
+        List("read", repoDefaultConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -181,6 +185,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
+    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -284,6 +289,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
+        List("read", repoDefaultConfigFile.toString),
         List("read", versionsFile.toString),
         List("read", pullRequestsFile.toString),
         List("read", versionsFile.toString),

--- a/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/update/PruningAlgTest.scala
@@ -11,7 +11,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
-    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -61,7 +60,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", repoDefaultConfigFile.toString),
+        List("read", config.reposDefaultConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -76,7 +75,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
-    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -170,7 +168,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", repoDefaultConfigFile.toString),
+        List("read", config.reposDefaultConfigFile.toString),
         List("read", pullRequestsFile.toString)
       ),
       logs = Vector(
@@ -185,7 +183,6 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     val repo = Repo("fthomas", "scalafix-test")
     val repoCacheFile =
       config.workspace / "store/repo_cache/v1/fthomas/scalafix-test/repo_cache.json"
-    val repoDefaultConfigFile = config.workspace / ".scala-steward.conf"
     val repoCacheContent =
       s"""|{
          |  "sha1": "12def27a837ba6dc9e17406cbbe342fba3527c14",
@@ -289,7 +286,7 @@ class PruningAlgTest extends AnyFunSuite with Matchers {
     state shouldBe initial.copy(
       commands = Vector(
         List("read", repoCacheFile.toString),
-        List("read", repoDefaultConfigFile.toString),
+        List("read", config.reposDefaultConfigFile.toString),
         List("read", versionsFile.toString),
         List("read", pullRequestsFile.toString),
         List("read", versionsFile.toString),

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,10 +21,9 @@ curl -s -o "$REPOS_GITLAB" https://raw.githubusercontent.com/scala-steward-org/r
 
 LOGIN="scala-steward"
 
+# Used for running public Scala Steward instance, repos-file / repos-default-conf will be set later
 COMMON_ARGS=(
   --workspace "$STEWARD_DIR/workspace"
-  --repos-file "$STEWARD_DIR/repos.md"
-  --repos-default-conf "$STEWARD_DIR/default.scala-steward.conf"
   --git-author-email "me@$LOGIN.org"
   --vcs-login "$LOGIN"
   --ignore-opts-files

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -23,6 +23,8 @@ LOGIN="scala-steward"
 
 COMMON_ARGS=(
   --workspace "$STEWARD_DIR/workspace"
+  --repos-file "$STEWARD_DIR/repos.md"
+  --repos-default-conf "$STEWARD_DIR/.scala-steward.conf"
   --git-author-email "me@$LOGIN.org"
   --vcs-login "$LOGIN"
   --ignore-opts-files

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -24,7 +24,7 @@ LOGIN="scala-steward"
 COMMON_ARGS=(
   --workspace "$STEWARD_DIR/workspace"
   --repos-file "$STEWARD_DIR/repos.md"
-  --repos-default-conf "$STEWARD_DIR/.scala-steward.conf"
+  --repos-default-conf "$STEWARD_DIR/default.scala-steward.conf"
   --git-author-email "me@$LOGIN.org"
   --vcs-login "$LOGIN"
   --ignore-opts-files


### PR DESCRIPTION
In some scenarios there is a need to limit dependencies you want to update for all repos. 

Currently you'd need to update repo configuration (`.scala-steward.conf`) for every project you are working on.
If the repo doesn't have configuration (`maybeRepoConfig`) it will fallback to empty `RepoConfig.default`.

This PR is adding ability to override fallback to `RepoConfig.default` by reading `default.scala-steward.conf` within main scala steward repo. It gives you all the features as described in [repo-specific-configuration.md](https://github.com/fthomas/scala-steward/blob/master/docs/repo-specific-configuration.md)

Specifically, you can limit dependencies by providing `allow` settings (which is helpful if you have 100+ repos and you want to propagate specific dependencies, only)

### Changes
- Added `--default-repo-config` setting (default to `default.scala-steward.conf`)
- Chain of configuration: check repoConf (`$repo/.scala-steward.conf`) => fallback to DefaultRepoConf (`root/default.scala-steward.conf`) => fallback to empty configuration
- Added extra tests