### PR TITLE
Find keywords that contain additional punctuation 

### DIFF
--- a/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
+++ b/modules/core/src/test/scala/org/scalasteward/core/edit/EditAlgTest.scala
@@ -175,4 +175,20 @@ class EditAlgTest extends AnyFunSuite with Matchers {
     )
     runApplyUpdate(update, original) shouldBe expected
   }
+
+  test("keyword with extra underscore") {
+    val update = Update.Group(
+      "org.scala-js" % Nel.of("sbt-scalajs", "scalajs-compiler") % "1.1.0",
+      Nel.of("1.1.1")
+    )
+    val original = Map(
+      ".travis.yml" -> """ - SCALA_JS_VERSION=1.1.0""",
+      "project/plugins.sbt" -> """val scalaJsVersion = Option(System.getenv("SCALA_JS_VERSION")).getOrElse("1.1.0")"""
+    )
+    val expected = Map(
+      ".travis.yml" -> """ - SCALA_JS_VERSION=1.1.1""",
+      "project/plugins.sbt" -> """val scalaJsVersion = Option(System.getenv("SCALA_JS_VERSION")).getOrElse("1.1.1")"""
+    )
+    runApplyUpdate(update, original) shouldBe expected
+  }
 }


### PR DESCRIPTION
This allows keywords to have additional punctuation that is not present in the artifactIds or groupIds. As the test demonstrates, `SCALA_JS_VERSION` is now recognized as variable for the Scala.js version although the artifactIds only contain `scalajs` without an underscore.