### PR TITLE
Rename plugin and mill sbt projects to sbt-plugin and mill-plugin

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.scalasteward.core.buildtool
-package mill
+package org.scalasteward.core.buildtool.mill
 
 import cats.implicits._
 import cats.effect.Sync
 import org.scalasteward.core.BuildInfo
+import org.scalasteward.core.buildtool.BuildToolAlg
 import org.scalasteward.core.data.Scope
 import org.scalasteward.core.data.Scope.Dependencies
 import org.scalasteward.core.io.{FileAlg, ProcessAlg, WorkspaceAlg}
@@ -38,7 +38,7 @@ object MillAlg {
        |    .of("https://oss.sonatype.org/content/repositories/snapshots/")
        |)
        |
-       |import $$ivy.`org.scala-steward::scala-steward-mill:${BuildInfo.version}`""".stripMargin
+       |import $$ivy.`${BuildInfo.organization}::${BuildInfo.millPluginModuleName}:${BuildInfo.version}`""".stripMargin
 
   def create[F[_]](implicit
       fileAlg: FileAlg[F],

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/package.scala
@@ -18,6 +18,7 @@ package org.scalasteward.core.buildtool
 
 import cats.Functor
 import cats.implicits._
+import org.scalasteward.core.BuildInfo
 import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 import org.scalasteward.core.io.{FileAlg, FileData}
@@ -46,6 +47,8 @@ package object sbt {
 
   def stewardPlugin[F[_]](implicit fileAlg: FileAlg[F], F: Functor[F]): F[FileData] = {
     val name = "StewardPlugin.scala"
-    fileAlg.readResource(s"org/scalasteward/plugin/$name").map(FileData(name, _))
+    fileAlg
+      .readResource(s"${BuildInfo.sbtPluginModuleRootPkg.replace('.', '/')}/$name")
+      .map(FileData(name, _))
   }
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -18,7 +18,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
       .runS(MockState.empty)
       .unsafeRunSync() shouldBe MockState.empty.copy(
       commands = Vector(
-        List("read", "classpath:org/scalasteward/plugin/StewardPlugin.scala"),
+        List("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
         List("create", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala"),
         List("create", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala"),
         List("fa", "fa"),

--- a/modules/mill-plugin/src/main/scala/org/scalasteward/mill/plugin/StewardPlugin.scala
+++ b/modules/mill-plugin/src/main/scala/org/scalasteward/mill/plugin/StewardPlugin.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.scalasteward.plugin
+package org.scalasteward.mill.plugin
 
 import coursier.core.{Authentication, Repository}
 import coursier.ivy.IvyRepository

--- a/modules/sbt-plugin/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/org/scalasteward/sbt/plugin/StewardPlugin.scala
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.scalasteward.plugin
+package org.scalasteward.sbt.plugin
 
 import sbt.Keys._
 import sbt.{Def, _}
-
 import scala.util.Try
 import scala.util.matching.Regex
 


### PR DESCRIPTION
Both projects serve the same purpose but for different build systems.
Their names should reflect their similarity.