### PR TITLE
use scalafixAll

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/SbtAlg.scala
@@ -92,8 +92,7 @@ object SbtAlg {
             scalafixCmds = for {
               migration <- migrations
               rule <- migration.rewriteRules
-              cmd <- Nel.of(scalafix, testScalafix)
-            } yield s"$cmd $rule"
+            } yield s"$scalafixAll $rule"
             _ <- exec(sbtCmd(scalafixEnable :: scalafixCmds.toList), repoDir)
           } yield ()
         }

--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/sbt/command.scala
@@ -21,7 +21,6 @@ object command {
   val stewardDependencies = "stewardDependencies"
   val crossStewardDependencies = s"+ $stewardDependencies"
   val reloadPlugins = "reload plugins"
-  val scalafix = "scalafix"
-  val testScalafix = "test:scalafix"
+  val scalafixAll = "scalafixAll"
   val scalafixEnable = "scalafixEnable"
 }

--- a/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/buildtool/sbt/SbtAlgTest.scala
@@ -81,7 +81,7 @@ class SbtAlgTest extends AnyFunSuite with Matchers {
           "sbt",
           "-batch",
           "-no-colors",
-          s";$scalafixEnable;$scalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5;$testScalafix github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
+          s";$scalafixEnable;$scalafixAll github:functional-streams-for-scala/fs2/v1?sha=v1.0.5"
         ),
         List("rm", "-rf", "/tmp/steward/.sbt/1.0/plugins/scala-steward-scalafix.sbt"),
         List("rm", "-rf", "/tmp/steward/.sbt/0.13/plugins/scala-steward-scalafix.sbt")


### PR DESCRIPTION
Use https://github.com/scalacenter/sbt-scalafix/pull/126, released in [sbt-scalafix 0.9.18](https://github.com/fthomas/scala-steward/pull/1522).

This slightly improves runtime as migrations can be run in parallel for `Compile` and `Test`.
    
Note that this will NOT run migrations on `IntegrationTest` or any other custom configuration, as Scalafix needs to be [enabled explicitly on them](https://github.com/scalacenter/scalafix/blob/v0.9.18/docs/users/installation.md#integration-tests).

