### PR TITLE
Fix reference to the root pkg of the mill-plugin project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,9 @@ lazy val core = myCrossProject("core")
       },
       BuildInfoKey.map(`mill-plugin`.jvm / moduleName) {
         case (_, v) => "millPluginModuleName" -> v
+      },
+      BuildInfoKey.map(`mill-plugin`.jvm / moduleRootPkg) {
+        case (_, v) => "millPluginModuleRootPkg" -> v
       }
     ),
     buildInfoPackage := moduleRootPkg.value,

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -64,7 +64,7 @@ object MillAlg {
                 "-p",
                 predef.toString(),
                 "show",
-                "org.scalasteward.plugin.StewardPlugin/extractDeps"
+                s"${BuildInfo.millPluginModuleRootPkg}.StewardPlugin/extractDeps"
               )
             ),
             repoDir


### PR DESCRIPTION
I forgot to do this in #1495.