### PR TITLE
Do not restrict Scalafmt updates to sbt

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -28,7 +28,6 @@ import org.scalasteward.core.buildtool.sbt.data.SbtVersion
 import org.scalasteward.core.data.{Dependency, Resolver, Scope}
 import org.scalasteward.core.io.{FileAlg, FileData, ProcessAlg, WorkspaceAlg}
 import org.scalasteward.core.scalafix.Migration
-import org.scalasteward.core.scalafmt.ScalafmtAlg
 import org.scalasteward.core.util.{BracketThrowable, Nel}
 import org.scalasteward.core.vcs.data.Repo
 
@@ -49,7 +48,6 @@ object SbtAlg {
       fileAlg: FileAlg[F],
       logger: Logger[F],
       processAlg: ProcessAlg[F],
-      scalafmtAlg: ScalafmtAlg[F],
       workspaceAlg: WorkspaceAlg[F],
       F: BracketThrowable[F]
   ): SbtAlg[F] =
@@ -85,14 +83,7 @@ object SbtAlg {
           lines <- exec(sbtCmd(commands), repoDir)
           dependencies = parser.parseDependencies(lines)
           additionalDependencies <- getAdditionalDependencies(repo)
-          // combine scopes with the same resolvers
-          result =
-            (dependencies ++ additionalDependencies)
-              .groupByNel(_.resolvers)
-              .values
-              .toList
-              .map(group => group.head.as(group.reduceMap(_.value).distinct.sorted))
-        } yield result
+        } yield additionalDependencies ::: dependencies
 
       override def runMigrations(repo: Repo, migrations: Nel[Migration]): F[Unit] =
         addGlobalPluginTemporarily(scalaStewardScalafixSbt) {
@@ -127,12 +118,7 @@ object SbtAlg {
         }
 
       def getAdditionalDependencies(repo: Repo): F[List[Scope.Dependencies]] =
-        for {
-          maybeSbtDependency <- getSbtDependency(repo)
-          maybeScalafmtDependency <- scalafmtAlg.getScalafmtDependency(repo)
-        } yield Nel
-          .fromList(maybeSbtDependency.toList ++ maybeScalafmtDependency.toList)
-          .map(dependencies => Scope(dependencies.toList, List(Resolver.mavenCentral)))
-          .toList
+        getSbtDependency(repo)
+          .map(_.map(dep => Scope(List(dep), List(Resolver.mavenCentral))).toList)
     }
 }

--- a/modules/core/src/main/scala/org/scalasteward/core/data/Scope.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/data/Scope.scala
@@ -32,6 +32,11 @@ object Scope {
   type Dependency = Scope[org.scalasteward.core.data.Dependency]
   type Dependencies = Scope[List[org.scalasteward.core.data.Dependency]]
 
+  def combineByResolvers[A: Order](scopes: List[Scope[List[A]]]): List[Scope[List[A]]] =
+    scopes.groupByNel(_.resolvers).toList.map {
+      case (resolvers, group) => Scope(group.reduceMap(_.value).distinct.sorted, resolvers)
+    }
+
   implicit def scopeTraverse: Traverse[Scope] =
     new Traverse[Scope] {
       override def traverse[G[_]: Applicative, A, B](fa: Scope[A])(f: A => G[B]): G[Scope[B]] =

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/ScalafmtAlg.scala
@@ -19,7 +19,6 @@ package org.scalasteward.core.scalafmt
 import cats.data.Nested
 import cats.implicits._
 import cats.{Functor, Monad}
-import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
 import org.scalasteward.core.data.{Dependency, Version}
 import org.scalasteward.core.io.{FileAlg, WorkspaceAlg}
 import org.scalasteward.core.vcs.data.Repo
@@ -28,7 +27,7 @@ trait ScalafmtAlg[F[_]] {
   def getScalafmtVersion(repo: Repo): F[Option[Version]]
 
   final def getScalafmtDependency(repo: Repo)(implicit F: Functor[F]): F[Option[Dependency]] =
-    Nested(getScalafmtVersion(repo)).map(scalafmtDependency(defaultScalaBinaryVersion)).value
+    Nested(getScalafmtVersion(repo)).map(scalafmtDependency).value
 }
 
 object ScalafmtAlg {

--- a/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/scalafmt/package.scala
@@ -17,13 +17,14 @@
 package org.scalasteward.core
 
 import cats.implicits._
+import org.scalasteward.core.buildtool.sbt.defaultScalaBinaryVersion
 import org.scalasteward.core.data.{ArtifactId, Dependency, GroupId, Version}
 
 package object scalafmt {
-  def scalafmtDependency(scalaBinaryVersion: String)(scalafmtVersion: Version): Dependency =
+  def scalafmtDependency(scalafmtVersion: Version): Dependency =
     Dependency(
       GroupId(if (scalafmtVersion > Version("2.0.0-RC1")) "org.scalameta" else "com.geirsson"),
-      ArtifactId("scalafmt-core", s"scalafmt-core_$scalaBinaryVersion"),
+      ArtifactId("scalafmt-core", s"scalafmt-core_$defaultScalaBinaryVersion"),
       scalafmtVersion.value
     )
 

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/BuildToolDispatcherTest.scala
@@ -1,8 +1,11 @@
 package org.scalasteward.core.buildtool
 
 import org.scalasteward.core.buildtool.sbt.command._
+import org.scalasteward.core.buildtool.sbt.data.SbtVersion
+import org.scalasteward.core.data.{Resolver, Scope, Version}
 import org.scalasteward.core.mock.MockContext.{buildToolDispatcher, config}
 import org.scalasteward.core.mock.MockState
+import org.scalasteward.core.scalafmt
 import org.scalasteward.core.vcs.data.Repo
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -11,14 +14,18 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
   test("getDependencies") {
     val repo = Repo("typelevel", "cats")
     val repoDir = config.workspace / repo.show
-    val initial = MockState.empty
-    val state = buildToolDispatcher.getDependencies(repo).runS(initial).unsafeRunSync()
+    val files = Map(
+      repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
+      repoDir / ".scalafmt.conf" -> "version=2.0.0"
+    )
+    val initial = MockState.empty.copy(files = files)
+    val (state, deps) = buildToolDispatcher.getDependencies(repo).run(initial).unsafeRunSync()
 
     state shouldBe initial.copy(commands =
       Vector(
-        List("test", "-f", s"$repoDir/build.sbt"),
         List("test", "-f", s"$repoDir/pom.xml"),
         List("test", "-f", s"$repoDir/build.sc"),
+        List("test", "-f", s"$repoDir/build.sbt"),
         List(
           "TEST_VAR=GREAT",
           "ANOTHER_TEST_VAR=ALSO_GREAT",
@@ -32,6 +39,15 @@ class BuildToolDispatcherTest extends AnyFunSuite with Matchers {
         ),
         List("read", s"$repoDir/project/build.properties"),
         List("read", s"$repoDir/.scalafmt.conf")
+      )
+    )
+    deps shouldBe List(
+      Scope(
+        List(
+          sbt.sbtDependency(SbtVersion("1.2.6")).get,
+          scalafmt.scalafmtDependency(Version("2.0.0"))
+        ),
+        List(Resolver.mavenCentral)
       )
     )
   }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -14,14 +14,14 @@ import org.scalatest.matchers.should.Matchers
 class SbtAlgTest extends AnyFunSuite with Matchers {
   test("addGlobalPlugins") {
     sbtAlg
-      .addGlobalPlugins(StateT.modify(_.exec(List("fa", "fa"))))
+      .addGlobalPlugins(StateT.modify(_.exec(List("fa"))))
       .runS(MockState.empty)
       .unsafeRunSync() shouldBe MockState.empty.copy(
       commands = Vector(
         List("read", "classpath:org/scalasteward/sbt/plugin/StewardPlugin.scala"),
         List("write", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala"),
         List("write", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala"),
-        List("fa", "fa"),
+        List("fa"),
         List("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/StewardPlugin.scala"),
         List("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/StewardPlugin.scala")
       ),
@@ -33,13 +33,10 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
   test("getDependenciesAndResolvers") {
     val repo = Repo("typelevel", "cats")
     val repoDir = config.workspace / repo.show
-    val files = Map(
-      repoDir / "project" / "build.properties" -> "sbt.version=1.2.6",
-      repoDir / ".scalafmt.conf" -> "version=2.0.0"
-    )
-    val state =
-      sbtAlg.getDependencies(repo).runS(MockState.empty.copy(files = files)).unsafeRunSync()
-    state shouldBe MockState.empty.copy(
+    val files = Map(repoDir / "project" / "build.properties" -> "sbt.version=1.2.6")
+    val initial = MockState.empty.copy(files = files)
+    val state = sbtAlg.getDependencies(repo).runS(initial).unsafeRunSync()
+    state shouldBe initial.copy(
       commands = Vector(
         List(
           "TEST_VAR=GREAT",
@@ -52,10 +49,8 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "-no-colors",
           s";$setOffline;$crossStewardDependencies;$reloadPlugins;$stewardDependencies"
         ),
-        List("read", s"$repoDir/project/build.properties"),
-        List("read", s"$repoDir/.scalafmt.conf")
-      ),
-      files = files
+        List("read", s"$repoDir/project/build.properties")
+      )
     )
   }
 
@@ -86,7 +81,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "sbt",
           "-batch",
           "-no-colors",
-          ";scalafixEnable;scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5;test:scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
+          s";$scalafixEnable;$scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5;$testScalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
         List("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         List("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt")


### PR DESCRIPTION
This will create Scalafmt updates independent of the used build tool.
This is possible because the Scalafmt version is defined in
`.scalafmt.conf` which is independent of any build tool.