### PR TITLE
Do not use mill scripts in repositories

### DIFF
--- a/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
+++ b/modules/core/src/main/scala/org/scalasteward/core/buildtool/mill/MillAlg.scala
@@ -54,10 +54,9 @@ object MillAlg {
           repoDir <- workspaceAlg.repoDir(repo)
           predef = repoDir / "scala-steward.sc"
           _ <- fileAlg.writeFile(predef, content)
-          millcmd = if ((repoDir / "mill").exists) (repoDir / "mill").toString() else "mill"
           extracted <- processAlg.exec(
             Nel(
-              millcmd,
+              "mill",
               List(
                 "-i",
                 "-p",


### PR DESCRIPTION
... and always use the mill executable from the PATH. For sbt and Maven
we're also not executing scripts in repositories but always the
systemwide installed sbt or maven executables. The less user-provided
code is executed, the better.