### PR TITLE
Push in mergeAndApplyAgain even if there is only a merge commit

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/git/Commit.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/git/Commit.scala
@@ -16,16 +16,4 @@
 
 package org.scalasteward.core.git
 
-import io.circe.{Decoder, Encoder}
-
-final case class Branch(name: String)
-
-object Branch {
-  val head: Branch = Branch("HEAD")
-
-  implicit val branchDecoder: Decoder[Branch] =
-    Decoder[String].map(Branch.apply)
-
-  implicit val branchEncoder: Encoder[Branch] =
-    Encoder[String].contramap(_.name)
-}
+final case class Commit()


### PR DESCRIPTION
Prior to this change `mergeAndApplyAgain` only pushed changes if
applying an update again resulted in changes in the working copy
of a repo. This prevented Scala Steward from updating PRs if
`updatePullRequests` was set to `"always"` and there were no
merge conflicts between the base branch and the update branch.
In these cases, merging the base branch is the only thing required
to bring the update branch up-to-date with the base branch.

With this change Scala Steward now pushes changes even if updating
only results in a merge commit.

Closes #1511.