### PR TITLE
Make --default-repo-conf an optional argument

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,7 @@ runSteward := Def.taskDyn {
   val args = Seq(
     Seq("--workspace", s"$projectDir/workspace"),
     Seq("--repos-file", s"$projectDir/repos.md"),
-    Seq("--default-repo-config", s"$projectDir/default.scala-steward.conf"),
+    Seq("--default-repo-conf", s"$projectDir/default.scala-steward.conf"),
     Seq("--git-author-email", s"me@$projectName.org"),
     Seq("--vcs-login", projectName),
     Seq("--git-ask-pass", s"$home/.github/askpass/$projectName.sh"),

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Cli.scala
@@ -37,7 +37,7 @@ object Cli {
   final case class Args(
       workspace: String,
       reposFile: String,
-      defaultRepoConf: String = "default.scala-steward.conf",
+      defaultRepoConf: Option[String] = None,
       gitAuthorName: String = "Scala Steward",
       gitAuthorEmail: String,
       vcsType: SupportedVCS = SupportedVCS.GitHub,

--- a/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/application/Config.scala
@@ -54,7 +54,7 @@ import scala.sys.process.Process
 final case class Config(
     workspace: File,
     reposFile: File,
-    defaultRepoConfigFile: File,
+    defaultRepoConfigFile: Option[File],
     gitAuthor: Author,
     vcsType: SupportedVCS,
     vcsApiHost: Uri,
@@ -90,7 +90,7 @@ object Config {
       Config(
         workspace = args.workspace.toFile,
         reposFile = args.reposFile.toFile,
-        defaultRepoConfigFile = args.defaultRepoConf.toFile,
+        defaultRepoConfigFile = args.defaultRepoConf.map(_.toFile),
         gitAuthor = Author(args.gitAuthorName, args.gitAuthorEmail),
         vcsType = args.vcsType,
         vcsApiHost = args.vcsApiHost,

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfig.scala
@@ -31,7 +31,7 @@ final case class RepoConfig(
 }
 
 object RepoConfig {
-  private[repoconfig] val empty: RepoConfig = RepoConfig()
+  val empty: RepoConfig = RepoConfig()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/repoconfig/RepoConfigAlg.scala
@@ -41,24 +41,25 @@ final class RepoConfigAlg[F[_]](implicit
     }
 
   /**
-    * Default configuration will try to read file specified in config.reposDefaultConfig first;
+    * Default configuration will try to read file specified in config.defaultRepoConfigFile first;
     * if not found - fallback to empty configuration.
     */
-  lazy val defaultRepoConfig: F[RepoConfig] =
-    readRepoConfigFromFile(config.defaultRepoConfigFile).map(_.getOrElse(RepoConfig.empty))
+  val defaultRepoConfig: F[RepoConfig] =
+    OptionT
+      .fromOption[F](config.defaultRepoConfigFile)
+      .flatMap(readRepoConfigFromFile)
+      .getOrElse(RepoConfig.empty)
 
   def readRepoConfig(repo: Repo): F[Option[RepoConfig]] =
     workspaceAlg
       .repoDir(repo)
-      .flatMap(dir => readRepoConfigFromFile(dir / repoConfigBasename))
+      .flatMap(dir => readRepoConfigFromFile(dir / repoConfigBasename).value)
 
-  private def readRepoConfigFromFile(configFile: File): F[Option[RepoConfig]] = {
-    val maybeRepoConfig = OptionT(fileAlg.readFile(configFile)).map(parseRepoConfig).flatMapF {
-      case Right(config)  => logger.info(s"Parsed $config").as(config.some)
-      case Left(errorMsg) => logger.info(errorMsg).as(none[RepoConfig])
+  private def readRepoConfigFromFile(configFile: File): OptionT[F, RepoConfig] =
+    OptionT(fileAlg.readFile(configFile)).map(parseRepoConfig).flatMapF {
+      case Right(repoConfig) => logger.info(s"Parsed $repoConfig").as(repoConfig.some)
+      case Left(errorMsg)    => logger.info(errorMsg).as(none[RepoConfig])
     }
-    maybeRepoConfig.value
-  }
 }
 
 object RepoConfigAlg {

--- a/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/application/CliTest.scala
@@ -31,7 +31,7 @@ class CliTest extends AnyFunSuite with Matchers {
       Cli.Args(
         workspace = "a",
         reposFile = "b",
-        defaultRepoConf = "c",
+        defaultRepoConf = Some("c"),
         gitAuthorEmail = "d",
         vcsType = SupportedVCS.Gitlab,
         vcsApiHost = uri"http://example.com",

--- a/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/mock/MockContext.scala
@@ -31,7 +31,7 @@ object MockContext {
   implicit val config: Config = Config(
     workspace = File.temp / "ws",
     reposFile = File.temp / "repos.md",
-    defaultRepoConfigFile = File.temp / "default.scala-steward.conf",
+    defaultRepoConfigFile = Some(File.temp / "default.scala-steward.conf"),
     gitAuthor = Author("Bot Doe", "bot@example.org"),
     vcsType = SupportedVCS.GitHub,
     vcsApiHost = Uri(),

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,7 +21,6 @@ curl -s -o "$REPOS_GITLAB" https://raw.githubusercontent.com/scala-steward-org/r
 
 LOGIN="scala-steward"
 
-# Used for running public Scala Steward instance, repos-file / repos-default-conf will be set later
 COMMON_ARGS=(
   --workspace "$STEWARD_DIR/workspace"
   --git-author-email "me@$LOGIN.org"


### PR DESCRIPTION
--default-repo-conf is not a mandatory argument and this should be
reflected in the type of Cli.defaultRepoConf.