### PR TITLE
Adding a scalafix rule for sbt-guardrail 0.59.0+

### DIFF
--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -33,7 +33,8 @@ migrations = [
     groupId: "com.twilio",
     artifactIds: ["sbt-guardrail"],
     newVersion: "0.59.0.1",
-    rewriteRules: ["https://raw.githubusercontent.com/blast-hardcheese/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailScalaResponseTypes.scala"]
+    rewriteRules: ["https://raw.githubusercontent.com/blast-hardcheese/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailScalaResponseTypes.scala"],
+    doc: "https://github.com/twilio/guardrail/blob/master/MIGRATING.md#0590-may-contain-type-and-package-naming-changes-that-will-require-changes-in-consuming-code"
   },
   {
     groupId: "dev.zio",

--- a/modules/core/src/main/resources/scalafix-migrations.conf
+++ b/modules/core/src/main/resources/scalafix-migrations.conf
@@ -30,6 +30,12 @@ migrations = [
     rewriteRules: ["github:spotify/scio/MigrateV0_8?sha=v0.8.0"]
   },
   {
+    groupId: "com.twilio",
+    artifactIds: ["sbt-guardrail"],
+    newVersion: "0.59.0.1",
+    rewriteRules: ["https://raw.githubusercontent.com/blast-hardcheese/guardrail-scalafix-rules/master/rules/src/main/scala/fix/GuardrailScalaResponseTypes.scala"]
+  },
+  {
     groupId: "dev.zio",
     artifactIds: ["zio-test"],
     newVersion: "1.0.0-RC18",

--- a/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/scalafix/MigrationAlgTest.scala
@@ -83,6 +83,6 @@ class MigrationAlgTest extends AnyFunSuite with Matchers {
   test("loadMigrations without extra file") {
     val migrations =
       MigrationAlg.loadMigrations[MockEff](None).runA(MockState.empty).unsafeRunSync()
-    migrations.size shouldBe 11
+    migrations.size shouldBe 12
   }
 }


### PR DESCRIPTION
[upgrade notes](https://github.com/twilio/guardrail/blob/master/MIGRATING.md#0590-may-contain-type-and-package-naming-changes-that-will-require-changes-in-consuming-code), forgot to create this PR before actually doing the release.